### PR TITLE
Fix website markdown rendering

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,8 @@
+theme: jekyll-theme-minimal
+title: Basis
+description: Basis Framework
+lsi: false
+safe: true
+kramdown:
+  math_engine: mathjax
+  syntax_highlighter: rouge


### PR DESCRIPTION
Jekyll _may_ need to have a different markdown renderer defined, or its just bad markdown. haven't tested locally, so who knows yet!