### PR TITLE
Adjust clipping planes for very small and very big avatars

### DIFF
--- a/Basis/Packages/com.basis.examples/Seats/SeatScene.unity
+++ b/Basis/Packages/com.basis.examples/Seats/SeatScene.unity
@@ -170,13 +170,15 @@ MonoBehaviour:
     extras: []
   interactableEnabled: 1
   AutoHold: 1
+  InputKey: 0
   InteractRange: 1
   highlightMode: 3
   _back: {x: 2.24, y: 0.33, z: 0}
   _foot: {x: -0.3, y: -0.25, z: 0}
   _knee: {x: -0.3, y: 0.33, z: 0}
   _spineAngleDegrees: 90
-  canInteract: 1
+  IsSeatTakenByAnyone: 0
+  LocallyInSeat: 0
 --- !u!65 &366497805
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -365,13 +367,15 @@ MonoBehaviour:
     extras: []
   interactableEnabled: 1
   AutoHold: 1
+  InputKey: 0
   InteractRange: 1
   highlightMode: 3
   _back: {x: -0.16, y: 0.33, z: 0}
   _foot: {x: -0.3, y: -0.25, z: 0}
   _knee: {x: -0.3, y: 0.33, z: 0}
   _spineAngleDegrees: 90
-  canInteract: 1
+  IsSeatTakenByAnyone: 0
+  LocallyInSeat: 0
 --- !u!65 &721748681
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -790,13 +794,15 @@ MonoBehaviour:
     extras: []
   interactableEnabled: 1
   AutoHold: 1
+  InputKey: 0
   InteractRange: 1
   highlightMode: 3
   _back: {x: 0, y: 0.33, z: 0.24}
   _foot: {x: 0, y: -0.2, z: -0.83}
   _knee: {x: 0, y: 0.33, z: -0.3}
   _spineAngleDegrees: 90
-  canInteract: 1
+  IsSeatTakenByAnyone: 0
+  LocallyInSeat: 0
 --- !u!114 &1047396125
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -822,13 +828,15 @@ MonoBehaviour:
     extras: []
   interactableEnabled: 1
   AutoHold: 1
+  InputKey: 0
   InteractRange: 1
   highlightMode: 3
   _back: {x: 0, y: 0.33, z: 0.24}
   _foot: {x: 0, y: -0.2, z: -0.83}
   _knee: {x: 0, y: 0.33, z: -0.3}
   _spineAngleDegrees: 120
-  canInteract: 1
+  IsSeatTakenByAnyone: 0
+  LocallyInSeat: 0
 --- !u!114 &1047396126
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -854,13 +862,15 @@ MonoBehaviour:
     extras: []
   interactableEnabled: 1
   AutoHold: 1
+  InputKey: 0
   InteractRange: 1
   highlightMode: 3
   _back: {x: 0, y: 0.33, z: 0.24}
   _foot: {x: 0, y: -0.25, z: -0.3}
   _knee: {x: 0, y: 0.33, z: -0.3}
   _spineAngleDegrees: 90
-  canInteract: 1
+  IsSeatTakenByAnyone: 0
+  LocallyInSeat: 0
 --- !u!114 &1047396127
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -886,13 +896,15 @@ MonoBehaviour:
     extras: []
   interactableEnabled: 1
   AutoHold: 1
+  InputKey: 0
   InteractRange: 1
   highlightMode: 3
   _back: {x: 0, y: 0.33, z: -0.24}
   _foot: {x: 0, y: -0.25, z: 0.3}
   _knee: {x: 0, y: 0.33, z: 0.3}
   _spineAngleDegrees: 90
-  canInteract: 1
+  IsSeatTakenByAnyone: 0
+  LocallyInSeat: 0
 --- !u!114 &1047396128
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -918,13 +930,15 @@ MonoBehaviour:
     extras: []
   interactableEnabled: 1
   AutoHold: 1
+  InputKey: 0
   InteractRange: 1
   highlightMode: 3
   _back: {x: 0, y: 2.07, z: -0.96}
   _foot: {x: 0, y: -0.25, z: 1.2}
   _knee: {x: 0, y: 2.07, z: 1.2}
   _spineAngleDegrees: 90
-  canInteract: 1
+  IsSeatTakenByAnyone: 0
+  LocallyInSeat: 0
 --- !u!114 &1047396129
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1016,13 +1030,15 @@ MonoBehaviour:
     extras: []
   interactableEnabled: 1
   AutoHold: 1
+  InputKey: 0
   InteractRange: 1
   highlightMode: 3
   _back: {x: 0, y: -0.105, z: -0.059}
   _foot: {x: 0, y: -0.25, z: 0.0755}
   _knee: {x: 0, y: -0.105, z: 0.0755}
   _spineAngleDegrees: 90
-  canInteract: 1
+  IsSeatTakenByAnyone: 0
+  LocallyInSeat: 0
 --- !u!114 &1403212574
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1048,13 +1064,15 @@ MonoBehaviour:
     extras: []
   interactableEnabled: 1
   AutoHold: 1
+  InputKey: 0
   InteractRange: 1
   highlightMode: 3
   _back: {x: 0.3, y: 0.33, z: 0}
   _foot: {x: -0.3, y: -0.25, z: 0}
   _knee: {x: -0.3, y: 0.33, z: 0}
   _spineAngleDegrees: 90
-  canInteract: 1
+  IsSeatTakenByAnyone: 0
+  LocallyInSeat: 0
 --- !u!1 &1511330576
 GameObject:
   m_ObjectHideFlags: 0
@@ -1133,13 +1151,15 @@ MonoBehaviour:
     extras: []
   interactableEnabled: 1
   AutoHold: 1
+  InputKey: 0
   InteractRange: 1
   highlightMode: 3
   _back: {x: 0, y: 0.33, z: 0.24}
   _foot: {x: 0, y: -0.25, z: -0.3}
   _knee: {x: 0, y: 0.33, z: -0.3}
   _spineAngleDegrees: 90
-  canInteract: 1
+  IsSeatTakenByAnyone: 0
+  LocallyInSeat: 0
 --- !u!1 &1703945651 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 5472706545657883201, guid: 8e9677a9f8cd4c947846603d5ca204e6, type: 3}
@@ -1170,13 +1190,15 @@ MonoBehaviour:
     extras: []
   interactableEnabled: 1
   AutoHold: 1
+  InputKey: 0
   InteractRange: 1
   highlightMode: 3
   _back: {x: 0, y: 0.32, z: -0.2}
   _foot: {x: 0, y: -0.75, z: -0.14}
   _knee: {x: 0, y: -0.25, z: -0.14}
   _spineAngleDegrees: 175
-  canInteract: 1
+  IsSeatTakenByAnyone: 0
+  LocallyInSeat: 0
 --- !u!65 &1703945654
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -1244,13 +1266,15 @@ MonoBehaviour:
     extras: []
   interactableEnabled: 1
   AutoHold: 1
+  InputKey: 0
   InteractRange: 1
   highlightMode: 3
   _back: {x: 0, y: 0.33, z: 0.24}
   _foot: {x: 0, y: -0.25, z: -0.3}
   _knee: {x: 0, y: 0.33, z: -0.3}
   _spineAngleDegrees: 90
-  canInteract: 1
+  IsSeatTakenByAnyone: 0
+  LocallyInSeat: 0
 --- !u!114 &1846288222
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1436,13 +1460,15 @@ MonoBehaviour:
     extras: []
   interactableEnabled: 1
   AutoHold: 1
+  InputKey: 0
   InteractRange: 1
   highlightMode: 3
   _back: {x: 0.105, y: 0.365, z: 0.14}
   _foot: {x: -0.02, y: -0.34, z: -0.2}
   _knee: {x: 0.345, y: 0.1, z: -0.27}
   _spineAngleDegrees: 90
-  canInteract: 1
+  IsSeatTakenByAnyone: 0
+  LocallyInSeat: 0
 --- !u!65 &2030883942
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -1489,13 +1515,15 @@ MonoBehaviour:
     extras: []
   interactableEnabled: 1
   AutoHold: 1
+  InputKey: 0
   InteractRange: 1
   highlightMode: 3
   _back: {x: 0, y: 0.01, z: 2.5}
   _foot: {x: 0, y: -5, z: -0.01}
   _knee: {x: 0, y: 0.01, z: -0.01}
   _spineAngleDegrees: 90
-  canInteract: 1
+  IsSeatTakenByAnyone: 0
+  LocallyInSeat: 0
 --- !u!65 &2061200783
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -1542,13 +1570,15 @@ MonoBehaviour:
     extras: []
   interactableEnabled: 1
   AutoHold: 1
+  InputKey: 0
   InteractRange: 1
   highlightMode: 3
   _back: {x: 0.33, y: 0.24, z: 0}
   _foot: {x: -0.25, y: -0.3, z: 0}
   _knee: {x: 0.33, y: -0.3, z: 0}
   _spineAngleDegrees: 90
-  canInteract: 1
+  IsSeatTakenByAnyone: 0
+  LocallyInSeat: 0
 --- !u!1001 &1977322212309204955
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Basis/Packages/com.basis.framework/Device Management/BasisDeviceManagement.cs
+++ b/Basis/Packages/com.basis.framework/Device Management/BasisDeviceManagement.cs
@@ -651,7 +651,7 @@ namespace Basis.Scripts.Device_Management
         /// <summary>
         /// Indicates whether the current runtime is a mobile platform (Android).
         /// </summary>
-        public static bool IsMobilehardware() => Application.isMobilePlatform;
+        public static bool IsMobileHardware() => Application.isMobilePlatform;
 
         /// <summary>
         /// Returns <c>true</c> when the current static mode equals <see cref="BasisConstants.Desktop"/>.

--- a/Basis/Packages/com.basis.framework/Device Management/Devices/Desktop/BasisDesktopMangement.cs
+++ b/Basis/Packages/com.basis.framework/Device Management/Devices/Desktop/BasisDesktopMangement.cs
@@ -10,14 +10,14 @@ using UnityEngine.InputSystem.EnhancedTouch;
 namespace Basis.Scripts.Device_Management.Devices.Desktop
 {
     /// <summary>
-    /// Provides device management logic for desktop-based usage of the Basis SDK.  
+    /// Provides device management logic for desktop-based usage of the Basis SDK.
     /// Handles initialization and cleanup of eye input simulation when running without XR hardware.
     /// </summary>
     [Serializable]
     public class BasisDesktopManagement : BasisBaseTypeManagement
     {
         /// <summary>
-        /// Reference to the <see cref="BasisAvatarEyeInput"/> component 
+        /// Reference to the <see cref="BasisAvatarEyeInput"/> component
         /// created for simulating desktop eye tracking input.
         /// </summary>
         public BasisDesktopEye BasisAvatarEyeInput;
@@ -30,9 +30,9 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
         public bool AlwaysSpawnHeadsUpControls;
         public GameObject Controls;
         /// <summary>
-        /// Starts the Basis SDK for desktop mode.  
+        /// Starts the Basis SDK for desktop mode.
         /// If no <see cref="BasisAvatarEyeInput"/> exists, it creates one and attaches it
-        /// under the <see cref="BasisLocalPlayer"/> object (if present).  
+        /// under the <see cref="BasisLocalPlayer"/> object (if present).
         /// Also locks the cursor for desktop interaction.
         /// </summary>
         public override void StartSDK()
@@ -51,7 +51,7 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
                 BasisAvatarEyeInput.Initialize(DesktopEye, nameof(BasisDesktopManagement));
                 BasisDeviceManagement.Instance.TryAdd(BasisAvatarEyeInput);
             }
-            if (BasisDeviceManagement.IsMobilehardware() || AlwaysSpawnHeadsUpControls)
+            if (BasisDeviceManagement.IsMobileHardware() || AlwaysSpawnHeadsUpControls)
             {
                 UnityEngine.ResourceManagement.AsyncOperations.AsyncOperationHandle<GameObject> op = Addressables.InstantiateAsync(OnScreenControls, BasisLocalCameraDriver.Instance.transform, true);
                 Controls = op.WaitForCompletion();
@@ -138,7 +138,7 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
         }
 
         /// <summary>
-        /// Stops the Basis SDK for desktop mode.  
+        /// Stops the Basis SDK for desktop mode.
         /// Removes the desktop eye input device from <see cref="BasisDeviceManagement"/> and destroys its component.
         /// </summary>
         public override void StopSDK()

--- a/Basis/Packages/com.basis.framework/Device Management/Devices/Desktop/BasisLocalInputActions.cs
+++ b/Basis/Packages/com.basis.framework/Device Management/Devices/Desktop/BasisLocalInputActions.cs
@@ -13,9 +13,9 @@ using UnityEngine.InputSystem.Users;
 namespace Basis.Scripts.Device_Management.Devices.Desktop
 {
     /// <summary>
-    /// Handles all local input actions for desktop devices.  
-    /// Provides movement, look, jump, crouch, run, UI, and device switching functionality 
-    /// by wiring up Unity Input System <see cref="InputAction"/> events to the <see cref="BasisLocalPlayer"/> 
+    /// Handles all local input actions for desktop devices.
+    /// Provides movement, look, jump, crouch, run, UI, and device switching functionality
+    /// by wiring up Unity Input System <see cref="InputAction"/> events to the <see cref="BasisLocalPlayer"/>
     /// and <see cref="BasisLocalCharacterDriver"/>.
     /// </summary>
     [DefaultExecutionOrder(15003)]
@@ -106,7 +106,7 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
                 }
             }
 
-            if (BasisDeviceManagement.IsCurrentModeVR() && BasisDeviceManagement.IsMobilehardware())
+            if (BasisDeviceManagement.IsCurrentModeVR() && BasisDeviceManagement.IsMobileHardware())
             {
 
             }
@@ -121,7 +121,7 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
         {
             BasisLocalCameraDriver.InstanceExists -= SetupCamera;
 
-            if (BasisDeviceManagement.IsCurrentModeVR() && BasisDeviceManagement.IsMobilehardware())
+            if (BasisDeviceManagement.IsCurrentModeVR() && BasisDeviceManagement.IsMobileHardware())
             {
 
             }

--- a/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalCameraDriver.cs
+++ b/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalCameraDriver.cs
@@ -61,8 +61,10 @@ namespace Basis.Scripts.Drivers
         public Vector3 DesktopMicrophoneViewportPosition = new(0.2f, 0.15f, 1f);
 
         public Vector3 MobileMicrophoneViewportPosition = new(0.5f, 0.1f, 1f);
-        /// <summary>Near clip plane override.</summary>
-        public float NearClip = 0.001f;
+        /// <summary>The desired far clipping plane from scene settings before avatar overriding.</summary>
+        private float DesiredClipFar = 1000.0f;
+        /// <summary>The desired near clipping plane from scene settings before avatar overriding.</summary>
+        private float DesiredClipNear = 0.001f;
 
         /// <summary>World-space position of the left eye (XR). In desktop mode this equals camera position.</summary>
         public static Vector3 LeftEye;
@@ -169,21 +171,11 @@ namespace Basis.Scripts.Drivers
                 Instance = this;
                 HasInstance = true;
             }
-            if (BasisDeviceManagement.IsMobilehardware())
-            {
-                Camera.nearClipPlane = 0.05f;
-                Camera.farClipPlane = 800;
-            }
-            else
-            {
-                Camera.nearClipPlane = NearClip;
-                Camera.farClipPlane = 1500;
-            }
 
             CameraInstanceID = Camera.GetInstanceID();
 
-            // Set initial scale from player height
-            OnHeightChanged();
+            // Set initial scale from player height and set the clip planes.
+            UpdateCameraScale();
 
             if (HasEvents == false)
             {
@@ -195,7 +187,7 @@ namespace Basis.Scripts.Drivers
                 RenderPipelineManager.endCameraRendering += EndCameraRendering;
 
                 BasisDeviceManagement.OnBootModeChanged += OnModeSwitch;
-                BasisLocalPlayer.OnPlayersHeightChangedNextFrame += OnHeightChanged;
+                BasisLocalPlayer.OnPlayersHeightChangedNextFrame += UpdateCameraScale;
 
                 InstanceExists?.Invoke();
                 HasEvents = true;
@@ -224,7 +216,7 @@ namespace Basis.Scripts.Drivers
             RenderPipelineManager.beginCameraRendering -= BeginCameraRendering;
             RenderPipelineManager.endCameraRendering -= EndCameraRendering;
             BasisDeviceManagement.OnBootModeChanged -= OnModeSwitch;
-            BasisLocalPlayer.OnPlayersHeightChangedNextFrame -= OnHeightChanged;
+            BasisLocalPlayer.OnPlayersHeightChangedNextFrame -= UpdateCameraScale;
             BasisLocalMicrophoneDriver.OnPausedAction -= microphoneIconDriver.OnPausedEvent;
             HasEvents = false;
             HasInstance = false;
@@ -260,7 +252,7 @@ namespace Basis.Scripts.Drivers
             {
                 Camera.fieldOfView = DefaultCameraFov;
             }
-            OnHeightChanged();
+            UpdateCameraScale();
         }
 
         /// <summary>
@@ -281,14 +273,34 @@ namespace Basis.Scripts.Drivers
             }
         }
 
+        public void SetDesiredClipPlanes(float clipFar, float clipNear)
+        {
+            DesiredClipFar = clipFar;
+            DesiredClipNear = clipNear;
+            UpdateCameraScale();
+        }
+
         /// <summary>
         /// Applies scale from the player's height so the camera’s local scale matches avatar scale.
         /// </summary>
-        public void OnHeightChanged()
+        public void UpdateCameraScale()
         {
-            BasisDebug.Log($"On Camera Scale Ratio Changed! {LocalPlayer.CurrentHeight.SelectedAvatarToAvatarDefaultScale}", BasisDebug.LogTag.Local);
             // the normal users scale is 1.6m; scale camera with selected avatar scale
             this.transform.localScale = Vector3.one * LocalPlayer.CurrentHeight.SelectedAvatarToAvatarDefaultScale;
+            // Ensure that the near clip plane is never far enough away that the avatar body clips through it.
+            // Critically we need to avoid small player heights causing the UI to become unusable due to clipping.
+            // At the same time, we need to pull in the far clip plane on mobile platforms to avoid depth buffer precision issues.
+            float eyeHeightMeters = Mathf.Max(LocalPlayer.CurrentHeight.SelectedPlayerHeight, 1e-4f);
+            if (BasisDeviceManagement.IsMobileHardware())
+            {
+                Camera.nearClipPlane = Mathf.Clamp(DesiredClipNear, eyeHeightMeters / 32.0f, eyeHeightMeters / 16.0f);
+                Camera.farClipPlane = Mathf.Clamp(DesiredClipFar, eyeHeightMeters * 64.0f, eyeHeightMeters * 512.0f);
+            }
+            else
+            {
+                Camera.nearClipPlane = Mathf.Clamp(DesiredClipNear, eyeHeightMeters / 128.0f, eyeHeightMeters / 32.0f);
+                Camera.farClipPlane = Mathf.Clamp(DesiredClipFar, eyeHeightMeters * 128.0f, eyeHeightMeters * 8192.0f);
+            }
         }
 
         /// <summary>
@@ -323,14 +335,14 @@ namespace Basis.Scripts.Drivers
                     }
                     else
                     {
-                        if (BasisDeviceManagement.IsMobilehardware())
+                        if (BasisDeviceManagement.IsMobileHardware())
                         {
                             Vector3 worldPoint = Camera.ViewportToWorldPoint(MobileMicrophoneViewportPosition);
                             // assume this transform is the camera parent
                             Vector3 localPos = this.transform.InverseTransformPoint(worldPoint);
                             ParentOfUI.localPosition = localPos * LocalPlayer.CurrentHeight.SelectedAvatarToAvatarDefaultScale;
                         }
-                        else 
+                        else
                         {
                             Vector3 worldPoint = Camera.ViewportToWorldPoint(DesktopMicrophoneViewportPosition);
                             // assume this transform is the camera parent

--- a/Basis/Packages/com.basis.framework/Drivers/Remote/BasisRemoteNamePlateDriver.cs
+++ b/Basis/Packages/com.basis.framework/Drivers/Remote/BasisRemoteNamePlateDriver.cs
@@ -110,7 +110,7 @@ namespace Basis.Scripts.UI.NamePlate
         public void Awake()
         {
             Instance = this;
-            if (BasisDeviceManagement.IsMobilehardware())
+            if (BasisDeviceManagement.IsMobileHardware())
             {
                 SelectedNamePlateMaterial = OpaqueNamePlateMaterial;
             }

--- a/Basis/Packages/com.basis.framework/Scene Management/BasisSceneFactory.cs
+++ b/Basis/Packages/com.basis.framework/Scene Management/BasisSceneFactory.cs
@@ -47,7 +47,7 @@ public static class BasisSceneFactory
         RespawnHeight = BasisScene.RespawnHeight;
         if (scene.MainCamera != null)
         {
-            LoadCameraPropertys(scene.MainCamera);
+            LoadCameraProperties(scene.MainCamera);
             GameObject.DestroyImmediate(scene.MainCamera.gameObject);
             BasisDebug.Log("Destroying Main Camera Attached To Scene");
         }
@@ -83,39 +83,26 @@ public static class BasisSceneFactory
             BasisLocalPlayer = GameObject.FindFirstObjectByType<BasisLocalPlayer>(FindObjectsInactive.Exclude);
         }
     }
-    public static void LoadCameraPropertys(Camera Camera)
+    public static void LoadCameraProperties(Camera Camera)
     {
-        BNL.Log("Loading Camera Propertys From Camera "+ Camera.gameObject.name);  
+        BNL.Log("Loading Camera Propertys From Camera "+ Camera.gameObject.name);
+        // Configure the local player's camera mostly based on the scene's placeholder camera.
         Camera RealCamera = BasisLocalCameraDriver.Instance.Camera;
         RealCamera.useOcclusionCulling = Camera.useOcclusionCulling;
         RealCamera.backgroundColor = Camera.backgroundColor;
         RealCamera.barrelClipping = Camera.barrelClipping;
-        RealCamera.usePhysicalProperties = Camera.usePhysicalProperties;;
-        if (BasisDeviceManagement.IsMobilehardware())
-        {
-            if (Camera.farClipPlane > 800)
-            {
-                RealCamera.farClipPlane = 800;
-            }
-            if (RealCamera.nearClipPlane < 0.05f)
-            {
-                RealCamera.nearClipPlane = 0.05f;
-            }
-        }
-        else
-        {
-            RealCamera.farClipPlane = Camera.farClipPlane;
-            RealCamera.nearClipPlane = Camera.nearClipPlane;
-        }
-
+        RealCamera.usePhysicalProperties = Camera.usePhysicalProperties;
+        // Note that these are limited by the player's size in BasisLocalCameraDriver.UpdateCameraScale().
+        BasisLocalCameraDriver.Instance.SetDesiredClipPlanes(Camera.farClipPlane, Camera.nearClipPlane);
+        // Set more camera data from the UniversalAdditionalCameraData component if it exists.
         if (Camera.TryGetComponent(out UniversalAdditionalCameraData AdditionalCameraData))
         {
             UniversalAdditionalCameraData Data = BasisLocalCameraDriver.Instance.CameraData;
 
-           Data.stopNaN = AdditionalCameraData.stopNaN;
+            Data.stopNaN = AdditionalCameraData.stopNaN;
             Data.dithering = AdditionalCameraData.dithering;
 
-           Data.volumeTrigger = AdditionalCameraData.volumeTrigger;
+            Data.volumeTrigger = AdditionalCameraData.volumeTrigger;
         }
     }
     public static void AttachMixerToAllSceneAudioSources()

--- a/Basis/Packages/com.basis.framework/UI/BasisInputModuleHandler.cs
+++ b/Basis/Packages/com.basis.framework/UI/BasisInputModuleHandler.cs
@@ -214,7 +214,7 @@ namespace Basis.Scripts.UI
         }
         public bool KeyboardRequired()
         {
-            return (BasisDeviceManagement.IsCurrentModeVR() || ForceKeyboard || BasisDeviceManagement.IsCurrentModeVR() == false && BasisDeviceManagement.IsMobilehardware());
+            return (BasisDeviceManagement.IsCurrentModeVR() || ForceKeyboard || BasisDeviceManagement.IsCurrentModeVR() == false && BasisDeviceManagement.IsMobileHardware());
         }
 
         /// <summary>


### PR DESCRIPTION
This PR ensures that the near clip plane is never far enough away that the avatar body clips through it. Critically, we need to avoid small player heights causing the UI to become unusable due to clipping. At the same time, we need to keep into account mobile depth buffer limits, including pulling in the far clip plane.