### PR TITLE
Videoplayer Improvements

### DIFF
--- a/Packages/Basis Framework/VideoPlayer/BasisVideoPlayer.cs
+++ b/Packages/Basis Framework/VideoPlayer/BasisVideoPlayer.cs
@@ -13,6 +13,7 @@ public class BasisVideoPlayer : MonoBehaviour
     public MeshRenderer mesh;
     public string MaterialTextureId = "_EmissionMap";
     public Material RuntimeMaterial;
+    public RenderTexture RuntimeTexture;
     public TMP_InputField Field;
    // public string Content;
     private void Start()
@@ -22,7 +23,7 @@ public class BasisVideoPlayer : MonoBehaviour
         RuntimeMaterial.mainTextureOffset = new Vector2(0, 1);
         mesh.sharedMaterial = RuntimeMaterial;
         ffmpeg.OnDisplay = OnDisplay;
-        Play(Field.text);
+        Play();
     }
 
     // Display the video texture on a 3D mesh in Unity
@@ -30,8 +31,15 @@ public class BasisVideoPlayer : MonoBehaviour
     {
         RuntimeMaterial.mainTexture = tex;
         RuntimeMaterial.SetTexture(MaterialTextureId, tex);
+        if (RuntimeTexture != null) Graphics.Blit(RuntimeMaterial.mainTexture, RuntimeTexture, RuntimeMaterial.mainTextureScale, RuntimeMaterial.mainTextureOffset);
         mesh.UpdateGIMaterials();
     }
+
+    public void Play()
+    {
+        Play(Field.text);
+    }
+    
     public async void Play(string url)
     {
         await PlayAsync(url);

--- a/Packages/Basis Framework/VideoPlayer/BasisVideoPlayer.cs
+++ b/Packages/Basis Framework/VideoPlayer/BasisVideoPlayer.cs
@@ -18,7 +18,7 @@ public class BasisVideoPlayer : MonoBehaviour
    // public string Content;
     private void Start()
     {
-        RuntimeMaterial = Material.Instantiate(mesh.sharedMaterial);
+        if (RuntimeMaterial == null) RuntimeMaterial = Material.Instantiate(mesh.sharedMaterial);
         RuntimeMaterial.mainTextureScale = new Vector2(1, -1);
         RuntimeMaterial.mainTextureOffset = new Vector2(0, 1);
         mesh.sharedMaterial = RuntimeMaterial;

--- a/Packages/Basis Framework/VideoPlayer/BasisVideoPlayerNetworked.cs
+++ b/Packages/Basis Framework/VideoPlayer/BasisVideoPlayerNetworked.cs
@@ -2,11 +2,14 @@ using Basis.Scripts.BasisSdk;
 using Basis.Scripts.BasisSdk.Players;
 using Basis.Scripts.Networking;
 using Basis.Scripts.Networking.NetworkedPlayer;
+using BasisSerializer.OdinSerializer;
+using DarkRift;
 using UnityEngine;
 public class BasisVideoPlayerNetworked : MonoBehaviour
 {
     public BasisVideoPlayer VideoPlayer;
     public ushort MyCurrentOwner;
+    public const ushort UrlSyncId = 420;
     public string MyUniqueString = "testing this damn string";
     public void Awake()
     {
@@ -36,11 +39,14 @@ public class BasisVideoPlayerNetworked : MonoBehaviour
     }
     public void Play(string Url)
     {
-
+        byte[] CompressedString = SerializationUtility.SerializeValue(Url, DataFormat.Binary);
+        BasisScene.NetworkMessageSend(UrlSyncId, CompressedString, DeliveryMethod.ReliableSequenced);
     }
     private void OnNetworkMessageReceived(ushort PlayerID, ushort MessageIndex, byte[] buffer, ushort[] Recipients)
     {
-
+        if (MessageIndex != UrlSyncId) return;
+        string url = SerializationUtility.DeserializeValue<string>(buffer, DataFormat.Binary);
+        VideoPlayer.Play(url);
     }
     public void OnRemotePlayerLeft(BasisNetworkedPlayer player1, BasisRemotePlayer player2)
     {

--- a/Packages/basistests/Prefabs/Basis VideoPlayer.prefab
+++ b/Packages/basistests/Prefabs/Basis VideoPlayer.prefab
@@ -138,7 +138,19 @@ MonoBehaviour:
   m_CharacterLimit: 0
   m_OnEndEdit:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 912005458244577639}
+        m_TargetAssemblyTypeName: BasisVideoPlayer, Basis
+        m_MethodName: Play
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   m_OnSubmit:
     m_PersistentCalls:
       m_Calls: []
@@ -585,8 +597,8 @@ AudioSource:
   Mute: 0
   Spatialize: 1
   SpatializePostEffects: 0
-  Priority: 128
-  DopplerLevel: 1
+  Priority: 16
+  DopplerLevel: 0
   MinDistance: 1
   MaxDistance: 500
   Pan2D: 0
@@ -653,7 +665,7 @@ AudioSource:
     m_Curve:
     - serializedVersion: 3
       time: 0
-      value: 1
+      value: 0
       inSlope: 0
       outSlope: 0
       tangentMode: 0
@@ -1448,6 +1460,7 @@ MonoBehaviour:
   mesh: {fileID: 8318058068607956400}
   MaterialTextureId: _EmissionMap
   RuntimeMaterial: {fileID: 0}
+  RuntimeTexture: {fileID: 0}
   Field: {fileID: 8576166549018468321}
 --- !u!114 &6811371427397274770
 MonoBehaviour:
@@ -1783,8 +1796,8 @@ AudioSource:
   Mute: 0
   Spatialize: 1
   SpatializePostEffects: 0
-  Priority: 128
-  DopplerLevel: 1
+  Priority: 16
+  DopplerLevel: 0
   MinDistance: 1
   MaxDistance: 500
   Pan2D: 0
@@ -1851,7 +1864,7 @@ AudioSource:
     m_Curve:
     - serializedVersion: 3
       time: 0
-      value: 1
+      value: 0
       inSlope: 0
       outSlope: 0
       tangentMode: 0


### PR DESCRIPTION
Add basic RenderTexture output.  
Add basic url syncing (no guardrails in place currently).  
Enable the UI to update the url during runtime.  
Adjust video player prefab audio sources to use better default settings.  
Support user-defined runtime materials for video players.

Need better mechanism for choosing a message index id. For now it'll be hardcoded.

No abuse guardrails are currently in place for the video URL inputs. It just intakes and goes.  
URL spam and race conditions will likely happen in the current state. Will be address in future PRs.