### PR TITLE
OpenVR devices changes

### DIFF
--- a/Assets/Scripts/Device Management/Devices/OpenVR/BasisOpenVRInput.cs
+++ b/Assets/Scripts/Device Management/Devices/OpenVR/BasisOpenVRInput.cs
@@ -1,9 +1,12 @@
 ﻿using UnityEngine;
 using Valve.VR;
+using VIVE.OpenXR.CompositionLayer;
+
 [DefaultExecutionOrder(15101)]
 public class BasisOpenVRInput : BasisInput
 {
     public OpenVRDevice Device;
+    public SteamVR_Input_Sources inputSource;
     public TrackedDevicePose_t devicePose = new TrackedDevicePose_t();
     public TrackedDevicePose_t deviceGamePose = new TrackedDevicePose_t();
     public SteamVR_Utils.RigidTransform deviceTransform;
@@ -12,25 +15,30 @@ public class BasisOpenVRInput : BasisInput
     public void Initialize(OpenVRDevice device, string iD)
     {
         Device = device;
-        GetControllerOrHMD(Device.SteamVR_Input_Sources);
+        TryAssignRole(Device.deviceClass);
         base.Initialize(iD);
     }
 
-    public void GetControllerOrHMD(SteamVR_Input_Sources SteamVR_Input_Sources)
+    public void TryAssignRole(ETrackedDeviceClass deviceClass)
     {
-        switch (SteamVR_Input_Sources)
+        if (deviceClass == ETrackedDeviceClass.Controller)
         {
-            case SteamVR_Input_Sources.LeftHand:
+            bool isLeftHand = SteamVR.instance.hmd.GetTrackedDeviceIndexForControllerRole(ETrackedControllerRole.LeftHand) == Device.deviceIndex;
+            if (isLeftHand)
+            {
                 TrackedRole = BasisBoneTrackedRole.LeftHand;
-                break;
-            case SteamVR_Input_Sources.RightHand:
+            }
+            else
+            {
                 TrackedRole = BasisBoneTrackedRole.RightHand;
-                break;
-            case SteamVR_Input_Sources.Head:
-                TrackedRole = BasisBoneTrackedRole.CenterEye;
-                break;
+            }
+        }
+        if (deviceClass == ETrackedDeviceClass.HMD)
+        {
+            TrackedRole = BasisBoneTrackedRole.CenterEye;
         }
     }
+    
     public override void PollData()
     {
         result = SteamVR.instance.compositor.GetLastPoseForTrackedDeviceIndex(Device.deviceIndex, ref devicePose, ref deviceGamePose);
@@ -51,10 +59,10 @@ public class BasisOpenVRInput : BasisInput
                     Control.LocalRawRotation = LocalRawRotation;
                 }
             }
-            SteamVR_Actions.default_Move.GetAxis(Device.SteamVR_Input_Sources);
-            primary2DAxis = SteamVR_Actions.default_Move.GetAxis(Device.SteamVR_Input_Sources);
-            primaryButton = SteamVR_Actions.default_Jump.GetStateDown(Device.SteamVR_Input_Sources);
-            secondaryButton = SteamVR_Actions.default_Menu.GetStateDown(Device.SteamVR_Input_Sources);
+            
+            primary2DAxis = SteamVR_Actions._default.Joystick.GetAxis(inputSource);
+            primaryButton = SteamVR_Actions._default.A_Button.GetStateDown(inputSource);
+            secondaryButton = SteamVR_Actions._default.B_Button.GetStateDown(inputSource);
             UpdatePlayerControl();
         }
         else

--- a/Assets/Scripts/Device Management/Devices/OpenVR/OpenVRDevice.cs
+++ b/Assets/Scripts/Device Management/Devices/OpenVR/OpenVRDevice.cs
@@ -2,8 +2,7 @@
 
 public struct OpenVRDevice
 {
-    public SteamVR_Input_Sources SteamVR_Input_Sources;
+    public ETrackedDeviceClass deviceClass;
     public uint deviceIndex;
     public string deviceName;
-    public SteamVR_Action_Pose SteamVR_Action_Pose;
 }

--- a/Assets/StreamingAssets/SteamVR/actions.json
+++ b/Assets/StreamingAssets/SteamVR/actions.json
@@ -15,21 +15,16 @@
       "skeleton": "/skeleton/hand/right"
     },
     {
-      "name": "/actions/default/in/Move",
+      "name": "/actions/default/in/Joystick",
       "type": "vector2",
       "requirement": "suggested"
     },
     {
-      "name": "/actions/default/in/Rotate",
-      "type": "vector2",
-      "requirement": "suggested"
-    },
-    {
-      "name": "/actions/default/in/Menu",
+      "name": "/actions/default/in/B-Button",
       "type": "boolean"
     },
     {
-      "name": "/actions/default/in/Jump",
+      "name": "/actions/default/in/A_Button",
       "type": "boolean"
     },
     {
@@ -40,7 +35,7 @@
   "action_sets": [
     {
       "name": "/actions/default",
-      "usage": "leftright"
+      "usage": "single"
     }
   ],
   "default_bindings": [

--- a/Assets/StreamingAssets/SteamVR/binding_vive_tracker_camera.json
+++ b/Assets/StreamingAssets/SteamVR/binding_vive_tracker_camera.json
@@ -1,28 +1,26 @@
 {
-   "action_manifest_version" : 0,
-   "alias_info" : {},
-   "bindings" : {
-      "/actions/default" : {
-         "poses" : [
-             {
-                 "output" : "/actions/default/in/pose",
-                 "path" : "/user/camera/pose/raw"
-             }
-         ]
-      },
-      "/actions/mixedreality": {
-         "poses" : [
-             {
-                 "output": "/actions/mixedreality/in/ExternalCamera",
-                 "path": "/user/camera/pose/raw"
-             }
-         ]
-      }
-   },
-   "category" : "steamvr_input",
-   "controller_type" : "vive_tracker_camera",
-   "description" : "",
-   "name" : "Holodance / Beat the Rhythm config for Mixed Reality Camera",
-   "options" : {},
-   "simulated_actions" : []
+  "bindings": {
+    "/actions/default": {
+      "chords": [],
+      "poses": [
+        {
+          "output": "/actions/default/in/pose",
+          "path": "/user/camera/pose/raw"
+        }
+      ],
+      "haptics": [],
+      "sources": [],
+      "skeleton": []
+    },
+    "/actions/mixedreality": {
+      "chords": [],
+      "poses": [],
+      "haptics": [],
+      "sources": [],
+      "skeleton": []
+    }
+  },
+  "controller_type": "vive_tracker_camera",
+  "description": "",
+  "name": "Holodance / Beat the Rhythm config for Mixed Reality Camera"
 }

--- a/Assets/StreamingAssets/SteamVR/bindings_knuckles.json
+++ b/Assets/StreamingAssets/SteamVR/bindings_knuckles.json
@@ -1,107 +1,230 @@
 {
-  "app_key": "application.generated.unity.basis.exe",
-  "bindings": {
-    "/actions/buggy": {
-      "chords": [],
-      "poses": [],
-      "haptics": [],
-      "sources": [],
-      "skeleton": []
-    },
-    "/actions/default": {
-      "chords": [],
-      "poses": [
-        {
-          "output": "/actions/default/in/pose",
-          "path": "/user/hand/left/pose/raw"
-        },
-        {
-          "output": "/actions/default/in/pose",
-          "path": "/user/hand/right/pose/raw"
-        }
-      ],
-      "haptics": [
-        {
-          "output": "/actions/default/out/haptic",
-          "path": "/user/hand/left/output/haptic"
-        },
-        {
-          "output": "/actions/default/out/haptic",
-          "path": "/user/hand/right/output/haptic"
-        }
-      ],
-      "sources": [
-        {
-          "path": "/user/hand/left/input/thumbstick",
-          "mode": "joystick",
-          "parameters": {},
-          "inputs": {
-            "position": {
-              "output": "/actions/default/in/move"
+   "action_manifest_version" : 0,
+   "alias_info" : {},
+   "app_key" : "application.generated.unity.basis.exe",
+   "bindings" : {
+      "/actions/buggy" : {
+         "chords" : [],
+         "haptics" : [],
+         "poses" : [],
+         "skeleton" : [],
+         "sources" : []
+      },
+      "/actions/default" : {
+         "chords" : [],
+         "haptics" : [
+            {
+               "output" : "/actions/default/out/haptic",
+               "path" : "/user/hand/left/output/haptic"
+            },
+            {
+               "output" : "/actions/default/out/haptic",
+               "path" : "/user/hand/right/output/haptic"
             }
-          }
-        },
-        {
-          "path": "/user/hand/right/input/thumbstick",
-          "mode": "joystick",
-          "parameters": {},
-          "inputs": {
-            "position": {
-              "output": "/actions/default/in/rotate"
+         ],
+         "poses" : [
+            {
+               "output" : "/actions/default/in/pose",
+               "path" : "/user/hand/left/pose/raw"
+            },
+            {
+               "output" : "/actions/default/in/pose",
+               "path" : "/user/hand/right/pose/raw"
             }
-          }
-        },
-        {
-          "path": "/user/hand/right/input/a",
-          "mode": "button",
-          "parameters": {},
-          "inputs": {
-            "click": {
-              "output": "/actions/default/in/jump"
+         ],
+         "skeleton" : [
+            {
+               "output" : "/actions/default/in/skeletonlefthand",
+               "path" : "/user/hand/left/input/skeleton/left"
+            },
+            {
+               "output" : "/actions/default/in/skeletonrighthand",
+               "path" : "/user/hand/right/input/skeleton/right"
             }
-          }
-        },
-        {
-          "path": "/user/hand/right/input/b",
-          "mode": "button",
-          "parameters": {},
-          "inputs": {
-            "click": {
-              "output": "/actions/default/in/menu"
+         ],
+         "sources" : [
+            {
+               "inputs" : {
+                  "click" : {
+                     "output" : "/actions/default/in/interactui"
+                  }
+               },
+               "mode" : "button",
+               "path" : "/user/hand/left/input/trigger"
+            },
+            {
+               "inputs" : {
+                  "click" : {
+                     "output" : "/actions/default/in/teleport"
+                  }
+               },
+               "mode" : "button",
+               "path" : "/user/hand/left/input/trackpad"
+            },
+            {
+               "inputs" : {
+                  "click" : {
+                     "output" : "/actions/default/in/interactui"
+                  }
+               },
+               "mode" : "button",
+               "path" : "/user/hand/right/input/trigger"
+            },
+            {
+               "inputs" : {
+                  "click" : {
+                     "output" : "/actions/default/in/teleport"
+                  }
+               },
+               "mode" : "button",
+               "path" : "/user/hand/right/input/trackpad"
+            },
+            {
+               "inputs" : {
+                  "north" : {
+                     "output" : "/actions/default/in/teleport"
+                  }
+               },
+               "mode" : "dpad",
+               "parameters" : {
+                  "deadzone_pct" : "25",
+                  "overlap_pct" : "30",
+                  "sub_mode" : "touch"
+               },
+               "path" : "/user/hand/left/input/thumbstick"
+            },
+            {
+               "inputs" : {
+                  "north" : {
+                     "output" : "/actions/default/in/teleport"
+                  }
+               },
+               "mode" : "dpad",
+               "parameters" : {
+                  "deadzone_pct" : "25",
+                  "overlap_pct" : "30",
+                  "sub_mode" : "touch"
+               },
+               "path" : "/user/hand/right/input/thumbstick"
+            },
+            {
+               "inputs" : {
+                  "grab" : {
+                     "output" : "/actions/default/in/grabgrip"
+                  }
+               },
+               "mode" : "grab",
+               "parameters" : {
+                  "force_hold_threshold" : "0.02",
+                  "force_release_threshold" : "0.01"
+               },
+               "path" : "/user/hand/left/input/grip"
+            },
+            {
+               "inputs" : {
+                  "grab" : {
+                     "output" : "/actions/default/in/grabgrip"
+                  }
+               },
+               "mode" : "grab",
+               "parameters" : {
+                  "force_hold_threshold" : "0.02",
+                  "force_release_threshold" : "0.01"
+               },
+               "path" : "/user/hand/right/input/grip"
+            },
+            {
+               "inputs" : {
+                  "grab" : {
+                     "output" : "/actions/default/in/grabpinch"
+                  }
+               },
+               "mode" : "grab",
+               "parameters" : {
+                  "force_hold_threshold" : "0.02",
+                  "force_release_threshold" : "0.01"
+               },
+               "path" : "/user/hand/left/input/pinch"
+            },
+            {
+               "inputs" : {
+                  "grab" : {
+                     "output" : "/actions/default/in/grabpinch"
+                  }
+               },
+               "mode" : "grab",
+               "parameters" : {
+                  "force_hold_threshold" : "0.02",
+                  "force_release_threshold" : "0.01"
+               },
+               "path" : "/user/hand/right/input/pinch"
+            },
+            {
+               "inputs" : {
+                  "position" : {
+                     "output" : "/actions/default/in/joystick"
+                  }
+               },
+               "mode" : "joystick",
+               "path" : "/user/hand/left/input/thumbstick"
+            },
+            {
+               "inputs" : {
+                  "position" : {
+                     "output" : "/actions/default/in/joystick"
+                  }
+               },
+               "mode" : "joystick",
+               "path" : "/user/hand/right/input/thumbstick"
+            },
+            {
+               "inputs" : {},
+               "mode" : "button",
+               "path" : "/user/hand/right/input/a"
+            },
+            {
+               "inputs" : {
+                  "click" : {
+                     "output" : "/actions/default/in/menu"
+                  }
+               },
+               "mode" : "button",
+               "path" : "/user/hand/right/input/b"
+            },
+            {
+               "inputs" : {
+                  "click" : {
+                     "output" : "/actions/default/in/b-button"
+                  }
+               },
+               "mode" : "button",
+               "path" : "/user/hand/left/input/b"
+            },
+            {
+               "inputs" : {},
+               "mode" : "button",
+               "path" : "/user/hand/left/input/a"
+            },
+            {
+               "inputs" : {},
+               "mode" : "none",
+               "path" : "/user/hand/right/input/a"
             }
-          }
-        },
-        {
-          "path": "/user/hand/left/input/b",
-          "mode": "button",
-          "parameters": {},
-          "inputs": {
-            "click": {
-              "output": "/actions/default/in/menu"
-            }
-          }
-        }
-      ],
-      "skeleton": [
-        {
-          "output": "/actions/default/in/skeletonlefthand",
-          "path": "/user/hand/left/input/skeleton/left"
-        },
-        {
-          "output": "/actions/default/in/skeletonrighthand",
-          "path": "/user/hand/right/input/skeleton/right"
-        }
-      ]
-    },
-    "/actions/platformer": {
-      "chords": [],
-      "poses": [],
-      "haptics": [],
-      "sources": [],
-      "skeleton": []
-    }
-  },
-  "controller_type": "knuckles",
-  "description": "",
-  "name": "My [Testing] Basis configuration for Index Controller"
+         ]
+      },
+      "/actions/platformer" : {
+         "chords" : [],
+         "haptics" : [],
+         "poses" : [],
+         "skeleton" : [],
+         "sources" : []
+      }
+   },
+   "category" : "steamvr_input",
+   "controller_type" : "knuckles",
+   "description" : "",
+   "interaction_profile" : "",
+   "name" : "My Basis [Testing] configuration for Index Controller",
+   "options" : {},
+   "simulated_actions" : []
 }

--- a/Assets/third_party/Plugins/SteamVR_Input/ActionSetClasses/SteamVR_Input_ActionSet_default.cs
+++ b/Assets/third_party/Plugins/SteamVR_Input/ActionSetClasses/SteamVR_Input_ActionSet_default.cs
@@ -41,35 +41,27 @@ namespace Valve.VR
             }
         }
         
-        public virtual SteamVR_Action_Vector2 Move
+        public virtual SteamVR_Action_Vector2 Joystick
         {
             get
             {
-                return SteamVR_Actions.default_Move;
+                return SteamVR_Actions.default_Joystick;
             }
         }
         
-        public virtual SteamVR_Action_Vector2 Rotate
+        public virtual SteamVR_Action_Boolean B_Button
         {
             get
             {
-                return SteamVR_Actions.default_Rotate;
+                return SteamVR_Actions.default_B_Button;
             }
         }
         
-        public virtual SteamVR_Action_Boolean Menu
+        public virtual SteamVR_Action_Boolean A_Button
         {
             get
             {
-                return SteamVR_Actions.default_Menu;
-            }
-        }
-        
-        public virtual SteamVR_Action_Boolean Jump
-        {
-            get
-            {
-                return SteamVR_Actions.default_Jump;
+                return SteamVR_Actions.default_A_Button;
             }
         }
         

--- a/Assets/third_party/Plugins/SteamVR_Input/SteamVR_Input_Actions.cs
+++ b/Assets/third_party/Plugins/SteamVR_Input/SteamVR_Input_Actions.cs
@@ -23,13 +23,11 @@ namespace Valve.VR
         
         private static SteamVR_Action_Skeleton p_default_SkeletonRightHand;
         
-        private static SteamVR_Action_Vector2 p_default_Move;
+        private static SteamVR_Action_Vector2 p_default_Joystick;
         
-        private static SteamVR_Action_Vector2 p_default_Rotate;
+        private static SteamVR_Action_Boolean p_default_B_Button;
         
-        private static SteamVR_Action_Boolean p_default_Menu;
-        
-        private static SteamVR_Action_Boolean p_default_Jump;
+        private static SteamVR_Action_Boolean p_default_A_Button;
         
         private static SteamVR_Action_Vibration p_default_Haptic;
         
@@ -57,35 +55,27 @@ namespace Valve.VR
             }
         }
         
-        public static SteamVR_Action_Vector2 default_Move
+        public static SteamVR_Action_Vector2 default_Joystick
         {
             get
             {
-                return SteamVR_Actions.p_default_Move.GetCopy<SteamVR_Action_Vector2>();
+                return SteamVR_Actions.p_default_Joystick.GetCopy<SteamVR_Action_Vector2>();
             }
         }
         
-        public static SteamVR_Action_Vector2 default_Rotate
+        public static SteamVR_Action_Boolean default_B_Button
         {
             get
             {
-                return SteamVR_Actions.p_default_Rotate.GetCopy<SteamVR_Action_Vector2>();
+                return SteamVR_Actions.p_default_B_Button.GetCopy<SteamVR_Action_Boolean>();
             }
         }
         
-        public static SteamVR_Action_Boolean default_Menu
+        public static SteamVR_Action_Boolean default_A_Button
         {
             get
             {
-                return SteamVR_Actions.p_default_Menu.GetCopy<SteamVR_Action_Boolean>();
-            }
-        }
-        
-        public static SteamVR_Action_Boolean default_Jump
-        {
-            get
-            {
-                return SteamVR_Actions.p_default_Jump.GetCopy<SteamVR_Action_Boolean>();
+                return SteamVR_Actions.p_default_A_Button.GetCopy<SteamVR_Action_Boolean>();
             }
         }
         
@@ -103,19 +93,17 @@ namespace Valve.VR
                     SteamVR_Actions.default_Pose,
                     SteamVR_Actions.default_SkeletonLeftHand,
                     SteamVR_Actions.default_SkeletonRightHand,
-                    SteamVR_Actions.default_Move,
-                    SteamVR_Actions.default_Rotate,
-                    SteamVR_Actions.default_Menu,
-                    SteamVR_Actions.default_Jump,
+                    SteamVR_Actions.default_Joystick,
+                    SteamVR_Actions.default_B_Button,
+                    SteamVR_Actions.default_A_Button,
                     SteamVR_Actions.default_Haptic};
             Valve.VR.SteamVR_Input.actionsIn = new Valve.VR.ISteamVR_Action_In[] {
                     SteamVR_Actions.default_Pose,
                     SteamVR_Actions.default_SkeletonLeftHand,
                     SteamVR_Actions.default_SkeletonRightHand,
-                    SteamVR_Actions.default_Move,
-                    SteamVR_Actions.default_Rotate,
-                    SteamVR_Actions.default_Menu,
-                    SteamVR_Actions.default_Jump};
+                    SteamVR_Actions.default_Joystick,
+                    SteamVR_Actions.default_B_Button,
+                    SteamVR_Actions.default_A_Button};
             Valve.VR.SteamVR_Input.actionsOut = new Valve.VR.ISteamVR_Action_Out[] {
                     SteamVR_Actions.default_Haptic};
             Valve.VR.SteamVR_Input.actionsVibration = new Valve.VR.SteamVR_Action_Vibration[] {
@@ -123,21 +111,19 @@ namespace Valve.VR
             Valve.VR.SteamVR_Input.actionsPose = new Valve.VR.SteamVR_Action_Pose[] {
                     SteamVR_Actions.default_Pose};
             Valve.VR.SteamVR_Input.actionsBoolean = new Valve.VR.SteamVR_Action_Boolean[] {
-                    SteamVR_Actions.default_Menu,
-                    SteamVR_Actions.default_Jump};
+                    SteamVR_Actions.default_B_Button,
+                    SteamVR_Actions.default_A_Button};
             Valve.VR.SteamVR_Input.actionsSingle = new Valve.VR.SteamVR_Action_Single[0];
             Valve.VR.SteamVR_Input.actionsVector2 = new Valve.VR.SteamVR_Action_Vector2[] {
-                    SteamVR_Actions.default_Move,
-                    SteamVR_Actions.default_Rotate};
+                    SteamVR_Actions.default_Joystick};
             Valve.VR.SteamVR_Input.actionsVector3 = new Valve.VR.SteamVR_Action_Vector3[0];
             Valve.VR.SteamVR_Input.actionsSkeleton = new Valve.VR.SteamVR_Action_Skeleton[] {
                     SteamVR_Actions.default_SkeletonLeftHand,
                     SteamVR_Actions.default_SkeletonRightHand};
             Valve.VR.SteamVR_Input.actionsNonPoseNonSkeletonIn = new Valve.VR.ISteamVR_Action_In[] {
-                    SteamVR_Actions.default_Move,
-                    SteamVR_Actions.default_Rotate,
-                    SteamVR_Actions.default_Menu,
-                    SteamVR_Actions.default_Jump};
+                    SteamVR_Actions.default_Joystick,
+                    SteamVR_Actions.default_B_Button,
+                    SteamVR_Actions.default_A_Button};
         }
         
         private static void PreInitActions()
@@ -145,10 +131,9 @@ namespace Valve.VR
             SteamVR_Actions.p_default_Pose = ((SteamVR_Action_Pose)(SteamVR_Action.Create<SteamVR_Action_Pose>("/actions/default/in/Pose")));
             SteamVR_Actions.p_default_SkeletonLeftHand = ((SteamVR_Action_Skeleton)(SteamVR_Action.Create<SteamVR_Action_Skeleton>("/actions/default/in/SkeletonLeftHand")));
             SteamVR_Actions.p_default_SkeletonRightHand = ((SteamVR_Action_Skeleton)(SteamVR_Action.Create<SteamVR_Action_Skeleton>("/actions/default/in/SkeletonRightHand")));
-            SteamVR_Actions.p_default_Move = ((SteamVR_Action_Vector2)(SteamVR_Action.Create<SteamVR_Action_Vector2>("/actions/default/in/Move")));
-            SteamVR_Actions.p_default_Rotate = ((SteamVR_Action_Vector2)(SteamVR_Action.Create<SteamVR_Action_Vector2>("/actions/default/in/Rotate")));
-            SteamVR_Actions.p_default_Menu = ((SteamVR_Action_Boolean)(SteamVR_Action.Create<SteamVR_Action_Boolean>("/actions/default/in/Menu")));
-            SteamVR_Actions.p_default_Jump = ((SteamVR_Action_Boolean)(SteamVR_Action.Create<SteamVR_Action_Boolean>("/actions/default/in/Jump")));
+            SteamVR_Actions.p_default_Joystick = ((SteamVR_Action_Vector2)(SteamVR_Action.Create<SteamVR_Action_Vector2>("/actions/default/in/Joystick")));
+            SteamVR_Actions.p_default_B_Button = ((SteamVR_Action_Boolean)(SteamVR_Action.Create<SteamVR_Action_Boolean>("/actions/default/in/B-Button")));
+            SteamVR_Actions.p_default_A_Button = ((SteamVR_Action_Boolean)(SteamVR_Action.Create<SteamVR_Action_Boolean>("/actions/default/in/A_Button")));
             SteamVR_Actions.p_default_Haptic = ((SteamVR_Action_Vibration)(SteamVR_Action.Create<SteamVR_Action_Vibration>("/actions/default/out/Haptic")));
         }
     }


### PR DESCRIPTION
Changes how OpenVR devices are added. We add using the device index and also listen for the SteamVR Input action event for the input role. We also assign the roles if needed. Controller roles are needed for controller input to differentiate between left and right hands. Updated input bindings to be mirrored.