### PR TITLE
Execute Non-Destructive Modular Framework during avatar builds if it is installed in the project

### DIFF
--- a/Packages/HVRBasisNDMF/Scripts/Editor.meta
+++ b/Packages/HVRBasisNDMF/Scripts/Editor.meta
@@ -1,0 +1,8 @@
+﻿fileFormatVersion: 2
+guid: 510e6e3a9936bba449517be785e685e0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/HVRBasisNDMF/Scripts/Editor/BasisNDMFBuildHook.cs
+++ b/Packages/HVRBasisNDMF/Scripts/Editor/BasisNDMFBuildHook.cs
@@ -1,0 +1,26 @@
+﻿#if BASISNDMF_NDMF_IS_INSTALLED
+using nadena.dev.ndmf;
+using UnityEditor;
+using UnityEngine;
+
+namespace HVR.Basis.NDMF
+{
+    [InitializeOnLoad]
+    internal class BasisNDMFBuildHook
+    {
+        static BasisNDMFBuildHook()
+        {
+            BasisAssetBundlePipeline.OnBeforeBuildPrefab += (prefab, _) =>
+            {
+                BasisAvatarPrefabProcessor(prefab);
+            };
+        }
+
+        private static GameObject BasisAvatarPrefabProcessor(GameObject copy)
+        {
+            AvatarProcessor.ProcessAvatar(copy);
+            return copy;
+        }
+    }
+}
+#endif

--- a/Packages/HVRBasisNDMF/Scripts/Editor/BasisNDMFBuildHook.cs.meta
+++ b/Packages/HVRBasisNDMF/Scripts/Editor/BasisNDMFBuildHook.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 819397cf83664f72b7f50040bebcf935
+timeCreated: 1727690129

--- a/Packages/HVRBasisNDMF/Scripts/HVR.Basis.NDMF.asmdef
+++ b/Packages/HVRBasisNDMF/Scripts/HVR.Basis.NDMF.asmdef
@@ -1,0 +1,25 @@
+﻿{
+    "name": "HVR.Basis.NDMF",
+    "rootNamespace": "",
+    "references": [
+        "nadena.dev.ndmf",
+        "BasisSDKEditor"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [
+        {
+            "name": "nadena.dev.ndmf",
+            "expression": "",
+            "define": "BASISNDMF_NDMF_IS_INSTALLED"
+        }
+    ],
+    "noEngineReferences": false
+}

--- a/Packages/HVRBasisNDMF/Scripts/HVR.Basis.NDMF.asmdef.meta
+++ b/Packages/HVRBasisNDMF/Scripts/HVR.Basis.NDMF.asmdef.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 17dafc0c18e54105b78afae6ce1599b0
+timeCreated: 1727690044

--- a/Packages/HVRBasisNDMF/package.json
+++ b/Packages/HVRBasisNDMF/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dev.hai-vr.basis.ndmf",
+  "displayName": "HVR Basis NDMF Hook",
+  "version": "0.0.1",
+  "description": "HVR Basis NDMF Hook"
+}

--- a/Packages/HVRBasisNDMF/package.json.meta
+++ b/Packages/HVRBasisNDMF/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3fd09610963543048a14b25082a8db69
+PackageManifestImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -357,6 +357,12 @@
       "source": "embedded",
       "dependencies": {}
     },
+    "dev.hai-vr.basis.ndmf": {
+      "version": "file:HVRBasisNDMF",
+      "depth": 0,
+      "source": "embedded",
+      "dependencies": {}
+    },
     "com.unity.modules.accessibility": {
       "version": "1.0.0",
       "depth": 0,


### PR DESCRIPTION
If Non-Destructive Modular Framework is installed in the project, execute it when building an avatar from a Prefab.

Only when hooked, the Prefab is instantiated, the processor runs, and a new Prefab in created in the Assets/ZZZ_Generated/ folder.

If NDMF is not installed, the build process remains unchanged from the original behavior.