### PR TITLE
Remove EditorOnly objects from avatar on build and on test

### DIFF
--- a/Basis/Packages/com.basis.sdk/Scripts/Editor/AssetBundleBuilder/BasisAssetBundlePipeline.cs
+++ b/Basis/Packages/com.basis.sdk/Scripts/Editor/AssetBundleBuilder/BasisAssetBundlePipeline.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using UnityEditor;
 using UnityEngine;
@@ -58,6 +59,8 @@ public static class BasisAssetBundlePipeline
             else
             {
                 prefab = Object.Instantiate(asset);
+                DestroyEditorOnlyInAvatar(prefab);
+
                 OnBeforeBuildPrefab?.Invoke(prefab, settings);
                 assetPath = TemporaryStorageHandler.SavePrefabToTemporaryStorage(prefab, settings, ref wasModified, out uniqueID);
 
@@ -111,6 +114,34 @@ public static class BasisAssetBundlePipeline
                 PlayerSettings.SetScriptingBackend(namedBuildTarget, ResetTo);
             }
             return new(false, (null, new AssetBundleBuilder.InformationHash()));
+        }
+    }
+
+    public static void DestroyEditorOnlyInAvatar(GameObject avatar)
+    {
+        // We need to do this instead of iterating on avatar.transform so that we can destroy
+        // the objects that we're currently iterating through.
+        var transforms = Enumerable.Range(0, avatar.transform.childCount)
+            .Select(i => avatar.transform.GetChild(i))
+            .ToList();
+        foreach (Transform t in transforms)
+        {
+            DestroyIfEditorOnlyRecursive(t.gameObject);
+        }
+    }
+
+    private static void DestroyIfEditorOnlyRecursive(GameObject subject)
+    {
+        if (subject.CompareTag("EditorOnly"))
+        {
+            Object.DestroyImmediate(subject);
+        }
+        else
+        {
+            foreach (Transform child in subject.transform)
+            {
+                DestroyIfEditorOnlyRecursive(child.gameObject);
+            }
         }
     }
 }

--- a/Basis/Packages/com.basis.sdk/Scripts/Editor/SDKInspector/BasisAvatarSDKInspector.cs
+++ b/Basis/Packages/com.basis.sdk/Scripts/Editor/SDKInspector/BasisAvatarSDKInspector.cs
@@ -517,9 +517,12 @@ public partial class BasisAvatarSDKInspector : Editor
             ScheduleCallback = false;
         }
         BasisDebug.Log("LoadAvatar Called", BasisDebug.LogTag.Editor);
+        var inSceneItem = GameObject.Instantiate(Avatar.gameObject);
+        BasisAssetBundlePipeline.DestroyEditorOnlyInAvatar(inSceneItem);
+
         BasisLoadableBundle LoadableBundle = new BasisLoadableBundle
         {
-            LoadableGameobject = new BasisLoadableGameobject() { InSceneItem = GameObject.Instantiate(Avatar.gameObject) }
+            LoadableGameobject = new BasisLoadableGameobject() { InSceneItem = inSceneItem }
         };
         LoadableBundle.LoadableGameobject.InSceneItem.transform.parent = null;
         LoadableBundle.BasisRemoteBundleEncrypted = new BasisRemoteEncyptedBundle


### PR DESCRIPTION
- To line up with common avatar workflows, objects tagged EditorOnly will now be removed when building avatars, and also when pressing the Test in Editor button.
- This removal is done post-validation: Due to this, the SDK window will not show accurate information about the validity of the avatar.
- The behaviour when building scenes currently remains unchanged.