### PR TITLE
Videoplayer fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,4 @@ crashlytics-build.properties
 # Basis exclusions
 /[Aa]sset[Bb]undles/
 /[Aa]ssets/_UserContent
+/[Aa]ssets/_UserContent.meta

--- a/Assets/Settings/UniversalRenderPipelineGlobalSettings.asset
+++ b/Assets/Settings/UniversalRenderPipelineGlobalSettings.asset
@@ -158,7 +158,7 @@ MonoBehaviour:
         m_Version: 0
         m_ExportShaderVariants: 1
         m_ShaderVariantLogLevel: 0
-        m_StripRuntimeDebugShaders: 0
+        m_StripRuntimeDebugShaders: 1
     - rid: 2858994164428701717
       type: {class: RenderGraphUtilsResources, ns: UnityEngine.Rendering.RenderGraphModule.Util, asm: Unity.RenderPipelines.Core.Runtime}
       data:

--- a/Packages/Basis Framework/VideoPlayer/BasisVideoPlayerNetworked.cs
+++ b/Packages/Basis Framework/VideoPlayer/BasisVideoPlayerNetworked.cs
@@ -1,3 +1,4 @@
+using System.Security.Policy;
 using Basis.Scripts.BasisSdk;
 using Basis.Scripts.BasisSdk.Players;
 using Basis.Scripts.Networking;
@@ -5,30 +6,38 @@ using Basis.Scripts.Networking.NetworkedPlayer;
 using BasisSerializer.OdinSerializer;
 using DarkRift;
 using UnityEngine;
+using UnityEngine.Serialization;
+
 public class BasisVideoPlayerNetworked : MonoBehaviour
 {
     public BasisVideoPlayer VideoPlayer;
-    public ushort MyCurrentOwner;
-    public const ushort UrlSyncId = 420;
-    public string MyUniqueString = "testing this damn string";
+
+    public const ushort UrlMessageId = 420;
+
+    public string Url { get => VideoPlayer.Url; set => VideoPlayer.Url = value; }
+
+    public ushort OwnerId { get; private set; } = 0;
+    public bool IsOwner { get; private set; }
+    public string OwnershipContextId { get; private set; }
+
     public void Awake()
     {
         if (VideoPlayer == null)
         {
-            Debug.LogError("Missing the video player!");
+            Error("Missing the video player!");
             this.enabled = false;
+            return;
         }
+
+        OwnershipContextId = GetUniqueContextId();
         BasisScene.OnNetworkMessageReceived += OnNetworkMessageReceived;
         BasisNetworkManagement.OnLocalPlayerJoined += OnLocalPlayerJoined;
         BasisNetworkManagement.OnRemotePlayerJoined += OnRemotePlayerJoined;
         BasisNetworkManagement.OnLocalPlayerLeft += OnLocalPlayerLeft;
         BasisNetworkManagement.OnRemotePlayerLeft += OnRemotePlayerLeft;
-        if (BasisNetworkManagement.HasSentOnLocalPlayerJoin)
-        {
-            BasisNetworkManagement.OnOwnershipTransfer += OnOwnershipTransfer;
-            BasisNetworkManagement.RequestCurrentOwnership(MyUniqueString);
-        }
+        BasisNetworkManagement.OnOwnershipTransfer += OnOwnershipTransfer;
     }
+
     public void OnDestroy()
     {
         BasisScene.OnNetworkMessageReceived -= OnNetworkMessageReceived;
@@ -36,42 +45,114 @@ public class BasisVideoPlayerNetworked : MonoBehaviour
         BasisNetworkManagement.OnRemotePlayerJoined -= OnRemotePlayerJoined;
         BasisNetworkManagement.OnLocalPlayerLeft -= OnLocalPlayerLeft;
         BasisNetworkManagement.OnRemotePlayerLeft -= OnRemotePlayerLeft;
+        BasisNetworkManagement.OnOwnershipTransfer -= OnOwnershipTransfer;
     }
-    public void Play(string Url)
+
+    public void Play()
     {
-        byte[] CompressedString = SerializationUtility.SerializeValue(Url, DataFormat.Binary);
-        BasisScene.NetworkMessageSend(UrlSyncId, CompressedString, DeliveryMethod.ReliableSequenced);
+        Log($"Playing from cache: {Url ?? "null"}");
+        Play(Url);
     }
+
+    public void Play(string url)
+    {
+        Log($"Playing: {url}");
+        Url = url;
+        VideoPlayer.Play(url);
+        SendUrl(url);
+    }
+
     private void OnNetworkMessageReceived(ushort PlayerID, ushort MessageIndex, byte[] buffer, ushort[] Recipients)
     {
-        if (MessageIndex != UrlSyncId) return;
-        string url = SerializationUtility.DeserializeValue<string>(buffer, DataFormat.Binary);
+        if (MessageIndex != UrlMessageId) return;
+        if (!TryGetUrl(buffer, out string url)) return;
+        Log($"Playing from network: {url}");
+        Url = url;
         VideoPlayer.Play(url);
     }
-    public void OnRemotePlayerLeft(BasisNetworkedPlayer player1, BasisRemotePlayer player2)
+
+    public void OnLocalPlayerJoined(BasisNetworkedPlayer playerNetwork, BasisLocalPlayer playerSystem)
     {
+        BasisNetworkManagement.RequestCurrentOwnership(OwnershipContextId);
     }
-    public void OnLocalPlayerLeft(BasisNetworkedPlayer player1, BasisLocalPlayer player2)
+
+    public void OnLocalPlayerLeft(BasisNetworkedPlayer playerNetwork, BasisLocalPlayer playerSystem) { }
+
+    public void OnRemotePlayerJoined(BasisNetworkedPlayer playerNetwork, BasisRemotePlayer playerSystem)
     {
+        if (IsOwner) SendUrl(Url, playerNetwork.NetId);
     }
-    public void OnRemotePlayerJoined(BasisNetworkedPlayer player1, BasisRemotePlayer player2)
+
+    public void OnRemotePlayerLeft(BasisNetworkedPlayer playerNetwork, BasisRemotePlayer playerSystem)
     {
+        // if prior owner has left, query for the new current owner data
+        if (playerNetwork.NetId == OwnerId) 
+            BasisNetworkManagement.RequestCurrentOwnership(OwnershipContextId);
     }
-    public void OnLocalPlayerJoined(BasisNetworkedPlayer player1, BasisLocalPlayer player2)
+
+    private void OnOwnershipTransfer(string EntityId, ushort NetworkOwner, bool isOwner)
     {
-        BasisNetworkManagement.OnOwnershipTransfer += OnOwnershipTransfer;
-        BasisNetworkManagement.RequestCurrentOwnership(MyUniqueString);
-    }
-    private void OnOwnershipTransfer(string UniqueEntityID, ushort NetIdNewOwner, bool IsOwner)
-    {
-        if (UniqueEntityID == MyUniqueString)
+        if (EntityId == OwnershipContextId)
         {
-            MyCurrentOwner = NetIdNewOwner;
-            Debug.Log("Updated my Owner To " + UniqueEntityID + " | " + NetIdNewOwner);
+            OwnerId = NetworkOwner;
+            IsOwner = isOwner;
+            Log($"Updated Owner to {NetworkOwner} (am I the owner? {isOwner}) for '{EntityId}'");
         }
-        else
+    }
+
+    private void SendUrl(string url, params ushort[] recipients)
+    {
+        if (recipients.Length == 0) recipients = null;
+        Log($"Sending URL to {(recipients == null ? "all" : recipients)} other clients: {url}");
+        BasisScene.NetworkMessageSend(UrlMessageId, SerializeData(url), DeliveryMethod.ReliableSequenced, recipients);
+    }
+
+    private bool TryGetUrl(byte[] buffer, out string url)
+    {
+        return TryDeserializeData(buffer, out url);
+    }
+
+    private byte[] SerializeData(string data)
+    {
+        return SerializationUtility.SerializeValue($"{OwnershipContextId}\0{data}", DataFormat.Binary);
+    }
+
+    private bool TryDeserializeData(byte[] buffer, out string data)
+    {
+        data = null;
+        string[] raw = SerializationUtility.DeserializeValue<string>(buffer, DataFormat.Binary).Split('\0', 2);
+        if (raw.Length != 2) return false; // invalid format, not from this script
+        if (raw[0] != OwnershipContextId) return false; // invalid id, not from this instance
+        data = raw[1];
+        return true;
+    }
+
+    private string GetUniqueContextId()
+    {
+        int componentIndex = System.Array.IndexOf(GetComponents<Component>(), this);
+        return $"{GetHierarchyPath(transform)}#{nameof(BasisVideoPlayerNetworked)}:{componentIndex}";
+    }
+
+    private static string GetHierarchyPath(Transform t)
+    {
+        string path = "";
+        while (t != null)
         {
-            Debug.Log("Recieving someone elses " + UniqueEntityID + " | " + NetIdNewOwner);
+            path = $"/{t.name.Replace(" ", "")}:{t.GetSiblingIndex()}";
+            t = t.parent;
         }
+
+        return path;
+    }
+
+
+    private static void Log(string message)
+    {
+        Debug.Log($"[<color=#00ffff>{nameof(BasisVideoPlayerNetworked)}</color>] {message}");
+    }
+
+    private static void Error(string message)
+    {
+        Debug.LogError($"[<color=#00ffff>{nameof(BasisVideoPlayerNetworked)}</color>] {message}");
     }
 }


### PR DESCRIPTION
Re-enable stripping of runtime debug shaders (was causing build failures).
Add preliminary support for URL syncing for video players.
Add unique ID contexts to enable support for multiple unique video players in scene.
Add null checks for stabilizing the lack of inspector fields that should be considered optional.
Add rudimentary log prefix structure to easily identify desired log statements.
Move data serialization/deserialization into helper methods for better organization.