### PR TITLE
Move height changed signal/action into BasisLocalHeight

### DIFF
--- a/Basis/Packages/com.basis.framework/BasisUI/BasisMenuMover.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/BasisMenuMover.cs
@@ -82,7 +82,7 @@ namespace Basis.BasisUI
         private void OnDestroy()
         {
             BasisLocalPlayer.Instance.OnAvatarSwitched -= OnAvatarHeightChange;
-            BasisLocalPlayer.OnPlayersHeightChangedNextFrame -= OnAvatarHeightChange;
+            BasisLocalHeight.OnHeightChangedNextFrame -= OnAvatarHeightChange;
 
             if (_hasLocalCreationEvent)
             {
@@ -100,7 +100,7 @@ namespace Basis.BasisUI
         private void OnLocalPlayerCreated()
         {
             BasisLocalPlayer.Instance.OnAvatarSwitched += OnAvatarHeightChange;
-            BasisLocalPlayer.OnPlayersHeightChangedNextFrame += OnAvatarHeightChange;
+            BasisLocalHeight.OnHeightChangedNextFrame += OnAvatarHeightChange;
             SetRootMode(GetFindCurrentMode());
 
             BasisLocalPlayer.Instance.LocalBoneDriver.FindBone(out _leftHandControl, BasisBoneTrackedRole.LeftHand);

--- a/Basis/Packages/com.basis.framework/Camera/BasisHandHeldCameraInteractable.cs
+++ b/Basis/Packages/com.basis.framework/Camera/BasisHandHeldCameraInteractable.cs
@@ -161,7 +161,7 @@ public abstract class BasisHandHeldCameraInteractable : BasisPickupInteractable
         OnInteractStartEvent += OnInteractDesktopTweak;
         BasisDeviceManagement.OnBootModeChanged += OnBootModeChanged;
 
-        BasisLocalPlayer.OnPlayersHeightChangedNextFrame += OnHeightChanged;
+        BasisLocalHeight.OnHeightChangedNextFrame += OnHeightChanged;
 
         // scale camera to avatar size
         transform.localScale = new Vector3(cameraDefaultScale, cameraDefaultScale, cameraDefaultScale) *
@@ -640,7 +640,7 @@ public abstract class BasisHandHeldCameraInteractable : BasisPickupInteractable
     {
         BasisDeviceManagement.OnBootModeChanged -= OnBootModeChanged;
         OnInteractStartEvent -= OnInteractDesktopTweak;
-        BasisLocalPlayer.OnPlayersHeightChangedNextFrame -= OnHeightChanged;
+        BasisLocalHeight.OnHeightChangedNextFrame -= OnHeightChanged;
 
         BasisLocalPlayer.AfterFinalMove.RemoveAction(202, UpdateCamera);
 

--- a/Basis/Packages/com.basis.framework/Device Management/Common/BasisVisualTracker.cs
+++ b/Basis/Packages/com.basis.framework/Device Management/Common/BasisVisualTracker.cs
@@ -54,7 +54,7 @@ namespace Basis.Scripts.Device_Management
                 if (HasEvents == false)
                 {
                     BasisLocalPlayer.OnLocalAvatarChanged += UpdateVisualSizeAndOffset;
-                    BasisLocalPlayer.OnPlayersHeightChangedNextFrame += UpdateVisualSizeAndOffset;
+                    BasisLocalHeight.OnHeightChangedNextFrame += UpdateVisualSizeAndOffset;
                     HasEvents = true;
                 }
 
@@ -70,7 +70,7 @@ namespace Basis.Scripts.Device_Management
             if (HasEvents)
             {
                 BasisLocalPlayer.OnLocalAvatarChanged -= UpdateVisualSizeAndOffset;
-                BasisLocalPlayer.OnPlayersHeightChangedNextFrame -= UpdateVisualSizeAndOffset;
+                BasisLocalHeight.OnHeightChangedNextFrame -= UpdateVisualSizeAndOffset;
                 HasEvents = false;
             }
         }

--- a/Basis/Packages/com.basis.framework/Drivers/Common/BasisHeightDriver.cs
+++ b/Basis/Packages/com.basis.framework/Drivers/Common/BasisHeightDriver.cs
@@ -28,7 +28,7 @@ public static class BasisHeightDriver
     /// <remarks>
     /// Establishes authoritative avatar metrics (eye height, arm span) first, then captures live player metrics.
     /// Ensures nonzero defaults, computes scale ratios safely, picks the active ratio set for <paramref name="selectedHeightMode"/>,
-    /// and invokes <see cref="BasisLocalPlayer.OnPlayersHeightChangedNextFrame"/> via <see cref="BasisLocalPlayer.ExecuteNextFrame(System.Action)"/>.
+    /// and invokes <see cref="BasisLocalHeight.OnHeightChangedNextFrame"/> via <see cref="BasisLocalPlayer.ExecuteNextFrame(System.Action)"/>.
     /// </remarks>
     public static void ChangeEyeHeightMode(BasisLocalPlayer localPlayer, BasisSelectedHeightMode selectedHeightMode)
     {
@@ -100,7 +100,7 @@ public static class BasisHeightDriver
         // notify next frame
         localPlayer.ExecuteNextFrame(() =>
         {
-            BasisLocalPlayer.OnPlayersHeightChangedNextFrame?.Invoke();
+            BasisLocalHeight.OnHeightChangedNextFrame?.Invoke();
         });
     }
 
@@ -254,7 +254,7 @@ public static class BasisHeightDriver
 
         player.ExecuteNextFrame(() =>
         {
-            BasisLocalPlayer.OnPlayersHeightChangedNextFrame?.Invoke();
+            BasisLocalHeight.OnHeightChangedNextFrame?.Invoke();
         });
     }
 }

--- a/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalCameraDriver.cs
+++ b/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalCameraDriver.cs
@@ -187,7 +187,7 @@ namespace Basis.Scripts.Drivers
                 RenderPipelineManager.endCameraRendering += EndCameraRendering;
 
                 BasisDeviceManagement.OnBootModeChanged += OnModeSwitch;
-                BasisLocalPlayer.OnPlayersHeightChangedNextFrame += UpdateCameraScale;
+                BasisLocalHeight.OnHeightChangedNextFrame += UpdateCameraScale;
 
                 InstanceExists?.Invoke();
                 HasEvents = true;
@@ -216,7 +216,7 @@ namespace Basis.Scripts.Drivers
             RenderPipelineManager.beginCameraRendering -= BeginCameraRendering;
             RenderPipelineManager.endCameraRendering -= EndCameraRendering;
             BasisDeviceManagement.OnBootModeChanged -= OnModeSwitch;
-            BasisLocalPlayer.OnPlayersHeightChangedNextFrame -= UpdateCameraScale;
+            BasisLocalHeight.OnHeightChangedNextFrame -= UpdateCameraScale;
             BasisLocalMicrophoneDriver.OnPausedAction -= microphoneIconDriver.OnPausedEvent;
             HasEvents = false;
             HasInstance = false;

--- a/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalRigDriver.cs
+++ b/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalRigDriver.cs
@@ -284,7 +284,7 @@ namespace Basis.Scripts.Drivers
                 basisTransformMapping,
                 out BasisFullIKConstraint
             );
-            BasisLocalPlayer.OnPlayersHeightChangedNextFrame += OnPlayersHeightChangedNextFrame;
+            BasisLocalHeight.OnHeightChangedNextFrame += OnPlayersHeightChangedNextFrame;
             OnPlayersHeightChangedNextFrame();
 
             var data = BasisFullIKConstraint.data;

--- a/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalSeatDriver.cs
+++ b/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalSeatDriver.cs
@@ -126,7 +126,7 @@ namespace Basis.Scripts.Drivers
             GrabLatestTposeLocalScaleData();
             if (hasEvent == false)
             {
-                BasisLocalPlayer.OnPlayersHeightChangedNextFrame += GrabLatestTposeLocalScaleData;
+                BasisLocalHeight.OnHeightChangedNextFrame += GrabLatestTposeLocalScaleData;
                 hasEvent = true;
             }
             OnSimulate();
@@ -162,7 +162,7 @@ namespace Basis.Scripts.Drivers
             GrabLatestTposeLocalScaleData();
             if (hasEvent)
             {
-                BasisLocalPlayer.OnPlayersHeightChangedNextFrame -= GrabLatestTposeLocalScaleData;
+                BasisLocalHeight.OnHeightChangedNextFrame -= GrabLatestTposeLocalScaleData;
                 hasEvent = false;
             }
             _seat = null;

--- a/Basis/Packages/com.basis.framework/Players/Local/BasisLocalHeight.cs
+++ b/Basis/Packages/com.basis.framework/Players/Local/BasisLocalHeight.cs
@@ -27,6 +27,11 @@ namespace Basis.Scripts.BasisSdk.Players
         public string AvatarName;
 
         /// <summary>
+        /// Fired on the frame after a player height change is requested.
+        /// </summary>
+        public static System.Action OnHeightChangedNextFrame;
+
+        /// <summary>
         /// Fallback height (meters) used when no measurement is available.
         /// not the total height but the eye height
         /// </summary>

--- a/Basis/Packages/com.basis.framework/Players/Local/BasisLocalPlayer.cs
+++ b/Basis/Packages/com.basis.framework/Players/Local/BasisLocalPlayer.cs
@@ -78,11 +78,6 @@ namespace Basis.Scripts.BasisSdk.Players
         public static Action OnSpawnedEvent;
 
         /// <summary>
-        /// Fired on the frame after a player height change is requested.
-        /// </summary>
-        public static Action OnPlayersHeightChangedNextFrame;
-
-        /// <summary>
         /// Ordered delegate queue invoked after all movement and simulation have completed for the frame.
         /// </summary>
         public static BasisOrderedDelegate AfterFinalMove = new BasisOrderedDelegate();

--- a/Basis/Packages/com.basis.framework/UI Panels/BasisSetUserName.cs
+++ b/Basis/Packages/com.basis.framework/UI Panels/BasisSetUserName.cs
@@ -82,7 +82,7 @@ namespace Basis.Scripts.UI.UI_Panels
             }
 
             ApplySize();
-            BasisLocalPlayer.OnPlayersHeightChangedNextFrame += ApplySize;
+            BasisLocalHeight.OnHeightChangedNextFrame += ApplySize;
             if (BasisNetworkManagement.Instance != null)
             {
                 LoadCurrentSettings();
@@ -110,7 +110,7 @@ namespace Basis.Scripts.UI.UI_Panels
                 AdvancedSettings.onClick.RemoveListener(ToggleAdvancedSettings);
                 UseLocalhost.onClick.RemoveListener(UseLocalHost);
             }
-            BasisLocalPlayer.OnPlayersHeightChangedNextFrame -= ApplySize;
+            BasisLocalHeight.OnHeightChangedNextFrame -= ApplySize;
         }
 
         /// <summary>

--- a/Basis/Packages/com.basis.framework/UI Panels/BasisUIMovementDriver.cs
+++ b/Basis/Packages/com.basis.framework/UI Panels/BasisUIMovementDriver.cs
@@ -46,7 +46,7 @@ namespace Basis.Scripts.UI.UI_Panels
                 BasisLocalPlayer.AfterFinalMove.RemoveAction(120, UpdateUIFollow);
             }
 
-            BasisLocalPlayer.OnPlayersHeightChangedNextFrame -= SetUILocation;
+            BasisLocalHeight.OnHeightChangedNextFrame -= SetUILocation;
 
             if (hasLocalCreationEvent)
             {
@@ -60,7 +60,7 @@ namespace Basis.Scripts.UI.UI_Panels
             {
                 BasisLocalPlayer.AfterFinalMove.AddAction(120, UpdateUIFollow);
             }
-            BasisLocalPlayer.OnPlayersHeightChangedNextFrame += SetUILocation;
+            BasisLocalHeight.OnHeightChangedNextFrame += SetUILocation;
             SetUILocation();
         }
         public void UpdateUIFollow()

--- a/Basis/Packages/com.basis.framework/UI Panels/BasisUIServers.cs
+++ b/Basis/Packages/com.basis.framework/UI Panels/BasisUIServers.cs
@@ -53,7 +53,7 @@ namespace Basis.Scripts.UI.UI_Panels
             }
             UseLocalhost.onClick.AddListener(UseLocalHost);
             ApplySize();
-            BasisLocalPlayer.OnPlayersHeightChangedNextFrame += ApplySize;
+            BasisLocalHeight.OnHeightChangedNextFrame += ApplySize;
             if (BasisNetworkManagement.Instance != null)
             {
                 LoadCurrentSettings();
@@ -68,7 +68,7 @@ namespace Basis.Scripts.UI.UI_Panels
         }
         public void OnDestroy()
         {
-            BasisLocalPlayer.OnPlayersHeightChangedNextFrame -= ApplySize;
+            BasisLocalHeight.OnHeightChangedNextFrame -= ApplySize;
             UseLocalhost.onClick.RemoveListener(UseLocalHost);
         }
         public void UseHostMode(bool IsDown)

--- a/Basis/Packages/com.basis.framework/UI/BasisMenuMovementDriver.cs
+++ b/Basis/Packages/com.basis.framework/UI/BasisMenuMovementDriver.cs
@@ -49,7 +49,7 @@ namespace Basis.Scripts.UI.UI_Panels
             }
 
             BasisLocalPlayer.OnLocalAvatarChanged -= UpdateDelayedSetUI;
-            BasisLocalPlayer.OnPlayersHeightChangedNextFrame -= UpdateDelayedSetUI;
+            BasisLocalHeight.OnHeightChangedNextFrame -= UpdateDelayedSetUI;
 
             BasisLocalPlayer.AfterFinalMove.RemoveAction(101, UpdateUI);
         }
@@ -59,7 +59,7 @@ namespace Basis.Scripts.UI.UI_Panels
         private void OnLocalPlayerGenerated()
         {
             BasisLocalPlayer.OnLocalAvatarChanged += UpdateDelayedSetUI;
-            BasisLocalPlayer.OnPlayersHeightChangedNextFrame += UpdateDelayedSetUI;
+            BasisLocalHeight.OnHeightChangedNextFrame += UpdateDelayedSetUI;
             if (LocalPlayer.LocalBoneDriver.FindBone(out hand, BasisBoneTrackedRole.LeftHand))
             {
             }

--- a/Basis/Packages/com.basis.framework/UI/BasisUIRaycast.cs
+++ b/Basis/Packages/com.basis.framework/UI/BasisUIRaycast.cs
@@ -70,7 +70,7 @@ namespace Basis.Scripts.UI
 
             HasLineRenderer = false;
             HasRedicalRenderer = false;
-            BasisLocalPlayer.OnPlayersHeightChangedNextFrame += OnPlayersHeightChanged;
+            BasisLocalHeight.OnHeightChangedNextFrame += OnPlayersHeightChanged;
             // Create the ray with the adjusted starting position and direction
             if (basisInput.DeviceMatchSettings.HasRayCastVisual)
             {
@@ -119,7 +119,7 @@ namespace Basis.Scripts.UI
         {
             if (HasOnPlayersHeightChanged)
             {
-                BasisLocalPlayer.OnPlayersHeightChangedNextFrame -= OnPlayersHeightChanged;
+                BasisLocalHeight.OnHeightChangedNextFrame -= OnPlayersHeightChanged;
             }
         }
 


### PR DESCRIPTION
The idea here is to centralize height-related code into `BasisLocalHeight` rather than having it be spread around. This is not the last PR organizing height-related code, but it is an easy first step.