### PR TITLE
Syncing differences between Basis Server copies

### DIFF
--- a/Basis/Packages/com.basis.server/BasisNetworkClientConsole/BasisNetworkClientConsole/MovementSender.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkClientConsole/BasisNetworkClientConsole/MovementSender.cs
@@ -3,8 +3,6 @@ using Basis.Scripts.Networking.Compression;
 using BasisNetworkClientConsole;
 using LiteNetLib;
 using LiteNetLib.Utils;
-using System;
-using System.Reflection;
 using static BasisNetworkPrimitiveCompression;
 using static SerializableBasis;
 
@@ -66,7 +64,7 @@ namespace Basis.Network
             WriteQuaternionToBytes(Rotation, ref message.array, ref offset, RotationCompression);//14
 
             // Scale (2 bytes) at the end
-            int scaleOffset = 171;
+            int scaleOffset = LocalAvatarSyncMessage.AvatarSyncSize-2;
             WriteUShort(CompressedScale, ref message.array, ref scaleOffset);//2
             pd.Message = message;
             return pd;

--- a/Basis/Packages/com.basis.server/BasisNetworkCore/Serializable/VoiceReceiversMessage.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkCore/Serializable/VoiceReceiversMessage.cs
@@ -3,34 +3,31 @@ public static partial class SerializableBasis
 {
     public struct VoiceReceiversMessage
     {
-        public ushort[] users;
-        public void Deserialize(NetDataReader Writer)
-        {
-            // Calculate the number of ushorts based on the remaining bytes
-            int remainingBytes = Writer.AvailableBytes;
-            int ushortCount = remainingBytes / sizeof(ushort);
+        public ushort[] Users;
 
-            // Initialize the array with the calculated size
-            if (users == null || users.Length != ushortCount)
+        public void Deserialize(NetDataReader reader)
+        {
+            int remainingBytes = reader.AvailableBytes;
+
+            // Optional sanity check: ensure whole ushorts
+            if ((remainingBytes & (sizeof(ushort) - 1)) != 0)
             {
-                users = new ushort[ushortCount];
+                BNL.LogError($"VoiceReceiversMessage: remaining bytes ({remainingBytes}) " +
+                     "not a multiple of sizeof(ushort).");
             }
-            // Read each ushort value into the array
-            for (int index = 0; index < ushortCount; index++)
+            else
             {
-                users[index] = Writer.GetUShort();
+                Users = reader.GetUShortArray();
             }
         }
-        public void Serialize(NetDataWriter Writer)
+
+        public void Serialize(NetDataWriter writer)
         {
-            if (users != null)
+            if (Users == null || Users.Length == 0)
             {
-                int Count = users.Length;
-                for (int Index = 0; Index < Count; Index++)
-                {
-                    Writer.Put(users[Index]);
-                }
+                return;
             }
+            writer.PutArray(Users);
         }
     }
 }

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/Auth/Interface.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/Auth/Interface.cs
@@ -16,12 +16,12 @@ namespace Basis.Network.Server.Auth
         /// the UUID of a player will become this.
         public void ProcessConnection(Configuration Configuration, ConnectionRequest ConnectionRequest, NetPeer NetPeer);
         public void DeInitalize();
-        public void RemoveConnection(ushort NetPeer);
+        public void RemoveConnection(int NetPeer);
         public bool IsNetPeerAdmin(string UUID);
         public bool AddNetPeerAsAdmin(string UUID);
         public bool RemoveNetPeerAsAdmin(string UUID);
         public bool NetIDToUUID(NetPeer Peer, out string UUID);
-        public bool UUIDToNetID(string UUID, out ushort Peer);
+        public bool UUIDToNetID(string UUID, out int Peer);
 
         public static bool HasFileSupport = false;
     }

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/BasisNetworking/BasisNetworkOwnership.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/BasisNetworking/BasisNetworkOwnership.cs
@@ -238,7 +238,7 @@ namespace Basis.Network.Server.Ownership
         /// <summary>
         /// Removes all ownership of a specific player and notifies all clients.
         /// </summary>
-        public static void RemovePlayerOwnership(ushort playerId)
+        public static void RemovePlayerOwnership(int playerId)
         {
             lock (LockObject)
             {

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/BasisNetworking/BasisSavedState.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/BasisNetworking/BasisSavedState.cs
@@ -39,6 +39,7 @@ namespace Basis.Network.Server.Generic
         public static void AddLastData(NetPeer client, VoiceReceiversMessage voiceReceiversMessage)
         {
             voiceReceiversMessages[client.Id] = voiceReceiversMessage;
+
         }
 
         /// <summary>
@@ -54,7 +55,7 @@ namespace Basis.Network.Server.Generic
         /// </summary>
         public static bool GetLastAvatarChangeState(NetPeer client, out ClientAvatarChangeMessage message)
         {
-            return avatarChangeStates.TryGetValue(client.Id, out message) && !message.Equals(default);
+            return avatarChangeStates.TryGetValue(client.Id, out message);
         }
 
         /// <summary>
@@ -62,7 +63,7 @@ namespace Basis.Network.Server.Generic
         /// </summary>
         public static bool GetLastPlayerMetaData(NetPeer client, out ClientMetaDataMessage message)
         {
-            return playerMetaDataMessages.TryGetValue(client.Id, out message) && !message.Equals(default);
+            return playerMetaDataMessages.TryGetValue(client.Id, out message);
         }
 
         /// <summary>
@@ -70,7 +71,7 @@ namespace Basis.Network.Server.Generic
         /// </summary>
         public static bool GetLastVoiceReceivers(NetPeer client, out VoiceReceiversMessage message)
         {
-            return voiceReceiversMessages.TryGetValue(client.Id, out message) && !message.Equals(default);
+            return voiceReceiversMessages.TryGetValue(client.Id, out message);
         }
     }
 }

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/BasisServerHandleEvents.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/BasisServerHandleEvents.cs
@@ -1,4 +1,3 @@
-using Basis.Contrib.Auth.DecentralizedIds;
 using Basis.Network.Core;
 using Basis.Network.Server.Generic;
 using Basis.Network.Server.Ownership;
@@ -64,7 +63,7 @@ namespace BasisServerHandle
                     BNL.LogError("Missing Peer this is a mistake!");
                     return;
                 }
-                ushort id = (ushort)peer.Id;
+                int id = peer.Id;
 
                 NetworkServer.AuthIdentity.RemoveConnection(id);
                 BasisNetworkOwnership.RemovePlayerOwnership(id);
@@ -304,13 +303,18 @@ namespace BasisServerHandle
 
         public static void SendVoiceMessageToClients(ServerAudioSegmentMessage audioSegment, byte channel, NetPeer sender, DeliveryMethod method)
         {
-            if (!BasisSavedState.GetLastVoiceReceivers(sender, out VoiceReceiversMessage receivers) || receivers.users == null || receivers.users.Length == 0)
+            if(BasisSavedState.GetLastVoiceReceivers(sender, out VoiceReceiversMessage receivers))
             {
                 BNL.Log($"[VoiceMessage] No receivers found for sender {sender.Id}.");
+            }
+
+            if (receivers.Users == null || receivers.Users.Length == 0)
+            {
+                BNL.Log($"[VoiceMessage] No users found for {sender.Id}.");
                 return;
             }
 
-            var targetPeers = GetTargetPeers(receivers.users);
+            var targetPeers = GetTargetPeers(receivers);
             if (targetPeers.Count == 0)
             {
                 BNL.Log($"[VoiceMessage] No valid peer matches found for sender {sender.Id}.");
@@ -329,12 +333,12 @@ namespace BasisServerHandle
             NetworkServer.BroadcastMessageToClients(writer, channel, ref targetPeers, method);
         }
 
-        private static List<NetPeer> GetTargetPeers(ushort[] userIds)
+        private static List<NetPeer> GetTargetPeers(VoiceReceiversMessage Message)
         {
-            var peers = new List<NetPeer>(userIds.Length);
-            foreach (var userId in userIds)
+            List<NetPeer> peers = new List<NetPeer>(Message.Users.Length);
+            foreach (ushort userId in Message.Users)
             {
-                if (NetworkServer.AuthenticatedPeers.TryGetValue(userId, out var found))
+                if (NetworkServer.AuthenticatedPeers.TryGetValue(userId, out NetPeer found))
                 {
                     peers.Add(found);
                 }

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/NetworkServer.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/NetworkServer.cs
@@ -16,7 +16,7 @@ public static class NetworkServer
 {
     public static EventBasedNetListener Listener;
     public static NetManager Server;
-    public static ConcurrentDictionary<ushort, NetPeer> AuthenticatedPeers = new();
+    public static ConcurrentDictionary<int, NetPeer> AuthenticatedPeers = new();
     public static Configuration Configuration;
     public static IAuth Auth;
     public static IAuthIdentity AuthIdentity;

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/Security/BasisDIDAuthIdentity.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/Security/BasisDIDAuthIdentity.cs
@@ -26,7 +26,7 @@ namespace BasisDidLink
     public class BasisDIDAuthIdentity : IAuthIdentity
     {
         internal readonly DidAuthentication DidAuth;
-        public ConcurrentDictionary<ushort, OnAuth> AuthIdentity = new ConcurrentDictionary<ushort, OnAuth>();
+        public ConcurrentDictionary<int, OnAuth> AuthIdentity = new ConcurrentDictionary<int, OnAuth>();
         private readonly ConcurrentDictionary<NetPeer, CancellationTokenSource> _timeouts = new ConcurrentDictionary<NetPeer, CancellationTokenSource>();
         public List<string> Admins = new List<string>();
         public static readonly string FilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, Configuration.ConfigFolderName, "admins.xml");
@@ -111,7 +111,7 @@ namespace BasisDidLink
                         ReadyMessage = readyMessage
                     };
 
-                    if (AuthIdentity.TryAdd((ushort)newPeer.Id, OnAuth))
+                    if (AuthIdentity.TryAdd(newPeer.Id, OnAuth))
                     {
                         readyMessage.playerMetaDataMessage.playerUUID = playerDid.V;
                         NetDataWriter Writer = new NetDataWriter();
@@ -150,7 +150,7 @@ namespace BasisDidLink
             {
                 await Task.Delay(NetworkServer.Configuration.AuthValidationTimeOutMiliseconds, cts.Token);
                 if (!_timeouts.ContainsKey(newPeer)) return;
-                AuthIdentity.TryRemove((ushort)newPeer.Id, out _);
+                AuthIdentity.TryRemove(newPeer.Id, out _);
                 _timeouts.TryRemove(newPeer, out _);
                 BNL.Log($"Authentication timeout for {UUID}.");
                 BasisServerHandleEvents.RejectWithReason(newPeer, "Authentication timeout");
@@ -183,7 +183,7 @@ namespace BasisDidLink
                 DidUrlFragment Fragment = new DidUrlFragment(FragmentAsString);
                 Response response = new Response(Sig, Fragment);
 
-                if (AuthIdentity.TryGetValue((ushort)newPeer.Id, out OnAuth authIdentity))
+                if (AuthIdentity.TryGetValue(newPeer.Id, out OnAuth authIdentity))
                 {
                     Challenge challenge = authIdentity.Challenge;
                     bool isAuthenticated = await RecvChallengeResponse(response, challenge);
@@ -221,7 +221,7 @@ namespace BasisDidLink
             return result.IsOk;
         }
 
-        public void RemoveConnection(ushort NetPeer)
+        public void RemoveConnection(int NetPeer)
         {
             AuthIdentity.TryRemove(NetPeer, out var authIdentity);
         }
@@ -312,7 +312,7 @@ namespace BasisDidLink
 
         public bool NetIDToUUID(NetPeer Peer, out string UUID)
         {
-            if (AuthIdentity.TryGetValue((ushort)Peer.Id, out OnAuth OnAuth))
+            if (AuthIdentity.TryGetValue(Peer.Id, out OnAuth OnAuth))
             {
                 UUID = OnAuth.Did.V;
                 return true;
@@ -321,9 +321,9 @@ namespace BasisDidLink
             return false;
         }
 
-        public bool UUIDToNetID(string UUID, out ushort Peer)
+        public bool UUIDToNetID(string UUID, out int Peer)
         {
-            foreach (KeyValuePair<ushort, OnAuth> Pair in AuthIdentity)
+            foreach (KeyValuePair<int, OnAuth> Pair in AuthIdentity)
             {
                 if (Pair.Value.Did.V == UUID)
                 {

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/Security/BasisPlayerModeration.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/Security/BasisPlayerModeration.cs
@@ -101,7 +101,7 @@ namespace BasisNetworkServer.Security
             if (string.IsNullOrEmpty(reason))
                 return "[Error] Reason cannot be null or empty.";
 
-            if (!NetworkServer.AuthIdentity.UUIDToNetID(UUID, out ushort peer))
+            if (!NetworkServer.AuthIdentity.UUIDToNetID(UUID, out int peer))
             {
                 return $"[Error] Unable to find player: {UUID}";
             }
@@ -138,7 +138,7 @@ namespace BasisNetworkServer.Security
             if (string.IsNullOrEmpty(reason))
                 return "[Error] Reason cannot be null or empty.";
 
-            if (!NetworkServer.AuthIdentity.UUIDToNetID(UUID, out ushort peer))
+            if (!NetworkServer.AuthIdentity.UUIDToNetID(UUID, out int peer))
                 return $"[Error] Unable to find player: {UUID}";
 
             NetworkServer.AuthenticatedPeers.TryGetValue(peer, out var peers);
@@ -172,7 +172,7 @@ namespace BasisNetworkServer.Security
             if (string.IsNullOrEmpty(reason))
                 return "[Error] Reason cannot be null or empty.";
 
-            if (!NetworkServer.AuthIdentity.UUIDToNetID(UUID, out ushort peer))
+            if (!NetworkServer.AuthIdentity.UUIDToNetID(UUID, out int peer))
                 return $"[Error] Unable to find player: {UUID}";
 
             NetworkServer.AuthenticatedPeers.TryGetValue(peer, out var peers);


### PR DESCRIPTION
PR-ing this first, in case I got any of the changes wrong.

I *really* want to get rid of the duplication here. Having the Basis unity project reference the top-level folder for the Basis Server doesn't work because of user confusion. Using symlinks doesn't necessarily work because of Windows.

Can we could get rid of the top-level Basis Server folder, and just have the copy that's inside of the unity project? Or make the top level Basis Sever csprojs reference the copy that's inside of the unity project?