### PR TITLE
User Interface/Experience (UIX) fixes

### DIFF
--- a/Packages/Basis Framework/Device Management/Devices/Desktop/BasisAvatarEyeInput.cs
+++ b/Packages/Basis Framework/Device Management/Devices/Desktop/BasisAvatarEyeInput.cs
@@ -133,10 +133,6 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
                 rotationY = Mathf.Clamp(rotationY, minimumY, maximumY);
                 LocalRawRotation = Quaternion.Euler(rotationY, rotationX, 0);
                 Vector3 adjustedHeadPosition = new Vector3(InjectedX, BasisLocalPlayer.Instance.PlayerEyeHeight, InjectedZ);
-                if (BlockCrouching)
-                {
-                    BasisLocalInputActions.Crouching = false;
-                }
                 if (BasisLocalInputActions.Crouching)
                 {
                     adjustedHeadPosition.y -= Control.TposeLocal.position.y * crouchPercentage;

--- a/Packages/Basis Framework/Device Management/Devices/Desktop/BasisLocalInputActions.cs
+++ b/Packages/Basis Framework/Device Management/Devices/Desktop/BasisLocalInputActions.cs
@@ -36,6 +36,7 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
         public PlayerInput Input;
         public static string InputActions = "InputActions";
         public bool HasEvents = false;
+        public bool IgnoreCrouchToggle = false;
         public static Action LateUpdateEvent;
         [SerializeField]
         public BasisInputState InputState = new BasisInputState();
@@ -265,7 +266,7 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
 
             if (context.phase == InputActionPhase.Performed)
             {
-                Crouching = !Crouching;
+                if (!IgnoreCrouchToggle) Crouching = !Crouching;
                 if (CharacterEyeInput != null)
                 {
                     CharacterEyeInput.HandleMouseRotation(LookDirection);

--- a/Packages/Basis Framework/UI/BasisInputModuleHandler.cs
+++ b/Packages/Basis Framework/UI/BasisInputModuleHandler.cs
@@ -126,9 +126,9 @@ namespace Basis.Scripts.UI
                         {
                             BasisLocalPlayer.Instance.Move.BlockMovement = true;
                         }
-                        if (BasisAvatarEyeInput.Instance != null)
+                        if (BasisLocalInputActions.Instance != null)
                         {
-                            BasisAvatarEyeInput.Instance.BlockCrouching = true;
+                            BasisLocalInputActions.Instance.IgnoreCrouchToggle = true;
                         }
                         if (BasisDeviceManagement.Instance.CurrentMode == "OpenVRLoader" || BasisDeviceManagement.Instance.CurrentMode == "OpenXRLoader" || ForceKeyboard)
                         {
@@ -149,10 +149,9 @@ namespace Basis.Scripts.UI
                             {
                                 BasisLocalPlayer.Instance.Move.BlockMovement = true;
                             }
-                            if (BasisAvatarEyeInput.Instance != null)
+                            if (BasisLocalInputActions.Instance != null)
                             {
-                                BasisAvatarEyeInput.Instance.BlockCrouching = true;
-
+                                BasisLocalInputActions.Instance.IgnoreCrouchToggle = true;
                             }
                             if (BasisDeviceManagement.Instance.CurrentMode == "OpenVRLoader" || BasisDeviceManagement.Instance.CurrentMode == "OpenXRLoader" || ForceKeyboard)
                             {
@@ -175,9 +174,9 @@ namespace Basis.Scripts.UI
                     {
                         BasisLocalPlayer.Instance.Move.BlockMovement = false;
                     }
-                    if (BasisAvatarEyeInput.Instance != null)
+                    if (BasisLocalInputActions.Instance != null)
                     {
-                        BasisAvatarEyeInput.Instance.BlockCrouching = false;
+                        BasisLocalInputActions.Instance.IgnoreCrouchToggle = false;
                     }
                     var data = GetBaseEventData();
                     ExecuteEvents.Execute(EventSystem.currentSelectedGameObject, data, ExecuteEvents.submitHandler);

--- a/Packages/Basis Framework/UI/BasisUIRaycastProcess.cs
+++ b/Packages/Basis Framework/UI/BasisUIRaycastProcess.cs
@@ -41,12 +41,14 @@ public class BasisUIRaycastProcess
         {
             int DevicesCount = Inputs.Count;
             HasTarget = false;
+            var EffectiveMouseAction = false;
 
             for (int Index = 0; Index < DevicesCount; Index++)
             {
                 BasisInput input = Inputs[Index];
                 if (input.HasUIInputSupport && input.BasisPointRaycaster != null && input.BasisPointRaycaster.WasCorrectLayer)
                 {
+                    EffectiveMouseAction |= input.BasisPointRaycaster.CurrentEventData.WasLastDown == false && input.InputState.Trigger == 1;
                     if (input.BasisPointRaycaster.HadRaycastUITarget)
                     {
                         List<RaycastHitData> hitData = input.BasisPointRaycaster.SortedGraphics;
@@ -59,9 +61,18 @@ public class BasisUIRaycastProcess
                     }
                 }
             }
-            if (!HasTarget)
+            if (!HasTarget && EffectiveMouseAction)
             {
                 EventSystem.current.SetSelectedGameObject(null, null);
+            }
+
+            for (int Index = 0; Index < DevicesCount; Index++)
+            {
+                BasisInput input = Inputs[Index];
+                if (input.HasUIInputSupport && input.BasisPointRaycaster != null && input.BasisPointRaycaster.WasCorrectLayer)
+                {
+                    SendUpdateEventToSelectedObject(input.BasisPointRaycaster.CurrentEventData); //needed if you want to use the keyboard
+                }
             }
         }
     public void SimulateOnCanvas(RaycastResult raycastResult, RaycastHitData hit, BasisPointerEventData currentEventData, BasisInputState Current, BasisInputState LastCurrent)
@@ -95,13 +106,11 @@ public class BasisUIRaycastProcess
                     currentEventData.WasLastDown = false;
                 }
             }
-            SendUpdateEventToSelectedObject(currentEventData);//needed if you want to use the keyboard
 
             ProcessScrollWheel(currentEventData);
             ProcessPointerMovement(currentEventData);
             ProcessPointerButtonDrag(currentEventData);
         }
-
     }
     public void CheckOrApplySelectedGameobject(RaycastHitData hit, BasisPointerEventData CurrentEventData)
     {


### PR DESCRIPTION
NOTE: While these do fix the most obnoxious issues, it is an imperfect hack to make input work for the short term. A larger rework of Input abstraction is needed. Will be covered by a separate issue.

Fix UI text input on desktop.
Fixes input focus kicking disabling crouch.
Fixes cursor raycast leaving the UI collider causing UI input de-focus. Fixes keyboard not usable when the cursor raycast wasn't on the UI collider.