### PR TITLE
Make menu panels request visibility of trackers:

### DIFF
--- a/Assets/Prefabs/Boot/InputActions.prefab
+++ b/Assets/Prefabs/Boot/InputActions.prefab
@@ -169,6 +169,7 @@ GameObject:
   - component: {fileID: 256212325347645450}
   - component: {fileID: 6482417607131076391}
   - component: {fileID: 6378574261833472064}
+  - component: {fileID: 2204982582000934740}
   m_Layer: 0
   m_Name: InputActions
   m_TagString: Untagged
@@ -2063,6 +2064,18 @@ MonoBehaviour:
   OnSettingsSaved:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &2204982582000934740
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1286943206467795689}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8abbe688010b4f9a9e08ca05b0fdee95, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &7884915406730103288
 GameObject:
   m_ObjectHideFlags: 0

--- a/Packages/Basis Framework/Device Management/Devices/BasisInput.cs
+++ b/Packages/Basis Framework/Device Management/Devices/BasisInput.cs
@@ -315,12 +315,10 @@ namespace Basis.Scripts.Device_Management.Devices
                         if (BasisHamburgerMenu.Instance == null)
                         {
                             BasisHamburgerMenu.OpenHamburgerMenuNow();
-                            BasisDeviceManagement.ShowTrackers();
                         }
                         else
                         {
                             BasisHamburgerMenu.Instance.CloseThisMenu();
-                            BasisDeviceManagement.HideTrackers();
                         }
                     }
                     if (InputState.PrimaryButtonGetState == false && LastState.PrimaryButtonGetState)

--- a/Packages/Basis Framework/UI/BasisTrackerVisibilityHandler.cs
+++ b/Packages/Basis Framework/UI/BasisTrackerVisibilityHandler.cs
@@ -1,0 +1,74 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using Basis.Scripts.Device_Management;
+using Basis.Scripts.UI.UI_Panels;
+using UnityEngine;
+
+namespace Basis.Scripts.UI
+{
+    public class BasisTrackerVisibilityHandler : MonoBehaviour
+    {
+        private bool wasVisible;
+
+        private void OnEnable()
+        {
+            BasisUINeedsVisibleTrackers.sceneInstance = this;
+        }
+        
+        private void OnDisable()
+        {
+            BasisUINeedsVisibleTrackers.sceneInstance = null;
+        }
+
+        public void VerifyAtEndOfFrame()
+        {
+            // We need to delay showing and hiding trackers, so that we don't hide-then-show within the same frame.
+            StartCoroutine(CheckCoroutine());
+        }
+
+        private IEnumerator CheckCoroutine()
+        {
+            yield return new WaitForEndOfFrame();
+
+            var shouldBeVisible = BasisUINeedsVisibleTrackers.Instance.ShouldBeVisible;
+            if (shouldBeVisible != wasVisible)
+            {
+                wasVisible = shouldBeVisible;
+                if (shouldBeVisible)
+                {
+                    BasisDeviceManagement.ShowTrackers();
+                }
+                else
+                {
+                    BasisDeviceManagement.HideTrackers();
+                }
+            }
+        }
+    }
+    
+    public class BasisUINeedsVisibleTrackers
+    {
+        public static BasisTrackerVisibilityHandler sceneInstance;
+        
+        public static BasisUINeedsVisibleTrackers Instance
+        {
+            get { return instance ??= new BasisUINeedsVisibleTrackers(); }
+        }
+        private static BasisUINeedsVisibleTrackers instance;
+        private HashSet<BasisUIBase> requesters = new();
+        
+        public bool ShouldBeVisible => requesters.Count > 0;
+
+        public void Add(BasisUIBase requester)
+        {
+            requesters.Add(requester);
+            if (sceneInstance) sceneInstance.VerifyAtEndOfFrame();
+        }
+
+        public void Remove(BasisUIBase requester)
+        {
+            requesters.Remove(requester);
+            if (sceneInstance) sceneInstance.VerifyAtEndOfFrame();
+        }
+    }
+}

--- a/Packages/Basis Framework/UI/UI Panels/BasisHamburgerMenu.cs
+++ b/Packages/Basis Framework/UI/UI Panels/BasisHamburgerMenu.cs
@@ -30,6 +30,7 @@ namespace Basis.Scripts.UI.UI_Panels
             FullBody.onClick.AddListener(PutIntoCalibrationMode);
             Respawn.onClick.AddListener(RespawnLocalPlayer);
             BasisCursorManagement.UnlockCursor(nameof(BasisHamburgerMenu));
+            BasisUINeedsVisibleTrackers.Instance.Add(this);
         }
         private Dictionary<BasisInput, Action> TriggerDelegates = new Dictionary<BasisInput, Action>();
         public void RespawnLocalPlayer()
@@ -98,6 +99,7 @@ namespace Basis.Scripts.UI.UI_Panels
         public override void DestroyEvent()
         {
             BasisCursorManagement.LockCursor(nameof(BasisHamburgerMenu));
+            BasisUINeedsVisibleTrackers.Instance.Remove(this);
         }
     }
 }

--- a/Packages/Basis Framework/UI/UI Panels/BasisSettingsPanelMenu.cs
+++ b/Packages/Basis Framework/UI/UI Panels/BasisSettingsPanelMenu.cs
@@ -7,7 +7,7 @@ namespace Basis.Scripts.UI.UI_Panels
 {
     public class BasisSettingsPanelMenu : BasisUIBase
     {
-        public static string SettingsPanel = "SettingsPanel";
+        public const string SettingsPanel = "SettingsPanel";
         public Button Connect;
         public TMP_InputField IP;
         public TMP_InputField Port;
@@ -58,10 +58,12 @@ namespace Basis.Scripts.UI.UI_Panels
         public override void InitalizeEvent()
         {
             BasisCursorManagement.UnlockCursor(nameof(BasisSettingsPanelMenu));
+            BasisUINeedsVisibleTrackers.Instance.Add(this);
         }
         public override void DestroyEvent()
         {
             BasisCursorManagement.LockCursor(nameof(BasisSettingsPanelMenu));
+            BasisUINeedsVisibleTrackers.Instance.Remove(this);
         }
     }
 }

--- a/Packages/Basis Framework/UI/UI Panels/BasisUIAvatarSelection.cs
+++ b/Packages/Basis Framework/UI/UI Panels/BasisUIAvatarSelection.cs
@@ -38,6 +38,7 @@ namespace Basis.Scripts.UI.UI_Panels
         public override void InitalizeEvent()
         {
             BasisCursorManagement.UnlockCursor(AvatarSelection);
+            BasisUINeedsVisibleTrackers.Instance.Add(this);
         }
 
         private async void AddAvatar()
@@ -209,6 +210,7 @@ namespace Basis.Scripts.UI.UI_Panels
         public override void DestroyEvent()
         {
             BasisCursorManagement.LockCursor(AvatarSelection);
+            BasisUINeedsVisibleTrackers.Instance.Remove(this);
         }
     }
 }

--- a/Packages/Basis Framework/UI/UI Panels/BasisUISettings.cs
+++ b/Packages/Basis Framework/UI/UI Panels/BasisUISettings.cs
@@ -7,11 +7,13 @@ namespace Basis.Scripts.UI.UI_Panels
         public override void DestroyEvent()
         {
             BasisCursorManagement.LockCursor(nameof(BasisUISettings));
+            BasisUINeedsVisibleTrackers.Instance.Remove(this);
         }
 
         public override void InitalizeEvent()
         {
             BasisCursorManagement.UnlockCursor(nameof(BasisUISettings));
+            BasisUINeedsVisibleTrackers.Instance.Add(this);
         }
         public void OpenConsole()
         {


### PR DESCRIPTION
- Fix trackers are no longer visible if the user closes the menu using the X button, or by respawning, or by opening the settings, or by opening the avatar menu.
- Basis UI Menus now must request in their UI Initialize event for the trackers to be visible, and un-request in the UI Destroy event.
- Add BasisTrackerVisibilityHandler MonoBehaviour in the InputActions prefab.
  - This behaviour contains a coroutine that is run upon at the end of frame after requests and un-requests are submitted, so that when a menu closes itself to open a different menu, the tracker visibility is only toggled ON or OFF once for any given frame.

NOTE: This PR conflicts with the Snap Turn PR because they both modify the InputActions prefab.