### PR TITLE
Spawn player at the scene's spawn point when loading the scene

### DIFF
--- a/Basis/Packages/com.basis.framework/Players/Local/BasisLocalPlayer.cs
+++ b/Basis/Packages/com.basis.framework/Players/Local/BasisLocalPlayer.cs
@@ -228,6 +228,7 @@ namespace Basis.Scripts.BasisSdk.Players
             if (BasisScene != null)
             {
                 BasisSceneFactory.Initalize(BasisScene);
+                BasisSceneFactory.SpawnPlayer(this);
             }
             else
             {

--- a/Basis/Packages/com.basis.framework/Scene Management/BasisSceneFactory.cs
+++ b/Basis/Packages/com.basis.framework/Scene Management/BasisSceneFactory.cs
@@ -125,13 +125,13 @@ public static class BasisSceneFactory
 
         BasisDebug.Log("Mixer group assigned to all scene AudioSources.");
     }
-    public static void SpawnPlayer(BasisLocalPlayer Basis)
+    public static void SpawnPlayer(BasisLocalPlayer localPlayer)
     {
         BasisDebug.Log("Spawning Player");
         RequestSpawnPoint(out Vector3 position, out Quaternion rotation);
-        if (Basis != null)
+        if (localPlayer != null)
         {
-            Basis.Teleport(position, rotation);
+            localPlayer.Teleport(position, rotation);
         }
         else
         {


### PR DESCRIPTION
This means that when pressing play in the editor, the player spawns at the spawn point.