### PR TITLE
Disable Vive Tracker OpenXR feature when extension missing

### DIFF
--- a/Basis/Assets/Basis/Profiles/HTCViveTrackerProfile.cs
+++ b/Basis/Assets/Basis/Profiles/HTCViveTrackerProfile.cs
@@ -212,10 +212,12 @@ namespace UnityEngine.XR.OpenXR.Features.Interactions
         {
             var result = base.OnInstanceCreate(xrInstance);
 
-            if (OpenXRRuntime.IsExtensionEnabled("XR_HTCX_vive_tracker_interaction"))
+            if (OpenXRRuntime.IsExtensionEnabled("XR_HTCX_vive_tracker_interaction")) {
                 Debug.Log("Basis HTC Vive Tracker Extension Enabled");
-            else
+            } else {
                 Debug.Log("Basis HTC Vive Tracker Extension Not Enabled");
+                return false;
+            }
 
             return result;
         }


### PR DESCRIPTION
Fixes #288 to the best of my knowledge. I was no longer reproduce any issues on the openvr side of things with either opencomposite or xrizer, and this appears to fix the openxr side of things.