### PR TITLE
Run NDMF on Test builds and integrate NDMF cross-application builds

### DIFF
--- a/Basis/Packages/HVRBasisNDMF/Scripts/Editor/BasisFrameworkPlatform.cs
+++ b/Basis/Packages/HVRBasisNDMF/Scripts/Editor/BasisFrameworkPlatform.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Linq;
+using Basis.Scripts.BasisSdk;
+using nadena.dev.ndmf.platform;
+using UnityEditor;
+using UnityEngine;
+
+namespace HVR.Basis.NDMF
+{
+    /// The class is called BasisFrameworkPlatform to follow NDMF's naming convention (INDMFPlatformProvider). Yes, we know Basis is not a platform.
+    [NDMFPlatformProvider]
+    public class BasisFrameworkPlatform : INDMFPlatformProvider
+    {
+        public static readonly INDMFPlatformProvider Instance = new BasisFrameworkPlatform();
+
+        private static readonly string[] OurVisemesIndexedByMovement = {
+            CommonAvatarInfo.Viseme_Silence, CommonAvatarInfo.Viseme_PP, CommonAvatarInfo.Viseme_FF, CommonAvatarInfo.Viseme_TH,
+            CommonAvatarInfo.Viseme_DD, CommonAvatarInfo.Viseme_kk, CommonAvatarInfo.Viseme_CH, CommonAvatarInfo.Viseme_SS,
+            CommonAvatarInfo.Viseme_nn, CommonAvatarInfo.Viseme_RR, CommonAvatarInfo.Viseme_aa, CommonAvatarInfo.Viseme_E,
+            CommonAvatarInfo.Viseme_ih, CommonAvatarInfo.Viseme_oh, CommonAvatarInfo.Viseme_ou
+        };
+
+        public string QualifiedName => "org.basisvr.basis-framework";
+        public string DisplayName => "Basis Framework";
+        public Texture2D? Icon => null;
+        public Type AvatarRootComponentType => typeof(BasisAvatar);
+        public bool HasNativeConfigData => true;
+
+        public BuildUIElement? CreateBuildUI()
+        {
+            return new BasisFrameworkBuildUI();
+        }
+
+        public CommonAvatarInfo ExtractCommonAvatarInfo(GameObject avatarRoot)
+        {
+            var basisAvatar = avatarRoot.GetComponent<BasisAvatar>();
+
+            var cai = new CommonAvatarInfo();
+            // The following is based on nadena.dev.ndmf.vrchat.VRChatPlatform
+            cai.EyePosition = avatarRoot.transform.InverseTransformVector(new Vector3(0, basisAvatar.AvatarEyePosition.x, basisAvatar.AvatarEyePosition.y));
+            if (basisAvatar.FaceVisemeMesh != null && basisAvatar.FaceVisemeMesh.sharedMesh != null)
+            {
+                cai.VisemeRenderer = basisAvatar.FaceVisemeMesh;
+
+                var sharedMesh = basisAvatar.FaceVisemeMesh.sharedMesh;
+                for (var movement = 0; movement < OurVisemesIndexedByMovement.Length; movement++)
+                {
+                    var ourViseme = OurVisemesIndexedByMovement[movement];
+                    if (TryGet(sharedMesh, basisAvatar.FaceVisemeMovement[movement], out var blendShape)) cai.VisemeBlendshapes[ourViseme] = blendShape;
+                }
+            }
+
+            return cai;
+        }
+
+        public void InitFromCommonAvatarInfo(GameObject avatarRoot, CommonAvatarInfo cai)
+        {
+            if (!avatarRoot.TryGetComponent<BasisAvatar>(out var basisAvatar))
+            {
+                basisAvatar = avatarRoot.AddComponent<BasisAvatar>();
+                // The following is based on nadena.dev.ndmf.vrchat.VRChatPlatform:
+                // Initialize array SerializeFields with empty array instances
+                EditorUtility.CopySerialized(basisAvatar, basisAvatar);
+            }
+
+            if (cai.EyePosition != null)
+            {
+                var transformVector = avatarRoot.transform.TransformVector(cai.EyePosition.Value);
+                basisAvatar.AvatarEyePosition = new Vector2(transformVector.y, transformVector.z);
+            }
+
+            if (cai.VisemeRenderer != null && cai.VisemeRenderer.sharedMesh != null)
+            {
+                basisAvatar.FaceVisemeMesh = cai.VisemeRenderer;
+
+                var sharedMesh = cai.VisemeRenderer.sharedMesh;
+                var blendShapeNames = Enumerable.Range(0, basisAvatar.FaceVisemeMesh.sharedMesh.blendShapeCount)
+                    .Select(i => sharedMesh.GetBlendShapeName(i))
+                    .ToList();
+                for (var visemeMovementIndex = 0; visemeMovementIndex < OurVisemesIndexedByMovement.Length; visemeMovementIndex++)
+                {
+                    var caiViseme = OurVisemesIndexedByMovement[visemeMovementIndex];
+                    if (cai.VisemeBlendshapes.TryGetValue(caiViseme, out var caiBlendShapeName))
+                    {
+                        var blendShapeIndex = blendShapeNames.IndexOf(caiBlendShapeName);
+                        if (blendShapeIndex >= 0)
+                        {
+                            basisAvatar.FaceVisemeMovement[visemeMovementIndex] = blendShapeIndex;
+                        }
+                    }
+                }
+            }
+        }
+
+        public bool CanInitFromCommonAvatarInfo(GameObject avatarRoot, CommonAvatarInfo info)
+        {
+            return true;
+        }
+
+        private bool TryGet(Mesh mesh, int blendShapeIndex, out string name)
+        {
+            if (blendShapeIndex < 0 || blendShapeIndex >= mesh.blendShapeCount)
+            {
+                name = null;
+                return false;
+            }
+
+            name = mesh.GetBlendShapeName(blendShapeIndex);
+            return true;
+        }
+    }
+
+    public class BasisFrameworkBuildUI : BuildUIElement
+    {
+    }
+}

--- a/Basis/Packages/HVRBasisNDMF/Scripts/Editor/BasisFrameworkPlatform.cs.meta
+++ b/Basis/Packages/HVRBasisNDMF/Scripts/Editor/BasisFrameworkPlatform.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c4c30975ff464f64aaaadbee5e804b46
+timeCreated: 1759213720

--- a/Basis/Packages/HVRBasisNDMF/Scripts/Editor/BasisNDMFBuildHook.cs
+++ b/Basis/Packages/HVRBasisNDMF/Scripts/Editor/BasisNDMFBuildHook.cs
@@ -10,15 +10,13 @@ namespace HVR.Basis.NDMF
     {
         static BasisNDMFBuildHook()
         {
-            BasisAssetBundlePipeline.OnBeforeBuildPrefab += (prefab, _) =>
-            {
-                BasisAvatarPrefabProcessor(prefab);
-            };
+            BasisAssetBundlePipeline.OnBeforeBuildPrefab += (prefab, _) => BasisAvatarPrefabProcessor(prefab);
+            BasisAvatarSDKInspector.OnBeforeTestInEditor += prefab => BasisAvatarPrefabProcessor(prefab);
         }
 
         private static GameObject BasisAvatarPrefabProcessor(GameObject copy)
         {
-            AvatarProcessor.ProcessAvatar(copy);
+            AvatarProcessor.ProcessAvatar(copy, BasisFrameworkPlatform.Instance);
             return copy;
         }
     }

--- a/Basis/Packages/HVRBasisNDMF/Scripts/Editor/BasisNDMFPlatformInitPlugin.cs
+++ b/Basis/Packages/HVRBasisNDMF/Scripts/Editor/BasisNDMFPlatformInitPlugin.cs
@@ -1,0 +1,18 @@
+﻿using HVR.Basis.NDMF;
+using nadena.dev.ndmf;
+
+[assembly: ExportsPlugin(typeof(BasisNDMFPlatformInitPlugin))]
+namespace HVR.Basis.NDMF
+{
+    [RunsOnPlatforms("org.basisvr.basis-framework")]
+    public class BasisNDMFPlatformInitPlugin : Plugin<BasisNDMFPlatformInitPlugin>
+    {
+        protected override void Configure()
+        {
+            InPhase(BuildPhase.PlatformInit).Run("Log", _ =>
+            {
+                BasisDebug.Log("Executing NDMF for the Basis Framework", BasisDebug.LogTag.Avatar);
+            });
+        }
+    }
+}

--- a/Basis/Packages/HVRBasisNDMF/Scripts/Editor/BasisNDMFPlatformInitPlugin.cs.meta
+++ b/Basis/Packages/HVRBasisNDMF/Scripts/Editor/BasisNDMFPlatformInitPlugin.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: dbd3c1d7550a41ddb563e8cb6cf8f7aa
+timeCreated: 1759214028

--- a/Basis/Packages/HVRBasisNDMF/Scripts/HVR.Basis.NDMF.asmdef
+++ b/Basis/Packages/HVRBasisNDMF/Scripts/HVR.Basis.NDMF.asmdef
@@ -3,6 +3,7 @@
     "rootNamespace": "",
     "references": [
         "nadena.dev.ndmf",
+        "BasisSDK",
         "BasisSDKEditor",
         "BasisDebug"
     ],

--- a/Basis/Packages/com.basis.sdk/Scripts/Editor/SDKInspector/BasisAvatarSDKInspector.cs
+++ b/Basis/Packages/com.basis.sdk/Scripts/Editor/SDKInspector/BasisAvatarSDKInspector.cs
@@ -15,6 +15,9 @@ using Basis.Scripts.BasisSdk.Players;
 [CustomEditor(typeof(BasisAvatar))]
 public partial class BasisAvatarSDKInspector : Editor
 {
+    public delegate void BeforeTestInEditorHandler(GameObject clone);
+    public static BeforeTestInEditorHandler OnBeforeTestInEditor;
+
     public static event Action<BasisAvatarSDKInspector> InspectorGuiCreated;
     public static event Action ButtonClicked;
     public static event Action ValueChanged;
@@ -519,6 +522,7 @@ public partial class BasisAvatarSDKInspector : Editor
         BasisDebug.Log("LoadAvatar Called", BasisDebug.LogTag.Editor);
         var inSceneItem = GameObject.Instantiate(Avatar.gameObject);
         BasisAssetBundlePipeline.DestroyEditorOnlyInAvatar(inSceneItem);
+        OnBeforeTestInEditor?.Invoke(inSceneItem);
 
         BasisLoadableBundle LoadableBundle = new BasisLoadableBundle
         {


### PR DESCRIPTION
- Pressing the "Test In Editor" button will now run non-destructive avatar tools, after all EditorOnly objects have been removed from the object.
- Integrate with NDMF's newly introduced platform-specific builds, by adding "org.basisvr.basis-framework" as the qualified name for Basis Framework avatars.
  - The class is called BasisFrameworkPlatform to follow NDMF's naming convention (INDMFPlatformProvider). Yes, we know Basis is not a platform.
- Avatars built on Basis will now only run NDMF plugins that are compatible with the Basis Framework.
- Implement NDMF's CommonAvatarInfo structure and NativeConfigData, so that "Modular Avatar for Resonite" may be used on Basis Framework avatars.

Note: This PR has the side effect of affecting the behavior of NDMF when entering Play Mode: it may automatically process the avatar when entering Play Mode; Disabling this through *Tools > NDM Framework > Apply on Play* should revert that behavior, see https://github.com/bdunderscore/ndmf/issues/697#issuecomment-3350704430