### PR TITLE
Fixed bug with building avatar bundles on Linux.

### DIFF
--- a/Basis/Packages/com.basis.sdk/Scripts/Editor/SDKInspector/BasisBundleBuild.cs
+++ b/Basis/Packages/com.basis.sdk/Scripts/Editor/SDKInspector/BasisBundleBuild.cs
@@ -298,6 +298,9 @@ public static class BasisBundleBuild
     {
         // Get the root path of the project (up to the Assets folder)
         string projectRoot = Application.dataPath.Replace("/Assets", "");
+        if (string.IsNullOrEmpty(relativePath)) {
+            return projectRoot;
+        }
 
         // If the relative path starts with './', remove it
         if (relativePath.StartsWith("./"))

--- a/Basis/Packages/com.basis.sdk/Scripts/Editor/SDKInspector/BasisBundleBuild.cs
+++ b/Basis/Packages/com.basis.sdk/Scripts/Editor/SDKInspector/BasisBundleBuild.cs
@@ -146,6 +146,7 @@ public static class BasisBundleBuild
         }
         catch (Exception ex)
         {
+            Debug.LogException(ex);
             Debug.LogError($"BuildBundle error: {ex.Message}");
             EditorUtility.ClearProgressBar();
             return (false, $"BuildBundle Exception: {ex.Message}");


### PR DESCRIPTION
I did it in a hacky way though, for whatever reason, `PathConversion()` gets passed a null.

According to the POSIX specification, this should always result in a failure. [source](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap04.html)

> A null pathname shall not be successfully resolved.

Instead of figuring out why a null was being passed in, I instead resolve the null path as if it were a "./", which is technically wrong but fixed it for my machine.

The only place PathConversion is used is directly on items generated by the bundle, it's possible the bundle is trying to denotate a "last element" with a null that we are accidentally enumerating. Or something like that. If that' the case this should be safe to merge.