### PR TITLE
Attempt to warn when "too little" data is read from a message.

### DIFF
--- a/Basis Server/BasisNetworkCore/BasisNetworkShell.cs
+++ b/Basis Server/BasisNetworkCore/BasisNetworkShell.cs
@@ -101,7 +101,18 @@ namespace Basis.Network.Core
 	{
 		Action RecycleInternal;
 
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+		internal byte channel;
+		internal DeliveryMethod method;
+#endif
+
 		public void Recycle() {
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+			if (!EndOfData) {
+				BNL.LogWarning($"Message on channel {channel} with delivery method {method} had {AvailableBytes} bytes remaining when recycling! Is this a parsing bug?");
+				// TODO: consider printing the bytes of the message.
+			}
+#endif
 			RecycleInternal?.Invoke();
 		}
 	}

--- a/Basis Server/BasisNetworkCore/LNLNetworkImpl.cs
+++ b/Basis Server/BasisNetworkCore/LNLNetworkImpl.cs
@@ -29,6 +29,12 @@ namespace Basis.Network.Core
         void LiteNetLib.INetEventListener.OnNetworkReceive(LiteNetLib.NetPeer peer, LiteNetLib.NetPacketReader reader, byte channelNumber, LiteNetLib.DeliveryMethod deliveryMethod)
         {
             NetPacketReader read = new NetPacketReader(reader);
+
+            #if UNITY_EDITOR || DEVELOPMENT_BUILD
+            read.channel = channelNumber;
+            read.method = (DeliveryMethod)(byte)deliveryMethod;
+            #endif
+
             NetworkReceiveEvent?.Invoke(new LNLNetPeer(peer), read, channelNumber, (DeliveryMethod)(byte)deliveryMethod);
         }
 

--- a/Basis/Packages/com.basis.server/BasisNetworkCore/BasisNetworkShell.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkCore/BasisNetworkShell.cs
@@ -101,7 +101,18 @@ namespace Basis.Network.Core
 	{
 		Action RecycleInternal;
 
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+		internal byte channel;
+		internal DeliveryMethod method;
+#endif
+
 		public void Recycle() {
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+			if (!EndOfData) {
+				BNL.LogWarning($"Message on channel {channel} with delivery method {method} had {AvailableBytes} bytes remaining when recycling! Is this a parsing bug?");
+				// TODO: consider printing the bytes of the message.
+			}
+#endif
 			RecycleInternal?.Invoke();
 		}
 	}

--- a/Basis/Packages/com.basis.server/BasisNetworkCore/LNLNetworkImpl.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkCore/LNLNetworkImpl.cs
@@ -29,6 +29,12 @@ namespace Basis.Network.Core
         void LiteNetLib.INetEventListener.OnNetworkReceive(LiteNetLib.NetPeer peer, LiteNetLib.NetPacketReader reader, byte channelNumber, LiteNetLib.DeliveryMethod deliveryMethod)
         {
             NetPacketReader read = new NetPacketReader(reader);
+
+            #if UNITY_EDITOR || DEVELOPMENT_BUILD
+            read.channel = channelNumber;
+            read.method = (DeliveryMethod)(byte)deliveryMethod;
+            #endif
+
             NetworkReceiveEvent?.Invoke(new LNLNetPeer(peer), read, channelNumber, (DeliveryMethod)(byte)deliveryMethod);
         }
 


### PR DESCRIPTION
Only active when running from the editor or running a development build.