### PR TITLE
Update .gitignore to include Linux DLL imports and Thry Editor exclusions

### DIFF
--- a/Basis/.gitignore
+++ b/Basis/.gitignore
@@ -112,3 +112,9 @@ mono_crash.mem.*.*.blob
 
 /[Aa]ssets/[Pp]lugins/[Yy]outube[Dd][Ll]/
 /[Aa]ssets/[Pp]lugins/[Yy]outube[Dd][Ll].meta
+
+# Linux Special DLL imports
+csc.*
+
+# Thry Editor (Poiyomi)
+Thry


### PR DESCRIPTION
- Ignore csc.rsp file that always generates.
- Ignore the config folder for Thry Editor that ships with Poiyomi and gets generates once user content uses poiymi shaders.