### PR TITLE
Ignore all cursor management requests while in VR mode:

### DIFF
--- a/Basis/Packages/Basis Framework/Device Management/BasisDeviceManagement.cs
+++ b/Basis/Packages/Basis Framework/Device Management/BasisDeviceManagement.cs
@@ -41,7 +41,7 @@ namespace Basis.Scripts.Device_Management
         /// <summary>
         /// checks to see if we are in desktop
         /// this being false does not mean its vr.
-        /// 
+        ///
         /// </summary>
         /// <returns></returns>
         public static bool IsUserInDesktop()
@@ -188,6 +188,8 @@ namespace Basis.Scripts.Device_Management
             }
 
             CurrentMode = newMode;
+            if (newMode == "Desktop") BasisCursorManagement.SwitchToDesktopMode();
+            else if (newMode != "Exiting") BasisCursorManagement.SwitchToVRMode();
             OnBootModeChanged?.Invoke(CurrentMode);
 
             Debug.Log("Loading " + CurrentMode);

--- a/Basis/Packages/Basis Framework/Device Management/BasisDeviceManagement.cs
+++ b/Basis/Packages/Basis Framework/Device Management/BasisDeviceManagement.cs
@@ -188,8 +188,10 @@ namespace Basis.Scripts.Device_Management
             }
 
             CurrentMode = newMode;
-            if (newMode == "Desktop") BasisCursorManagement.SwitchToDesktopMode();
-            else if (newMode != "Exiting") BasisCursorManagement.SwitchToVRMode();
+            if (newMode != "Desktop" && newMode != "Exiting")
+            {
+                BasisCursorManagement.UnlockCursorBypassChecks();
+            }
             OnBootModeChanged?.Invoke(CurrentMode);
 
             Debug.Log("Loading " + CurrentMode);

--- a/Basis/Packages/Basis Framework/Device Management/Devices/BasisCursorManagement.cs
+++ b/Basis/Packages/Basis Framework/Device Management/Devices/BasisCursorManagement.cs
@@ -8,6 +8,10 @@ public static class BasisCursorManagement
     private static List<string> cursorLockRequests = new List<string>();
     // Event that gets triggered whenever the cursor state changes
     public static event Action<CursorLockMode, bool> OnCursorStateChange;
+
+    // When in VR mode, all cursor lock requests are ignored.
+    private static bool isVRMode;
+
     public static void OverrideableLock(string requestName)
     {
         Cursor.lockState = CursorLockMode.Locked;
@@ -22,12 +26,30 @@ public static class BasisCursorManagement
     {
         return Cursor.visible;
     }
+
+    public static void SwitchToVRMode()
+    {
+        isVRMode = true;
+
+        Cursor.lockState = CursorLockMode.None;
+        Cursor.visible = true;
+        Debug.Log("Cursor Unlocked due to entering VR mode");
+        OnCursorStateChange?.Invoke(CursorLockMode.None, true);
+    }
+
+    public static void SwitchToDesktopMode()
+    {
+        isVRMode = false;
+    }
+
     /// <summary>
     /// Locks the cursor to the center of the screen and hides it.
     /// Adds a request to lock the cursor.
     /// </summary>
     public static void LockCursor(string requestName)
     {
+        if (isVRMode) return;
+
         Cursor.lockState = CursorLockMode.Locked;
         Cursor.visible = false;
         Debug.Log("Cursor Locked");
@@ -40,6 +62,8 @@ public static class BasisCursorManagement
     /// </summary>
     public static void UnlockCursor(string requestName)
     {
+        if (isVRMode) return;
+
         Cursor.lockState = CursorLockMode.None;
         Cursor.visible = true;
         Debug.Log("Cursor Unlocked");
@@ -52,6 +76,8 @@ public static class BasisCursorManagement
     /// </summary>
     public static void ConfineCursor(string requestName)
     {
+        if (isVRMode) return;
+
         Cursor.lockState = CursorLockMode.Confined;
         Cursor.visible = true;
         Debug.Log("Cursor Confined");


### PR DESCRIPTION
- When entering VR mode, unlock cursor and ignore all cursor management requests.
- This new behaviour prevents the cursor from being stolen from other VR desktop overlay applications.