### PR TITLE
Fix avatar selection UI now passes avatar mode for local testing:

### DIFF
--- a/Packages/Basis Framework/UI/UI Panels/BasisUIAvatarSelection.cs
+++ b/Packages/Basis Framework/UI/UI Panels/BasisUIAvatarSelection.cs
@@ -200,7 +200,9 @@ namespace Basis.Scripts.UI.UI_Panels
         {
             if (BasisLocalPlayer.Instance != null)
             {
-                await BasisLocalPlayer.Instance.CreateAvatar(0, avatarLoadRequest);
+                var assetMode = avatarLoadRequest.BasisBundleInformation.BasisBundleGenerated.AssetMode;
+                var mode = !string.IsNullOrEmpty(assetMode) && byte.TryParse(assetMode, out var result) ? result : (byte)0;
+                await BasisLocalPlayer.Instance.CreateAvatar(mode, avatarLoadRequest);
             }
         }
 


### PR DESCRIPTION
- Local avatars (Asset Mode = 1) could not be loaded because the asset mode was not passed when selecting a new avatar in the UI.
- Parse and pass the asset mode to the avatar instantiation.