### PR TITLE
Fix visual hardware model should scale more accurately after 1st VR calibration:

### DIFF
--- a/Packages/Basis Framework/Device Management/BasisVisualTracker.cs
+++ b/Packages/Basis Framework/Device Management/BasisVisualTracker.cs
@@ -43,7 +43,7 @@ namespace Basis.Scripts.Device_Management
         }
         public void UpdateVisualSizeAndOffset()
         {
-            gameObject.transform.localScale = ScaleOfModel;//* BasisLocalPlayer.Instance.RatioPlayerToAvatarScale;
+            gameObject.transform.localScale = ScaleOfModel * BasisLocalPlayer.Instance.EyeRatioAvatarToAvatarDefaultScale;
             gameObject.transform.SetLocalPositionAndRotation(ModelPositionOffset * BasisLocalPlayer.Instance.EyeRatioPlayerToDefaultScale, ModelRotationOffset);
         }
     }


### PR DESCRIPTION
- There was a mismatch between the visual hardware scale, which was testable by opening the Basis menu, and then opening the SteamVR menu to compare the hardware viewmodels.
- Rescale the visual hardware more accurately after the 1st VR calibration.
- There is still a visual issue where switching from Desktop to VR for the first time might not update or calibrate the player scale properly. This commit does not fix this.