### PR TITLE
Quick fix bottom half of the Snap Turn Angle slider is now clickable:

### DIFF
--- a/Basis/Assets/Prefabs/UI/Settings UI.prefab
+++ b/Basis/Assets/Prefabs/UI/Settings UI.prefab
@@ -21946,7 +21946,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 1
+  m_PresetInfoIsWorld: 0
 --- !u!114 &6328418170902668384
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -26726,8 +26726,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 200, y: -15}
-  m_SizeDelta: {x: 325, y: 30}
+  m_AnchoredPosition: {x: 115.55, y: -15}
+  m_SizeDelta: {x: 155.81, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3294497918497136317
 CanvasRenderer:
@@ -26836,7 +26836,7 @@ MonoBehaviour:
   m_VertexBufferAutoSizeReduction: 0
   m_useMaxVisibleDescender: 1
   m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 37.342415, w: 0}
+  m_margin: {x: 0, y: 0, z: 7.657139, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_hasFontAssetChanged: 0


### PR DESCRIPTION
- The "Microphone" label hitbox was overlapping the slider, it no longer overlaps it.