### PR TITLE
Fix copy-paste error relating to fingers.

### DIFF
--- a/Basis/Packages/com.basis.framework/Drivers/BasisBaseMuscleDriver.cs
+++ b/Basis/Packages/com.basis.framework/Drivers/BasisBaseMuscleDriver.cs
@@ -268,7 +268,7 @@ public abstract class BasisBaseMuscleDriver : MonoBehaviour
             GetClosestValue(RightFinger.LittlePercentage, out RightLittleAdditional);
             LastRightLittlePercentage = RightFinger.LittlePercentage;
         }
-        UpdateFingerPoses(Map.RightLittle, RightLittleAdditional.PoseData.RightLittle, ref Current.RightLittle, Map.HasRightRing, Rotation);
+        UpdateFingerPoses(Map.RightLittle, RightLittleAdditional.PoseData.RightLittle, ref Current.RightLittle, Map.HasRightLittle, Rotation);
     }
     public void UpdateFingerPoses(Transform[] proximal, MuscleLocalPose[] poses, ref MuscleLocalPose[] currentPoses, bool[] hasProximal, float rotation)
     {


### PR DESCRIPTION
The right little finger was using the finger availability information of the right ring finger, instead of its own availability information. This causes issues if, for instance, you have a right ring finger but don't have a right pinky finger. (hi, that's both of my avatars)

This fixes the local error spam caused by my avatar. I haven't tested if this fixes loading my avatar as a remote avatar yet, or if it fixes the finger mangling.

For reference, the relevant log spam looks like this:
```
NullReferenceException: Object reference not set to an instance of an object
BasisBaseMuscleDriver.UpdateFingerPoses (UnityEngine.Transform[] proximal, MuscleLocalPose[] poses, MuscleLocalPose[]& currentPoses, System.Boolean[] hasProximal, System.Single rotation) (at ./Packages/com.basis.framework/Drivers/BasisBaseMuscleDriver.cs:284)
BasisBaseMuscleDriver.UpdateAllFingers (Basis.Scripts.Common.BasisTransformMapping Map, PoseData& Current) (at ./Packages/com.basis.framework/Drivers/BasisBaseMuscleDriver.cs:271)
BasisMuscleDriver.UpdateFingers () (at ./Packages/com.basis.framework/Drivers/BasisMuscleDriver.cs:171)
Basis.Scripts.Drivers.BaseBoneDriver+OrderedDelegate.Invoke () (at ./Packages/com.basis.framework/Drivers/BaseBoneDriver.cs:360)
Basis.Scripts.Drivers.BaseBoneDriver.ApplyMovement () (at ./Packages/com.basis.framework/Drivers/BaseBoneDriver.cs:58)
Basis.Scripts.Drivers.BaseBoneDriver.SimulateAndApply (System.Single deltaTime) (at ./Packages/com.basis.framework/Drivers/BaseBoneDriver.cs:70)
Basis.Scripts.Drivers.BasisLocalBoneDriver.Simulate () (at ./Packages/com.basis.framework/Drivers/BasisLocalBoneDriver.cs:40)
BasisEventDriver.OnBeforeRender () (at ./Packages/com.basis.framework/BasisEventDriver/BasisEventDriver.cs:56)
UnityEngine.BeforeRenderHelper.Invoke () (at <2431722e3e3e41d78b6718bb39ab9111>:0)
UnityEngine.Application.InvokeOnBeforeRender () (at <2431722e3e3e41d78b6718bb39ab9111>:0)
UnityEngine.GUIUtility:ProcessEvent(Int32, IntPtr, Boolean&)
```

Aside: this code feels somewhat error-prone and repetitious. It specifies *11* times per finger what finger we're dealing with. It might be worth looking into refactoring this in some way, if you need to touch this code again in the future.