### PR TITLE
Scale hardware-to-avatar offset with avatar height:

### DIFF
--- a/Packages/Basis Framework/Device Management/Devices/OpenVR/BasisOpenVRInput.cs
+++ b/Packages/Basis Framework/Device Management/Devices/OpenVR/BasisOpenVRInput.cs
@@ -43,7 +43,7 @@ namespace Basis.Scripts.Device_Management.Devices.OpenVR
                             if (Control.HasTracked != BasisHasTracked.HasNoTracker)
                             {
                                 // Apply the position offset using math.mul for quaternion-vector multiplication
-                                Control.IncomingData.position = FinalPosition - math.mul(FinalRotation, AvatarPositionOffset);
+                                Control.IncomingData.position = FinalPosition - math.mul(FinalRotation, AvatarPositionOffset * BasisLocalPlayer.Instance.EyeRatioAvatarToAvatarDefaultScale);
 
                                 // Apply the rotation offset using math.mul for quaternion multiplication
                                 Control.IncomingData.rotation = math.mul(FinalRotation, Quaternion.Euler(AvatarRotationOffset));

--- a/Packages/Basis Framework/Device Management/Devices/OpenVR/BasisOpenVRInputController.cs
+++ b/Packages/Basis Framework/Device Management/Devices/OpenVR/BasisOpenVRInputController.cs
@@ -80,7 +80,7 @@ namespace Basis.Scripts.Device_Management.Devices.OpenVR
                 if (Control.HasTracked != BasisHasTracked.HasNoTracker)
                 {
                     // Apply position offset using math.mul for quaternion-vector multiplication
-                    Control.IncomingData.position = FinalPosition - math.mul(FinalRotation, AvatarPositionOffset);
+                    Control.IncomingData.position = FinalPosition - math.mul(FinalRotation, AvatarPositionOffset * BasisLocalPlayer.Instance.EyeRatioAvatarToAvatarDefaultScale);
 
                     // Apply rotation offset using math.mul for quaternion multiplication
                     Control.IncomingData.rotation = math.mul(FinalRotation, Quaternion.Euler(AvatarRotationOffset));

--- a/Packages/Basis Framework/Device Management/Devices/OpenVR/BasisOpenVRInputSpatial.cs
+++ b/Packages/Basis Framework/Device Management/Devices/OpenVR/BasisOpenVRInputSpatial.cs
@@ -40,7 +40,7 @@ namespace Basis.Scripts.Device_Management.Devices.Unity_Spatial_Tracking
                 {
                     if (Control.HasTracked != BasisHasTracked.HasNoTracker)
                     {
-                        Control.IncomingData.position = FinalPosition - math.mul(FinalRotation, AvatarPositionOffset);
+                        Control.IncomingData.position = FinalPosition - math.mul(FinalRotation, AvatarPositionOffset * BasisLocalPlayer.Instance.EyeRatioAvatarToAvatarDefaultScale);
                         Control.IncomingData.rotation = math.mul(FinalRotation, Quaternion.Euler(AvatarRotationOffset));
                     }
                 }

--- a/Packages/Basis Framework/Device Management/Devices/OpenXR/BasisOpenXRInput.cs
+++ b/Packages/Basis Framework/Device Management/Devices/OpenXR/BasisOpenXRInput.cs
@@ -49,7 +49,7 @@ namespace Basis.Scripts.Device_Management.Devices.OpenXR
                     if (hasRoleAssigned && Control.HasTracked != BasisHasTracked.HasNoTracker)
                     {
                         // Apply the inverse rotation to position offset
-                        Control.IncomingData.position = LocalRawPosition - math.mul(LocalRawRotation, AvatarPositionOffset);
+                        Control.IncomingData.position = LocalRawPosition - math.mul(LocalRawRotation, AvatarPositionOffset * BasisLocalPlayer.Instance.EyeRatioAvatarToAvatarDefaultScale);
                     }
                 }
 

--- a/Packages/Basis Framework/Device Management/Devices/Simulation/BasisInputXRSimulate.cs
+++ b/Packages/Basis Framework/Device Management/Devices/Simulation/BasisInputXRSimulate.cs
@@ -39,7 +39,7 @@ namespace Basis.Scripts.Device_Management.Devices.Simulation
                 if (Control.HasTracked != BasisHasTracked.HasNoTracker)
                 {
                     // Apply the position offset using math.mul for quaternion-vector multiplication
-                    Control.IncomingData.position = FinalPosition - math.mul(FinalRotation, AvatarPositionOffset);
+                    Control.IncomingData.position = FinalPosition - math.mul(FinalRotation, AvatarPositionOffset * BasisLocalPlayer.Instance.EyeRatioAvatarToAvatarDefaultScale);
                     Control.IncomingData.rotation = math.mul(FinalRotation, Quaternion.Euler(AvatarRotationOffset));
                 }
             }


### PR DESCRIPTION
- When wearing avatars with a shorter height, the offset should now be applied accounting for the avatar scale.
- This should alleviate an issue where shorter avatars had the avatar hand was significantly away from the hardware controller; still, despite this change, the hands still feel off, so this does not fully fix embodiment.
- For this to work, the user must calibrate at least once. This is because there is still a visual issue where switching from Desktop to VR for the first time might not update or calibrate the player scale properly. This commit does not fix this.