### PR TITLE
Ignore Oculus exe meta file to stop Unity adding and deleting it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@
 # Gradle cache directory
 .gradle/
 
+# Oculus
+*.exe.meta
+
 # Vim
 *.swp
 *.swo

--- a/Basis/Assets/Oculus/OculusProjectSetupSettings.asset
+++ b/Basis/Assets/Oculus/OculusProjectSetupSettings.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 939e07d58bc74256b6cb58d86fe35a56, type: 3}
+  m_Name: OculusProjectSetupSettings
+  m_EditorClassIdentifier: Oculus.VR.Editor::OVRProjectSetupSettings
+  boolProperties:
+    keys:
+    - Meta.XR.SDK.a1496eb74fefeab6fb10095b6d0ca987.Ignored.Standalone
+    values: 01
+  intProperties:
+    keys: []
+    values: 

--- a/Basis/Assets/Oculus/OculusProjectSetupSettings.asset.meta
+++ b/Basis/Assets/Oculus/OculusProjectSetupSettings.asset.meta
@@ -1,7 +1,8 @@
 fileFormatVersion: 2
-guid: 4235784afad25994a97b74ceef27aba9
-DefaultImporter:
+guid: 8051cb316cd3de241b056ff58f11e247
+NativeFormatImporter:
   externalObjects: {}
+  mainObjectFileID: 11400000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Basis/Packages/com.basis.framework/Interactions/BasisSeat.cs
+++ b/Basis/Packages/com.basis.framework/Interactions/BasisSeat.cs
@@ -235,7 +235,7 @@ namespace Basis.Scripts.BasisSdk.Interactions
             return new Vector3(sx.magnitude, sy.magnitude, sz.magnitude);
         }
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="scale"></param>
         /// <param name="LeftLowerLegControlRotation"></param>

--- a/Basis/Packages/com.basis.framework/UI/BasisPointRaycaster.cs
+++ b/Basis/Packages/com.basis.framework/UI/BasisPointRaycaster.cs
@@ -142,7 +142,7 @@ namespace Basis.Scripts.UI
         /// </summary>
         /// <param name="hitInfo"></param>
         /// <param name="maxDistance"></param>
-        /// <returns>true on valid hit</returns> 
+        /// <returns>true on valid hit</returns>
         public bool FirstHit(out RaycastHit hitInfo, float maxDistance = float.PositiveInfinity)
         {
             hitInfo = default;

--- a/Basis/Packages/com.basis.sdk/Prefabs/Boot/BasisFramework.prefab
+++ b/Basis/Packages/com.basis.sdk/Prefabs/Boot/BasisFramework.prefab
@@ -562,7 +562,7 @@ MonoBehaviour:
   m_ActionEvents: []
   m_NeverAutoSwitchControlSchemes: 1
   m_DefaultControlScheme: All
-  m_DefaultActionMap: f00afc78-a030-47bb-ae9a-e2bab910633d
+  m_DefaultActionMap: Player
   m_SplitScreenIndex: -1
   m_Camera: {fileID: 0}
 --- !u!114 &1625421887690667428


### PR DESCRIPTION
Unity keeps adding this `ovr-platform-util.exe.meta` file, then deleting it, then adding it, then deleting it, over and over...

We should just gitignore it. Problem solved. This PR also ignores the Meta XR SDK warning that pops up all the time about the camera's background.

Note that GitHub does not display the diff correctly, it thinks the `.meta` file was moved and altered.