### PR TITLE
Created custom "BTween" tweening system.

### DIFF
--- a/Basis/Packages/com.basis.framework/BasisUI/PanelComponents/PanelToggle.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/PanelComponents/PanelToggle.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+using Basis.BTween;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -16,20 +16,18 @@ namespace Basis.BasisUI
         public RectTransform ToggleVisual;
 
         [Header("Visual Elements")]
-        public Graphic Background;                     // <= ADD THIS (Image or any UI Graphic)
-
+        public Graphic Background;
         [Min(0)] public float ToggleVisualOffset = 20f;
 
         [Header("Tween Settings")]
         [Min(0)] public float TweenDuration = 0.2f;
-        public AnimationCurve EaseCurve = AnimationCurve.EaseInOut(0, 0, 1, 1);
-
-        [Header("Color Settings")]                     // <= NICE INSPECTOR BLOCK
         public Color OffColor = new Color(0.4f, 0.4f, 0.4f, 1f);
         public Color OnColor = new Color(0.2f, 0.8f, 0.4f, 1f);
+        private TweenAnchorPosition _toggleTween;
+        private TweenGraphicColor _backgroundTween;
 
-        private Coroutine _tweenRoutine;
         private bool _initialized;
+
 
         private PanelToggle() { }
 
@@ -62,6 +60,7 @@ namespace Basis.BasisUI
             base.ApplyValue();
 
             float targetX = Value ? ToggleVisualOffset : -ToggleVisualOffset;
+            Color targetColor = Value ? OnColor : OffColor;
 
             if (!Application.isPlaying || !_initialized || TweenDuration <= 0f)
             {
@@ -69,69 +68,34 @@ namespace Basis.BasisUI
                 return;
             }
 
-            if (_tweenRoutine != null)
-                StopCoroutine(_tweenRoutine);
 
-            _tweenRoutine = StartCoroutine(TweenToX(targetX, Value));
+
+            if (ToggleVisual)
+            {
+                if (_toggleTween && _toggleTween.Active) _toggleTween.Finish();
+                _toggleTween = ToggleVisual.TweenAnchorPosition(TweenDuration, new Vector2(targetX, 0));
+            }
+
+            if (Background)
+            {
+                if (_backgroundTween && _backgroundTween.Active) _backgroundTween.Finish();
+                _backgroundTween = Background.TweenColor(TweenDuration, Background.color, targetColor);
+            }
         }
 
         private void SetVisualInstant(bool on)
         {
-            if (ToggleVisual != null)
+            if (ToggleVisual)
             {
                 float x = on ? ToggleVisualOffset : -ToggleVisualOffset;
-                var pos = ToggleVisual.anchoredPosition;
+                Vector2 pos = ToggleVisual.anchoredPosition;
                 ToggleVisual.anchoredPosition = new Vector2(x, pos.y);
             }
 
-            if (Background != null)
+            if (Background)
             {
                 Background.color = on ? OnColor : OffColor;
             }
-        }
-
-        private IEnumerator TweenToX(float targetX, bool turningOn)
-        {
-            if (ToggleVisual == null && Background == null)
-                yield break;
-
-            Vector2 startPos = ToggleVisual ? ToggleVisual.anchoredPosition : Vector2.zero;
-            float startX = startPos.x;
-            float y = startPos.y;
-
-            Color startColor = Background ? Background.color : Color.white;
-            Color targetColor = turningOn ? OnColor : OffColor;
-
-            float time = 0f;
-
-            while (time < TweenDuration)
-            {
-                time += Time.unscaledDeltaTime;
-                float t = Mathf.Clamp01(time / TweenDuration);
-
-                float eased = EaseCurve != null ? EaseCurve.Evaluate(t) : t;
-
-                if (ToggleVisual != null)
-                {
-                    float x = Mathf.Lerp(startX, targetX, eased);
-                    ToggleVisual.anchoredPosition = new Vector2(x, y);
-                }
-
-                if (Background != null)
-                {
-                    Background.color = Color.Lerp(startColor, targetColor, eased);
-                }
-
-                yield return null;
-            }
-
-            if (ToggleVisual != null)
-                ToggleVisual.anchoredPosition = new Vector2(targetX, y);
-
-            if (Background != null)
-                Background.color = targetColor;
-
-            _tweenRoutine = null;
         }
     }
 }

--- a/Basis/Packages/com.basis.framework/BasisUI/Tweening.meta
+++ b/Basis/Packages/com.basis.framework/BasisUI/Tweening.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0f9069d2d74070b418de403007932740
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Basis/Packages/com.basis.framework/BasisUI/Tweening/BTweenManager.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Tweening/BTweenManager.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Basis.BTween
+{
+    public class BTweenManager : MonoBehaviour
+    {
+        public static BTweenManager Instance
+        {
+            get
+            {
+                if (!_instance) AssignInstance();
+                return _instance;
+            }
+        }
+        private static BTweenManager _instance;
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        private static void AssignInstance()
+        {
+            _instance = FindAnyObjectByType<BTweenManager>(FindObjectsInactive.Include);
+            if (_instance) return;
+            GameObject obj = new(nameof(BTweenManager));
+            _instance = obj.AddComponent<BTweenManager>();
+        }
+
+        private void Awake()
+        {
+            if (_instance)
+            {
+                if (_instance != this)
+                {
+                    Destroy(gameObject);
+                    return;
+                }
+            }
+            else
+            {
+                _instance = this;
+                DontDestroyOnLoad(this);
+            }
+        }
+
+        private const int MAX_GROUP_COUNT = 16;
+        private static readonly List<Action<float>> _tweenProcessors = new(MAX_GROUP_COUNT);
+
+        internal static void RegisterGroup(Action<float> processor)
+        {
+            if (processor == null) return;
+            if (_tweenProcessors.Contains(processor)) return;
+            _tweenProcessors.Add(processor);
+        }
+
+        private static void ProcessAll()
+        {
+            float currentTime = Time.realtimeSinceStartup;
+            List<Action<float>> processors = _tweenProcessors;
+            foreach (Action<float> tween in processors)
+            {
+                tween(currentTime);
+            }
+        }
+
+        private void Update()
+        {
+            ProcessAll();
+        }
+    }
+}

--- a/Basis/Packages/com.basis.framework/BasisUI/Tweening/BTweenManager.cs.meta
+++ b/Basis/Packages/com.basis.framework/BasisUI/Tweening/BTweenManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7ca43202ab482b24e897b00ec7bf5497

--- a/Basis/Packages/com.basis.framework/BasisUI/Tweening/EaseTypes.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Tweening/EaseTypes.cs
@@ -1,0 +1,157 @@
+// Largely based on the work of https://easings.net/#
+
+using UnityEngine;
+
+namespace Basis.BTween
+{
+    public enum Easing
+    {
+        InSine,
+        OutSine,
+        InOutSine,
+        InQuad,
+        OutQuad,
+        InOutQuad,
+        InCubic,
+        OutCubic,
+        InOutCubic,
+        InQuart,
+        OutQuart,
+        InOutQuart,
+        InQuint,
+        OutQuint,
+        InOutQuint,
+        InExpo,
+        OutExpo,
+        InOutExpo,
+        InCirc,
+        OutCirc,
+        InOutCirc,
+        InBack,
+        OutBack,
+        InOutBack,
+        InElastic,
+        OutElastic,
+        InOutElastic,
+        InBounce,
+        OutBounce,
+        InOutBounce,
+    }
+
+    public static class EaseTypes
+    {
+        public const float c1  = 1.70158f;
+        public const float c2  = c1 * 1.525f;
+        public const float c3  = c1 + 1;
+        public const float c4  = (2 * Mathf.PI) / 3;
+        public const float c5  = (2 * Mathf.PI) / 4.5f;
+        public const float n1  = 7.5625f;
+        public const float d1  = 2.75f;
+
+        public static float PerformEase(Easing ease, float x)
+        {
+            switch (ease)
+            {
+                case Easing.InSine:
+                    return 1 - Mathf.Cos((x * Mathf.PI) / 2);
+                case Easing.OutSine:
+                    return Mathf.Sin((x * Mathf.PI) / 2);
+                case Easing.InOutSine:
+                    return -(Mathf.Cos(Mathf.PI * x) - 1) / 2;
+                case Easing.InQuad:
+                    return x * x;
+                case Easing.OutQuad:
+                    return 1 - (1 - x) * (1 - x);
+                case Easing.InOutQuad:
+                    return x < 0.5 ? 2 * x * x : 1 - Mathf.Pow(-2 * x + 2, 2) / 2;
+                case Easing.InCubic:
+                    return x * x * x;
+                case Easing.OutCubic:
+                    return 1 - Mathf.Pow(1 - x, 3);
+                case Easing.InOutCubic:
+                    return x < 0.5 ? 4 * x * x * x : 1 - Mathf.Pow(-2 * x + 2, 3) / 2;
+                case Easing.InQuart:
+                    return x * x * x * x;
+                case Easing.OutQuart:
+                    return 1 - Mathf.Pow(1 - x, 4);
+                case Easing.InOutQuart:
+                    return x < 0.5 ? 8 * x * x * x * x : 1 - Mathf.Pow(-2 * x + 2, 4) / 2;
+                case Easing.InQuint:
+                    return x * x * x * x * x;
+                case Easing.OutQuint:
+                    return 1 - Mathf.Pow(1 - x, 5);
+                case Easing.InOutQuint:
+                    return x < 0.5 ? 16 * x * x * x * x * x : 1 - Mathf.Pow(-2 * x + 2, 5) / 2;
+                case Easing.InExpo:
+                    return x == 0 ? 0 : Mathf.Pow(2, 10 * x - 10);
+                case Easing.OutExpo:
+                    return x == 1 ? 1 : 1 - Mathf.Pow(2, -10 * x);
+                case Easing.InOutExpo:
+                    return x == 0
+                        ? 0
+                        : x == 1
+                            ? 1
+                            : x < 0.5
+                                ? Mathf.Pow(2, 20 * x - 10) / 2
+                                : (2 - Mathf.Pow(2, -20 * x + 10)) / 2;
+                case Easing.InCirc:
+                    return 1 - Mathf.Sqrt(1 - Mathf.Pow(x, 2));
+                case Easing.OutCirc:
+                    return Mathf.Sqrt(1 - Mathf.Pow(x - 1, 2));
+                case Easing.InOutCirc:
+                    return x < 0.5
+                        ? (1 - Mathf.Sqrt(1 - Mathf.Pow(2 * x, 2))) / 2
+                        : (Mathf.Sqrt(1 - Mathf.Pow(-2 * x + 2, 2)) + 1) / 2;
+                case Easing.InBack:
+                    return c3 * x * x * x - c1 * x * x;
+                case Easing.OutBack:
+                    return 1 + c3 * Mathf.Pow(x - 1, 3) + c1 * Mathf.Pow(x - 1, 2);
+                case Easing.InOutBack:
+                    return x < 0.5
+                        ? (Mathf.Pow(2 * x, 2) * ((c2 + 1) * 2 * x - c2)) / 2
+                        : (Mathf.Pow(2 * x - 2, 2) * ((c2 + 1) * (x * 2 - 2) + c2) + 2) / 2;
+                case Easing.InElastic:
+                    return x == 0
+                        ? 0
+                        : x == 1
+                            ? 1
+                            : -Mathf.Pow(2, 10 * x - 10) * Mathf.Sin((x * 10 - 10.75f) * c4);
+                case Easing.OutElastic:
+                    return x == 0
+                        ? 0
+                        : x == 1
+                            ? 1
+                            : Mathf.Pow(2, -10 * x) * Mathf.Sin((x * 10 - 0.75f) * c4) + 1;
+                case Easing.InOutElastic:
+                    return x == 0
+                        ? 0
+                        : x == 1
+                            ? 1
+                            : x < 0.5
+                                ? -(Mathf.Pow(2, 20 * x - 10) * Mathf.Sin((20 * x - 11.125f) * c5)) / 2
+                                : (Mathf.Pow(2, -20 * x + 10) * Mathf.Sin((20 * x - 11.125f) * c5)) / 2 + 1;
+                case Easing.InBounce:
+                    return 1 - PerformEase(Easing.OutBounce, 1 - x);
+                case Easing.OutBounce:
+                    if (x < 1 / d1)
+                        return n1 * x * x;
+
+                    if (x < 2 / d1)
+                        return n1 * (x -= 1.5f / d1) * x + 0.75f;
+
+                    if (x < 2.5 / d1)
+                        return n1 * (x -= 2.25f / d1) * x + 0.9375f;
+
+                    return n1 * (x -= 2.625f / d1) * x + 0.984375f;
+                case Easing.InOutBounce:
+                    return x < 0.5
+                        ? (1 - PerformEase(Easing.OutBounce,(1 - 2 * x))) / 2
+                        : (1 + PerformEase(Easing.OutBounce,(2 * x - 1))) / 2;
+                default:
+                    Debug.LogWarning($"Ease type {ease} not implemented.");
+                    break;
+            }
+            return x;
+        }
+    }
+}

--- a/Basis/Packages/com.basis.framework/BasisUI/Tweening/EaseTypes.cs.meta
+++ b/Basis/Packages/com.basis.framework/BasisUI/Tweening/EaseTypes.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2b9dadc19819583419ce2a8e8d5d8be2

--- a/Basis/Packages/com.basis.framework/BasisUI/Tweening/TweenTypes.meta
+++ b/Basis/Packages/com.basis.framework/BasisUI/Tweening/TweenTypes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0a2b89401b25e604487fd496e975469c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Basis/Packages/com.basis.framework/BasisUI/Tweening/TweenTypes/BaseTween.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Tweening/TweenTypes/BaseTween.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Basis.BTween
+{
+    [Serializable]
+    public abstract class BaseTween<T> where T: BaseTween<T>, new()
+    {
+
+        public static implicit operator bool(BaseTween<T> tween) => tween != null;
+
+
+        public bool Active;
+        public Easing Ease = Easing.OutSine;
+        public float StartTime;
+        public float EndTime;
+        public Action OnComplete;
+
+        private const int MAX_TWEEN_COUNT = 64;
+        public static List<T> Tweens = new(MAX_TWEEN_COUNT);
+
+
+        static BaseTween()
+        {
+            BTweenManager.RegisterGroup(ProcessGroup);
+        }
+
+        private static void ProcessGroup(float currentTime)
+        {
+            List<T> list = Tweens;
+            foreach (T tween in list)
+            {
+                if (!tween.Active) continue;
+                tween.Process(currentTime);
+            }
+        }
+
+        public static T GetAvailableTween()
+        {
+            foreach (T tween in Tweens)
+            {
+                if (tween.Active) continue;
+                return tween;
+            }
+
+            T newTween = new();
+            Tweens.Add(newTween);
+            return newTween;
+        }
+
+        protected float BlendValue(float currentTime) =>
+            EaseTypes.PerformEase(Ease, Mathf.InverseLerp(StartTime, EndTime, currentTime));
+
+
+        protected void AssignTimes(float duration)
+        {
+            Active = true;
+            StartTime = Time.realtimeSinceStartup;
+            EndTime = StartTime + duration;
+        }
+
+
+        public T SetEase(Easing easing)
+        {
+            Ease = easing;
+            return (T)this;
+        }
+
+        public T AddCallback(Action callback)
+        {
+            OnComplete += callback;
+            return (T)this;
+        }
+
+        /// <summary>
+        /// Returns true when completed.
+        /// </summary>
+        public virtual bool Process(float currentTime)
+        {
+            float percentage = BlendValue(currentTime);
+            if (percentage >= 1)
+            {
+                Finish();
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Complete a tween, applying its End value.
+        /// </summary>
+        public virtual void Finish()
+        {
+            // Debug.Log("Finished!");
+            OnComplete?.Invoke();
+            Reset();
+        }
+
+        public virtual void Reset()
+        {
+            Active = false;
+            StartTime = 0;
+            EndTime = 0;
+            OnComplete = null;
+        }
+    }
+}

--- a/Basis/Packages/com.basis.framework/BasisUI/Tweening/TweenTypes/BaseTween.cs.meta
+++ b/Basis/Packages/com.basis.framework/BasisUI/Tweening/TweenTypes/BaseTween.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4c83845e52fb4774cae39b0bb4a1a125

--- a/Basis/Packages/com.basis.framework/BasisUI/Tweening/TweenTypes/BaseTweenColor.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Tweening/TweenTypes/BaseTweenColor.cs
@@ -1,0 +1,39 @@
+using UnityEngine;
+
+namespace Basis.BTween
+{
+    public abstract class BaseTweenColor<T> : BaseTween<T>
+        where T: BaseTweenColor<T>, new()
+    {
+        public Color StartValue;
+        public Color EndValue;
+
+        public T Start(float duration, Color startValue, Color endValue)
+        {
+            AssignTimes(duration);
+            AssignRange(startValue, endValue);
+            return (T)this;
+        }
+
+        public void AssignRange(Color startValue, Color endValue)
+        {
+            StartValue = startValue;
+            EndValue = endValue;
+        }
+
+        public T Start(float duration, Color endValue)
+        {
+            AssignTimes(duration);
+            StartValue = Color.white;
+            EndValue = endValue;
+            return (T)this;
+        }
+
+        public override void Reset()
+        {
+            base.Reset();
+            StartValue = Color.white;
+            EndValue = Color.white;
+        }
+    }
+}

--- a/Basis/Packages/com.basis.framework/BasisUI/Tweening/TweenTypes/BaseTweenColor.cs.meta
+++ b/Basis/Packages/com.basis.framework/BasisUI/Tweening/TweenTypes/BaseTweenColor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 69386e59c1964bf49b4ca337a3b36523

--- a/Basis/Packages/com.basis.framework/BasisUI/Tweening/TweenTypes/BaseTweenFloat.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Tweening/TweenTypes/BaseTweenFloat.cs
@@ -1,0 +1,39 @@
+using UnityEngine;
+
+namespace Basis.BTween
+{
+    public abstract class BaseTweenFloat<T> : BaseTween<T>
+        where T: BaseTweenFloat<T>, new()
+    {
+        public float StartValue;
+        public float EndValue;
+
+        public T Start(float duration, float startValue, float endValue)
+        {
+            AssignTimes(duration);
+            AssignRange(startValue, endValue);
+            return (T)this;
+        }
+
+        public void AssignRange(float startValue, float endValue)
+        {
+            StartValue = startValue;
+            EndValue = endValue;
+        }
+
+        public T Start(float duration, float endValue)
+        {
+            AssignTimes(duration);
+            StartValue = 0;
+            EndValue = endValue;
+            return (T)this;
+        }
+
+        public override void Reset()
+        {
+            base.Reset();
+            StartValue = 0;
+            EndValue = 0;
+        }
+    }
+}

--- a/Basis/Packages/com.basis.framework/BasisUI/Tweening/TweenTypes/BaseTweenFloat.cs.meta
+++ b/Basis/Packages/com.basis.framework/BasisUI/Tweening/TweenTypes/BaseTweenFloat.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d63759707c3c925448e3995e5b25fd7e

--- a/Basis/Packages/com.basis.framework/BasisUI/Tweening/TweenTypes/BaseTweenVector2.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Tweening/TweenTypes/BaseTweenVector2.cs
@@ -1,0 +1,39 @@
+using UnityEngine;
+
+namespace Basis.BTween
+{
+    public abstract class BaseTweenVector2<T> : BaseTween<T>
+        where T: BaseTweenVector2<T>, new()
+    {
+        public Vector2 StartValue;
+        public Vector2 EndValue;
+
+        public T Start(float duration, Vector2 startValue, Vector2 endValue)
+        {
+            AssignTimes(duration);
+            AssignRange(startValue, endValue);
+            return (T)this;
+        }
+
+        public void AssignRange(Vector2 startValue, Vector2 endValue)
+        {
+            StartValue = startValue;
+            EndValue = endValue;
+        }
+
+        public T Start(float duration, Vector2 endValue)
+        {
+            AssignTimes(duration);
+            StartValue = Vector2.zero;
+            EndValue = endValue;
+            return (T)this;
+        }
+
+        public override void Reset()
+        {
+            base.Reset();
+            StartValue = Vector2.zero;
+            EndValue = Vector2.zero;
+        }
+    }
+}

--- a/Basis/Packages/com.basis.framework/BasisUI/Tweening/TweenTypes/BaseTweenVector2.cs.meta
+++ b/Basis/Packages/com.basis.framework/BasisUI/Tweening/TweenTypes/BaseTweenVector2.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ba8eeadad0d439f43b16d52af5838623

--- a/Basis/Packages/com.basis.framework/BasisUI/Tweening/TweenTypes/BaseTweenVector3.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Tweening/TweenTypes/BaseTweenVector3.cs
@@ -1,0 +1,39 @@
+using UnityEngine;
+
+namespace Basis.BTween
+{
+    public abstract class BaseTweenVector3<T> : BaseTween<T>
+        where T: BaseTweenVector3<T>, new()
+    {
+        public Vector3 StartValue;
+        public Vector3 EndValue;
+
+        public T Start(float duration, Vector3 startValue, Vector3 endValue)
+        {
+            AssignTimes(duration);
+            AssignRange(startValue, endValue);
+            return (T)this;
+        }
+
+        public void AssignRange(Vector3 startValue, Vector3 endValue)
+        {
+            StartValue = startValue;
+            EndValue = endValue;
+        }
+
+        public T Start(float duration, Vector3 endValue)
+        {
+            AssignTimes(duration);
+            StartValue = Vector3.zero;
+            EndValue = endValue;
+            return (T)this;
+        }
+
+        public override void Reset()
+        {
+            base.Reset();
+            StartValue = Vector3.zero;
+            EndValue = Vector3.zero;
+        }
+    }
+}

--- a/Basis/Packages/com.basis.framework/BasisUI/Tweening/TweenTypes/BaseTweenVector3.cs.meta
+++ b/Basis/Packages/com.basis.framework/BasisUI/Tweening/TweenTypes/BaseTweenVector3.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c34ce8474ae43e24bb02e8f57dfba779

--- a/Basis/Packages/com.basis.framework/BasisUI/Tweening/TweenTypes/TweenAnchorPosition.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Tweening/TweenTypes/TweenAnchorPosition.cs
@@ -1,0 +1,58 @@
+using UnityEngine;
+
+namespace Basis.BTween
+{
+    public static class TweenAnchorPositionExtensions
+    {
+        public static TweenAnchorPosition TweenAnchorPosition(
+            this RectTransform rectTransform,
+            float duration,
+            Vector2 endPosition)
+        {
+            TweenAnchorPosition tween = BTween.TweenAnchorPosition.GetAvailableTween()
+                .SetTarget(rectTransform)
+                .Start(duration, endPosition);
+            return tween;
+        }
+
+        public static TweenAnchorPosition TweenAnchorPosition(
+            this RectTransform rectTransform,
+            float duration,
+            Vector2 startPosition,
+            Vector2 endPosition)
+        {
+            TweenAnchorPosition tween = BTween.TweenAnchorPosition.GetAvailableTween()
+                .SetTarget(rectTransform)
+                .Start(duration, startPosition, endPosition);
+            return tween;
+        }
+    }
+
+    public class TweenAnchorPosition : BaseTweenVector2<TweenAnchorPosition>
+    {
+
+        public RectTransform Target;
+
+        public TweenAnchorPosition SetTarget(RectTransform target)
+        {
+            Target = target;
+            return this;
+        }
+
+        public override bool Process(float currentTime)
+        {
+            if (base.Process(currentTime)) return true;
+
+            float blend = BlendValue(currentTime);
+            Target.anchoredPosition = Vector2.Lerp(StartValue, EndValue, blend);
+            return false;
+        }
+
+        public override void Finish()
+        {
+            Target.anchoredPosition = EndValue;
+            base.Finish();
+        }
+
+    }
+}

--- a/Basis/Packages/com.basis.framework/BasisUI/Tweening/TweenTypes/TweenAnchorPosition.cs.meta
+++ b/Basis/Packages/com.basis.framework/BasisUI/Tweening/TweenTypes/TweenAnchorPosition.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: aa7556d1c2a9b6746a278e800a20a9af

--- a/Basis/Packages/com.basis.framework/BasisUI/Tweening/TweenTypes/TweenGraphicColor.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Tweening/TweenTypes/TweenGraphicColor.cs
@@ -1,0 +1,58 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Basis.BTween
+{
+    public static class TweenGraphicColorExtensions
+    {
+        public static TweenGraphicColor TweenColor(
+            this Graphic image,
+            float duration,
+            Color endPosition)
+        {
+            TweenGraphicColor tween = TweenGraphicColor.GetAvailableTween()
+                .SetTarget(image)
+                .Start(duration, endPosition);
+            return tween;
+        }
+
+        public static TweenGraphicColor TweenColor(
+            this Graphic image,
+            float duration,
+            Color startPosition,
+            Color endPosition)
+        {
+            TweenGraphicColor tween = TweenGraphicColor.GetAvailableTween()
+                .SetTarget(image)
+                .Start(duration, startPosition, endPosition);
+            return tween;
+        }
+    }
+
+
+    public class TweenGraphicColor : BaseTweenColor<TweenGraphicColor>
+    {
+        public Graphic Target;
+
+        public TweenGraphicColor SetTarget(Graphic target)
+        {
+            Target = target;
+            return this;
+        }
+
+        public override bool Process(float currentTime)
+        {
+            if (base.Process(currentTime)) return true;
+
+            float blend = BlendValue(currentTime);
+            Target.color = Color.Lerp(StartValue, EndValue, blend);
+            return false;
+        }
+
+        public override void Finish()
+        {
+            Target.color = EndValue;
+            base.Finish();
+        }
+    }
+}

--- a/Basis/Packages/com.basis.framework/BasisUI/Tweening/TweenTypes/TweenGraphicColor.cs.meta
+++ b/Basis/Packages/com.basis.framework/BasisUI/Tweening/TweenTypes/TweenGraphicColor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4ee29ed8d3b2af341ad747f019a8e3ea

--- a/Basis/Packages/com.basis.framework/BasisUI/Tweening/TweenTypes/TweenPosition.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Tweening/TweenTypes/TweenPosition.cs
@@ -1,0 +1,58 @@
+using UnityEngine;
+
+namespace Basis.BTween
+{
+    public static class TweenPositionExtensions
+    {
+        public static TweenPosition TweenPosition(
+            this Transform transform,
+            float duration,
+            Vector3 endPosition)
+        {
+            TweenPosition tween = BTween.TweenPosition.GetAvailableTween()
+                .SetTarget(transform)
+                .Start(duration, endPosition);
+            return tween;
+        }
+
+        public static TweenPosition TweenPosition(
+            this Transform transform,
+            float duration,
+            Vector3 startPosition,
+            Vector3 endPosition)
+        {
+            TweenPosition tween = BTween.TweenPosition.GetAvailableTween()
+                .SetTarget(transform)
+                .Start(duration, startPosition, endPosition);
+            return tween;
+        }
+    }
+
+
+    public class TweenPosition : BaseTweenVector3<TweenPosition>
+    {
+
+        public Transform Target;
+
+        public TweenPosition SetTarget(Transform target)
+        {
+            Target = target;
+            return this;
+        }
+
+        public override bool Process(float currentTime)
+        {
+            if (base.Process(currentTime)) return true;
+
+            float blend = BlendValue(currentTime);
+            Target.position = Vector3.Lerp(StartValue, EndValue, blend);
+            return false;
+        }
+
+        public override void Finish()
+        {
+            Target.position = EndValue;
+            base.Finish();
+        }
+    }
+}

--- a/Basis/Packages/com.basis.framework/BasisUI/Tweening/TweenTypes/TweenPosition.cs.meta
+++ b/Basis/Packages/com.basis.framework/BasisUI/Tweening/TweenTypes/TweenPosition.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3f798f5f06bc26b4ebbf3c3ec87ae589


### PR DESCRIPTION
This is an easily expandable Tweening setup that shouldn't hit garbage collection.
BTween makes use of extension methods, so you can call `transform.TweenPosition` or `background.TweenColor`.

Currently, there are inheritable classes for Float, Vector2, Vector3, and Color. The two classes that make use of this are TweenGraphicColor and TweenPosition, which should act as a good structure for creating new implementations.

PanelToggle.cs has been modified to take advantage of this new tweening system.