### PR TITLE
Fix permission issue when deleting old cache

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -26,6 +26,8 @@ jobs:
     name: Build client for ${{ matrix.targetPlatform }}
     timeout-minutes: 100
     runs-on: ${{ matrix.buildPlatform }}
+    permissions:
+      actions: write # to allow us to manage cache
     env:
       projectPath: Basis
       buildName: Basis Unity
@@ -112,6 +114,7 @@ jobs:
         run: |
           OLD_CACHE_IDS=$(gh cache list --sort created_at --key Library-${{ env.projectPath }}-${{ matrix.targetPlatform }}- --json id --jq '.[1:] | map(.id) | @sh')
           for cache_id in $OLD_CACHE_IDS; do
+            echo "Deleting cache id: $cache_id"
             gh cache delete $cache_id
           done
       - name: "Upload client artifact"


### PR DESCRIPTION
This may require further tweaking, as while performing the test run for this PR, I noticed that github deleted a cache entry *before* the pipeline's cache management kicked in. This didn't cause any issues in this case, since all the jobs had already pulled their cache, but I could envision a case where we end up loosing a platform's cache due to this. We may wish to re-order the steps, so that the old cache is deleted before we upload the new cache.

