### PR TITLE
Face tracking now networks value with largest delta instead of current value

### DIFF
--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/Components/Actuation/BlendshapeActuation.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/Components/Actuation/BlendshapeActuation.cs
@@ -271,11 +271,15 @@ namespace HVR.Basis.Comms
             {
                 foreach (var target in computedActuator.Targets)
                 {
-                    foreach (var blendshapeIndex in target.BlendshapeIndices)
+                    if (null != target.Renderer && null != target.Renderer.sharedMesh)
                     {
-                        if (null != target.Renderer)
+                        var blendshapeCount = target.Renderer.sharedMesh.blendShapeCount;
+                        foreach (var blendshapeIndex in target.BlendshapeIndices)
                         {
-                            target.Renderer.SetBlendShapeWeight(blendshapeIndex, 0);
+                            if (blendshapeIndex < blendshapeCount)
+                            {
+                                target.Renderer.SetBlendShapeWeight(blendshapeIndex, 0);
+                            }
                         }
                     }
                 }

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/Components/Networking/StreamedAvatarFeature.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/Components/Networking/StreamedAvatarFeature.cs
@@ -8,6 +8,8 @@ namespace HVR.Basis.Comms
     [AddComponentMenu("HVR.Basis/Comms/Internal/Streamed Avatar Feature")]
     public class StreamedAvatarFeature : MonoBehaviour
     {
+        private const bool PrioritizeLargeChanges = true;
+
         private const int HeaderBytes = 3;
         // 1/60 makes for a maximum encoded delta time of 4.25 seconds.
         private const float DeltaLocalIntToSeconds = 1 / 60f;
@@ -51,6 +53,17 @@ namespace HVR.Basis.Comms
         public void Store(int index, float value)
         {
             current[index] = value;
+            if (PrioritizeLargeChanges && isWearer)
+            {
+                // When prioritizing large changes, we want to put an emphasis on values that are further away from the previous value.
+                // We use the "target" array on the sender to store the furthest value,
+                // and the "previous" array on the sender to store the last value we sent for networking.
+                var previousValue = previous[index];
+                if (Mathf.Abs(value - previousValue) > Mathf.Abs(target[index] - previousValue))
+                {
+                    target[index] = value;
+                }
+            }
         }
 
         /// Exposed for testing purposes.
@@ -80,10 +93,18 @@ namespace HVR.Basis.Comms
                 var toSend = new StreamedAvatarFeaturePayload
                 {
                     DeltaTime = _timeLeft,
-                    FloatValues = current // Not copied: Process this message immediately
+                    FloatValues = PrioritizeLargeChanges ? target : current // Not copied: Process this message immediately
                 };
-
                 EncodeAndSubmit(toSend, null);
+                if (PrioritizeLargeChanges)
+                {
+                    // Order matters: Modify target after EncodeAndSubmit() executes.
+                    for (var i = 0; i < current.Length; i++)
+                    {
+                        previous[i] = target[i];
+                        target[i] = current[i];
+                    }
+                }
 
                 _timeLeft = 0;
             }


### PR DESCRIPTION
- Previously, we were networking the current value for face tracking.
- Now, we are networking the value that has the largest delta since the last networked value.
- This should make movements that only lasts a split second more likely to be visible, such as blinking, or briefly looking in a specific direction.

Also contains this fix attempt:
- Try to fix resetting blendshapes was failing on obsolete SkinnedMeshRenderer references.