### PR TITLE
Correct File Extension on Generated Password File

### DIFF
--- a/Basis/Packages/basisdk/Scripts/Editor/AssetBundleBuilder/BasisAssetBundleBuilder.cs
+++ b/Basis/Packages/basisdk/Scripts/Editor/AssetBundleBuilder/BasisAssetBundleBuilder.cs
@@ -51,7 +51,7 @@ public static class AssetBundleBuilder
                 }
                 string Pathout = Path.GetDirectoryName(actualFilePath);
 
-                await SaveFileAsync(Pathout, "dontuploadmepassword", ".txt", Password);
+                await SaveFileAsync(Pathout, "dontuploadmepassword", "txt", Password);
 
                 OpenRelativePath(Pathout);
             }


### PR DESCRIPTION
SaveFileAsync only needs the extension, the period is automatic. This fixes the double period in filename issue.