### PR TITLE
Save and restore relative transform when entering and exiting seats

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,9 +3,9 @@
   "isRoot": true,
   "tools": {
     "csharpier": {
-      "version": "0.30.3",
+      "version": "1.2.1",
       "commands": [
-        "dotnet-csharpier"
+        "csharpier"
       ],
       "rollForward": false
     }

--- a/Basis/Assets/MetaXR.meta
+++ b/Basis/Assets/MetaXR.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8f28c16048c8fe247a2191b81aa37c05
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Basis/Assets/MetaXR/MetaXRProjectSettings.asset
+++ b/Basis/Assets/MetaXR/MetaXRProjectSettings.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0bfde92e0a2190c4ca32f6fb0a0c73ce, type: 3}
+  m_Name: MetaXRProjectSettings
+  m_EditorClassIdentifier: Meta.XR.Editor.Settings::Meta.XR.Editor.Settings.ProjectSettings
+  boolProperties:
+    keys:
+    - Meta.XR.SDK.UsageSettings.UsesProjectSetupTool
+    values: 01
+  intProperties:
+    keys: []
+    values: 

--- a/Basis/Assets/MetaXR/MetaXRProjectSettings.asset.meta
+++ b/Basis/Assets/MetaXR/MetaXRProjectSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7aa9bbb5ade14984cb045d3abe5d8b92
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Basis/Basis.slnx
+++ b/Basis/Basis.slnx
@@ -20,6 +20,7 @@
   <Project Path="SteamAudioUnity.csproj" />
   <Project Path="UnityEngine.TestRunner.csproj" />
   <Project Path="Oculus.VR.csproj" />
+  <Project Path="Unity.XR.OpenXR.csproj" />
   <Project Path="Unity.Burst.csproj" />
   <Project Path="Unity.Services.Core.Environments.Editor.csproj" />
   <Project Path="Oculus.VR.Editor.csproj" />
@@ -35,7 +36,6 @@
   <Project Path="PPv2URPConverters.csproj" />
   <Project Path="Meta.XR.ImmersiveDebugger.csproj" />
   <Project Path="SteamVR.csproj" />
-  <Project Path="Unity.XR.OpenXR.csproj" />
   <Project Path="com.gator-dragon-games.jigglephysics.editor.csproj" />
   <Project Path="Unity.XR.CoreUtils.csproj" />
   <Project Path="Unity.Searcher.Editor.csproj" />
@@ -112,6 +112,7 @@
   <Project Path="Unity.ShaderGraph.Utilities.csproj" />
   <Project Path="Unity.Toolchain.Macos-arm64-Linux-x86_64.csproj" />
   <Project Path="BasisPoolTable.csproj" />
+  <Project Path="Cilbox.csproj" />
   <Project Path="BasisSeatExamples.csproj" />
   <Project Path="AudioLink.Editor.csproj" />
   <Project Path="Unity.Profiling.Core.csproj" />
@@ -160,6 +161,7 @@
   <Project Path="BasisEventDriver.csproj" />
   <Project Path="Meta.XR.Editor.Guide.About.csproj" />
   <Project Path="BasisSDKMIrrorEditor.csproj" />
+  <Project Path="Unity.XR.OpenXR.TestTooling.csproj" />
   <Project Path="Unity.XR.OpenXR.Features.ConformanceAutomation.csproj" />
   <Project Path="Unity.XR.Hands.Analytics.Hooks.Editor.csproj" />
   <Project Path="Unity.ScriptableBuildPipeline.csproj" />

--- a/Basis/Packages/com.basis.framework.editor/Editor/BasisMenuItemsEditor.cs
+++ b/Basis/Packages/com.basis.framework.editor/Editor/BasisMenuItemsEditor.cs
@@ -259,7 +259,7 @@ public static class BasisMenuItemsEditor
         BasisAvatarEyeInput basisAvatarEyeInput = GameObject.FindFirstObjectByType<BasisAvatarEyeInput>();
         if (basisAvatarEyeInput != null)
         {
-            basisAvatarEyeInput.rotationX = UnityEngine.Random.Range(-360, 360);
+            basisAvatarEyeInput.rotationYaw = UnityEngine.Random.Range(-360, 360);
         }
         BasisLocalPlayer.Instance.StartCoroutine(WaitAndCreatePuck3Tracker());
     }

--- a/Basis/Packages/com.basis.framework/Device Management/Devices/Desktop/BasisAvatarEyeInput.cs
+++ b/Basis/Packages/com.basis.framework/Device Management/Devices/Desktop/BasisAvatarEyeInput.cs
@@ -9,7 +9,7 @@ using UnityEngine.InputSystem;
 namespace Basis.Scripts.Device_Management.Devices.Desktop
 {
     /// <summary>
-    /// Provides simulated eye-tracking input for desktop mode.  
+    /// Provides simulated eye-tracking input for desktop mode.
     /// Handles look rotation via mouse input, device initialization, and integration with avatar drivers.
     /// </summary>
     public class BasisAvatarEyeInput : BasisInput
@@ -38,22 +38,22 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
         /// <summary>
         /// Current pitch rotation (X axis).
         /// </summary>
-        public float rotationY;
+        public float rotationPitch;
 
         /// <summary>
         /// Current yaw rotation (Y axis).
         /// </summary>
-        public float rotationX;
+        public float rotationYaw;
 
         /// <summary>
         /// Minimum clamped pitch angle.
         /// </summary>
-        public float minimumY = -89f;
+        public float minimumPitch = -89f;
 
         /// <summary>
         /// Maximum clamped pitch angle.
         /// </summary>
-        public float maximumY = 80;
+        public float maximumPitch = 80;
 
         [Header("Mouse/Look")]
         /// <summary>
@@ -85,7 +85,7 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
         public float Z;
 
         /// <summary>
-        /// Initializes the eye input system for desktop usage.  
+        /// Initializes the eye input system for desktop usage.
         /// Sets device coordinates, hooks into player events, and prepares tracking roles.
         /// </summary>
         /// <param name="ID">Identifier for this input device (default "Desktop Eye").</param>
@@ -130,7 +130,7 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
         }
 
         /// <summary>
-        /// Handles updates when the cursor state changes (locked or free).  
+        /// Handles updates when the cursor state changes (locked or free).
         /// Adjusts <see cref="LookRotationLock"/> accordingly.
         /// </summary>
         private void OnCursorStateChange(CursorLockMode cursor, bool newCursorVisible)
@@ -162,7 +162,7 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
         }
 
         /// <summary>
-        /// Re-initializes player-specific references (camera, avatar driver, and input bindings).  
+        /// Re-initializes player-specific references (camera, avatar driver, and input bindings).
         /// Called on local avatar change.
         /// </summary>
         public void PlayerInitialized()
@@ -188,7 +188,7 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
         }
 
         /// <summary>
-        /// Updates the look rotation input vector.  
+        /// Updates the look rotation input vector.
         /// Called externally by input actions.
         /// </summary>
         /// <param name="delta">Mouse or input delta vector.</param>
@@ -198,7 +198,7 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
         }
 
         /// <summary>
-        /// Applies yaw/pitch rotation based on the given input vector.  
+        /// Applies yaw/pitch rotation based on the given input vector.
         /// Handles mouse-look simulation for the eye.
         /// </summary>
         /// <param name="lookVector">Delta vsector from input system.</param>
@@ -209,11 +209,11 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
                 return;
             }
 
-            rotationX += lookVector.x * rotationSpeed; // yaw
-            rotationY -= lookVector.y * rotationSpeed; // pitch (invert Y)
+            rotationYaw += lookVector.x * rotationSpeed; // yaw
+            rotationPitch -= lookVector.y * rotationSpeed; // pitch (invert Y)
         }
         /// <summary>
-        /// Main polling loop for updating eye input state.  
+        /// Main polling loop for updating eye input state.
         /// Calculates eye position/rotation based on avatar head, crouching, and inputs deltas.
         /// </summary>
         public override void DoPollData()
@@ -244,9 +244,9 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
             Vector3 neutralEyeFromHead = tposeEyeWorld - tposeHeadWorld;
 
             // Apply yaw/pitch with clamping
-            rotationX = Mathf.Repeat(rotationX, 360f);
-            rotationY = Mathf.Clamp(rotationY, minimumY, maximumY);
-            Quaternion targetRot = Quaternion.Euler(rotationY, rotationX, 0);
+            rotationYaw = Mathf.Repeat(rotationYaw, 360f);
+            rotationPitch = Mathf.Clamp(rotationPitch, minimumPitch, maximumPitch);
+            Quaternion targetRot = Quaternion.Euler(rotationPitch, rotationYaw, 0);
 
             // Handle crouching adjustment
             if (!CrouchingLock)
@@ -276,7 +276,7 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
         }
 
         /// <summary>
-        /// Displays a visual tracker for the device if supported by the matched device definition.  
+        /// Displays a visual tracker for the device if supported by the matched device definition.
         /// Falls back to a generic model if needed.
         /// </summary>
         public override void ShowTrackedVisual()
@@ -299,7 +299,7 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
         }
 
         /// <summary>
-        /// Plays a haptic effect.  
+        /// Plays a haptic effect.
         /// Not implemented for desktop eye input.
         /// </summary>
         public override void PlayHaptic(float duration = 0.25F, float amplitude = 0.5F, float frequency = 0.5F)
@@ -307,7 +307,7 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
         }
 
         /// <summary>
-        /// Plays a sound effect for the input device.  
+        /// Plays a sound effect for the input device.
         /// Uses the default implementation.
         /// </summary>
         /// <param name="SoundEffectName">The sound effect key or name.</param>

--- a/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalSeatDriver.cs
+++ b/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalSeatDriver.cs
@@ -1,6 +1,8 @@
 using Basis.Scripts.BasisSdk.Interactions;
 using Basis.Scripts.BasisSdk.Players;
+using Basis.Scripts.Device_Management.Devices.Desktop;
 using UnityEngine;
+
 namespace Basis.Scripts.Drivers
 {
     /// <summary>
@@ -15,7 +17,6 @@ namespace Basis.Scripts.Drivers
 
         private BasisSeat _seat;
         public bool IsSeated { get { return _seat != null; } }
-        public bool hasEvent = false;
         /// <summary>
         /// Initialize the driver with the owning local player.
         /// </summary>
@@ -25,6 +26,8 @@ namespace Basis.Scripts.Drivers
             // but passing it in directly makes this class more self-contained.
             LocalPlayer = localPlayer;
         }
+
+        // Player-specific pose values calculated when the player sits in a seat.
         private Vector3 leftLowerLegOffset;
         private Vector3 rightLowerLegOffset;
         private Vector3 leftUpperLegOffset;
@@ -40,6 +43,13 @@ namespace Basis.Scripts.Drivers
         private float lowerLegFootRadius;
         private float upperLegAngleVsSeatRadians;
         private float lowerLegAngleVsSeatRadians;
+
+        // Player-specific non-pose values to keep track of state during seating.
+        private Vector3 previousRelativePosition = Vector3.zero;
+        private float previousHeadPitchGlobal = 0.0f;
+        private float previousHeadYawVsSeat = 0.0f;
+        private bool hasEvent = false;
+
         private void GrabLatestTposeLocalScaleData()
         {
             leftLowerLegOffset = BasisLocalBoneDriver.LeftFootControl.TposeLocalScaled.position - BasisLocalBoneDriver.LeftLowerLegControl.TposeLocalScaled.position;
@@ -79,6 +89,9 @@ namespace Basis.Scripts.Drivers
                 Stand();
             }
             _seat = seat;
+            previousRelativePosition = _seat.transform.InverseTransformPoint(LocalPlayer.transform.position);
+            previousHeadPitchGlobal = BasisAvatarEyeInput.Instance.rotationPitch;
+            previousHeadYawVsSeat = BasisAvatarEyeInput.Instance.rotationYaw - (_seat.transform.rotation * _seat.SpineRotation).eulerAngles.y;
             // Disable character movement and add a movement lock so other systems respect being seated.
             BasisLocalVirtualSpineDriver.HipsFreezeToTpose = true;
             LocalPlayer.LocalCharacterDriver.IsEnabled = false;
@@ -86,6 +99,8 @@ namespace Basis.Scripts.Drivers
             LocalPlayer.LocalCharacterDriver.CrouchingLock.Add(nameof(BasisLocalSeatDriver));
             LocalPlayer.LocalAnimatorDriver.StopAllVariables();
             LocalPlayer.LocalAnimatorDriver.PauseAnimator = true;
+            // Set the player's relative yaw to zero to face forward on the seat, but don't do the same for pitch.
+            BasisAvatarEyeInput.Instance.rotationYaw = 0.0f;
             _setAllOverrideUsages(true);
             LocalPlayer.OnPreSimulateBones += OnSimulate;
             GrabLatestTposeLocalScaleData();
@@ -115,7 +130,9 @@ namespace Basis.Scripts.Drivers
             LocalPlayer.LocalCharacterDriver.CrouchingLock.Remove(nameof(BasisLocalSeatDriver));
             LocalPlayer.LocalCharacterDriver.IsEnabled = true;
             _setAllOverrideUsages(false);
-            LocalPlayer.transform.rotation = Quaternion.identity;
+            BasisAvatarEyeInput.Instance.rotationPitch = previousHeadPitchGlobal;
+            BasisAvatarEyeInput.Instance.rotationYaw = previousHeadYawVsSeat + (_seat.transform.rotation * _seat.SpineRotation).eulerAngles.y;
+            LocalPlayer.transform.SetPositionAndRotation(_seat.transform.TransformPoint(previousRelativePosition), Quaternion.identity);
             LocalPlayer.AvatarTransform.rotation = Quaternion.identity;
             LocalPlayer.LocalAnimatorDriver.HandleTeleport();
             GrabLatestTposeLocalScaleData();
@@ -241,8 +258,9 @@ namespace Basis.Scripts.Drivers
                 desiredRightUpperLegRot,
                 desiredLeftLowerLegRot,
                 desiredRightLowerLegRot
-        );
+            );
         }
+
         private void _applyLocalLegPose(
             Vector3 pelvisPos,
             Quaternion leftUpperLegRot,
@@ -285,7 +303,6 @@ namespace Basis.Scripts.Drivers
                 BasisLocalBoneDriver.RightLowerLegControl.TposeLocalScaled.position,
                 hipsWorldRot * rightLowerLegRot);
         }
-
 
         private void _setAllOverrideUsages(bool enabled)
         {


### PR DESCRIPTION
This PR updates the code to save restore the relative transform when entering and existing seats. The position part will affect both VR and desktop, while the rotation part only affects desktop.

I also renamed `rotationX` to `rotationYaw` and `rotationY` to `rotationPitch` because... c'mon Dooly, you can't do this to me:

<img width="663" height="451" alt="Screenshot 2025-11-19 081209" src="https://github.com/user-attachments/assets/30377dcd-c079-47ab-8709-c3e6610b2bc9" />

<img width="1373" height="287" alt="Screenshot 2025-11-19 074514" src="https://github.com/user-attachments/assets/4026487f-b0b1-459f-8148-0a4dc1217f14" />

