### PR TITLE
When using content removal, add option to disallow animator events:

### DIFF
--- a/Packages/Basis Framework/Bundle Management/BasisBundleLoadAsset.cs
+++ b/Packages/Basis Framework/Bundle Management/BasisBundleLoadAsset.cs
@@ -72,6 +72,15 @@ public static class BasisBundleLoadAsset
                     }
                 }
             }
+
+            if (BundledContentHolder.Instance.Selector.disallowAnimatorEvents)
+            {
+                var animators = SearchAndDestroy.GetComponentsInChildren<Animator>(true);
+                foreach (var animator in animators)
+                {
+                    animator.fireEvents = false;
+                }
+            }
         }
         if (Parent == null)
         {

--- a/Packages/Basis Framework/Bundle Management/Content Police/ContentPoliceSelector.cs
+++ b/Packages/Basis Framework/Bundle Management/Content Police/ContentPoliceSelector.cs
@@ -7,4 +7,7 @@ public class ContentPoliceSelector : ScriptableObject
 {
     [SerializeField]
     public List<string> selectedTypes;
+    
+    [SerializeField]
+    public bool disallowAnimatorEvents = true;
 }

--- a/Packages/Basis Framework/Editor/ContentPoliceSelectorEditor.cs
+++ b/Packages/Basis Framework/Editor/ContentPoliceSelectorEditor.cs
@@ -37,6 +37,12 @@ public class ContentPoliceSelectorEditor : Editor
 
     public override void OnInspectorGUI()
     {
+        var disallowAnimatorEventsValue = EditorGUILayout.ToggleLeft("Disallow Animator events", selector.disallowAnimatorEvents);
+        if (disallowAnimatorEventsValue != selector.disallowAnimatorEvents)
+        {
+            selector.disallowAnimatorEvents = disallowAnimatorEventsValue;
+            EditorUtility.SetDirty(selector);
+        }
         EditorGUILayout.LabelField("Select MonoBehaviour Types that are approved", EditorStyles.boldLabel);
         int TypeCount = typeNames.Length;
         // Loop through the type names and create checkboxes


### PR DESCRIPTION
- Add `disallowAnimatorEvents` content policing.
- When enabled, Animator.fireEvents will be set to false on all Animator components found in the asset.