### PR TITLE
Linux CI Fixes

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -77,7 +77,10 @@ jobs:
         run: echo "gitversion=$(git describe --tags --always)" >> "$GITHUB_OUTPUT"
       - name: "Remove OpenXR when building for Linux"
         if: matrix.targetPlatform == 'StandaloneLinux64'
-        run: jq 'del(.dependencies ["com.meta.xr.sdk.core", "com.unity.xr.openxr"])' < ${projectPath}/Packages/manifest.json > manifest.json.tmp && mv manifest.json.tmp ${projectPath}/Packages/manifest.json
+        run: jq 'del(.dependencies ["com.unity.xr.openxr"])' < ${projectPath}/Packages/manifest.json > manifest.json.tmp && mv manifest.json.tmp ${projectPath}/Packages/manifest.json
+      - name: "Remove Meta XR Core when building for Linux"
+        if: matrix.targetPlatform == 'StandaloneLinux64'
+        run: rm -rf ${projectPath}/Packages/com.meta.xr.sdk.core
       - name: "Build Unity project"
         timeout-minutes: 100
         uses: kitlith/unity-builder@linux-extension

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -80,7 +80,7 @@ jobs:
         run: jq 'del(.dependencies ["com.meta.xr.sdk.core", "com.unity.xr.openxr"])' < ${projectPath}/Packages/manifest.json > manifest.json.tmp && mv manifest.json.tmp ${projectPath}/Packages/manifest.json
       - name: "Build Unity project"
         timeout-minutes: 100
-        uses: game-ci/unity-builder@v4
+        uses: kitlith/unity-builder@linux-extension
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
@@ -100,6 +100,7 @@ jobs:
           androidKeystorePass: ${{ secrets.ANDROID_KEYSTORE_PASS }}
           androidKeyaliasName: ${{ secrets.ANDROID_KEYALIAS_NAME }}
           androidKeyaliasPass: ${{ secrets.ANDROID_KEYALIAS_PASS }}
+          linux64RemoveExecutableExtension: false
       - name: "Save Library Cache"
         uses: actions/cache/save@v3
         if: always() && github.ref_name == 'developer'


### PR DESCRIPTION
Two separate fixes in two commits.

First commit is <https://github.com/game-ci/unity-builder/pull/726>, which fixes a file not getting included with the final linux build. 

Second commit fixes the fact that linux CI has been proken for the past two weeks, after the meta sdk got inlined into the repository.