### PR TITLE
Misc minor changes

### DIFF
--- a/Basis/Packages/com.basis.common/BasisCalibratedOffsetData.cs
+++ b/Basis/Packages/com.basis.common/BasisCalibratedOffsetData.cs
@@ -13,10 +13,21 @@ namespace Basis.Scripts.Common
     {
         public Quaternion rotation;
         public Vector3 position;
+
+        public static BasisCalibratedCoords Identity
+        {
+            get { return new BasisCalibratedCoords(Vector3.zero, Quaternion.identity); }
+        }
+
         public BasisCalibratedCoords(Vector3 pos, Quaternion rot)
         {
             this.position = pos;
             this.rotation = rot;
+        }
+
+        public static Vector3 operator *(BasisCalibratedCoords basisTransform, Vector3 vec)
+        {
+            return basisTransform.position + (basisTransform.rotation * vec);
         }
     }
 }

--- a/Basis/Packages/com.basis.framework/Device Management/Devices/Desktop/BasisDesktopEye.cs
+++ b/Basis/Packages/com.basis.framework/Device Management/Devices/Desktop/BasisDesktopEye.cs
@@ -160,7 +160,7 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
         /// </summary>
         public void PlayerInitialized()
         {
-            BasisLocalInputActions.Instance.AvatarEyeInput = this;
+            BasisLocalInputActions.Instance.DesktopEyeInput = this;
             Camera = BasisLocalCameraDriver.Instance.Camera;
 
             BasisDeviceManagement Device = BasisDeviceManagement.Instance;
@@ -192,6 +192,7 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
         /// <summary>
         /// Applies yaw/pitch rotation based on the given input vector.
         /// Handles mouse-look simulation for the eye.
+        /// Note: This is relative to the player's non-head rotation. The final camera rotation is that, combined with this eye rotation.
         /// </summary>
         /// <param name="lookVector">Delta vsector from input system.</param>
         public void HandleLookRotation(Vector2 lookVector)

--- a/Basis/Packages/com.basis.framework/Device Management/Devices/Desktop/BasisLocalInputActions.cs
+++ b/Basis/Packages/com.basis.framework/Device Management/Devices/Desktop/BasisLocalInputActions.cs
@@ -61,7 +61,7 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
 
         [System.NonSerialized] public BasisLocalPlayer LocalPlayer;
         [System.NonSerialized] public BasisLocalCharacterDriver LocalCharacterDriver;
-        [System.NonSerialized] public BasisDesktopEye AvatarEyeInput;
+        [System.NonSerialized] public BasisDesktopEye DesktopEyeInput;
 
         public PlayerInput Input;
 
@@ -348,7 +348,7 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
                 lookDelta.y = 0;
             }
 
-            AvatarEyeInput?.SetLookRotationVector(lookDelta);
+            DesktopEyeInput?.SetLookRotationVector(lookDelta);
         }
 
         #endregion
@@ -385,9 +385,9 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
             var sensitivity = IsMonoStableInput(ctx.control.device) ? JoystickSensitivity : MouseSensitivity;
             OnLookAction(ctx.ReadValue<Vector2>(), sensitivity);
         }
-        public void OnLookAction(Vector2 Delta,float sensitivity)
+        public void OnLookAction(Vector2 delta, float sensitivity)
         {
-            var lookDelta = Delta * (deltaCoefficient * sensitivity);
+            var lookDelta = delta * (deltaCoefficient * sensitivity);
             if (SMModuleControllerSettings.HasInvertedMouse)
             {
                 lookDelta.y *= -1f;
@@ -398,13 +398,13 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
                 lookDelta.y = 0;
             }
 
-            AvatarEyeInput?.SetLookRotationVector(lookDelta);
+            DesktopEyeInput?.SetLookRotationVector(lookDelta);
         }
 
         public void OnLookActionCancelled(InputAction.CallbackContext ctx)
         {
             LocalCharacterDriver.SetCrouchBlendDelta(0f);
-            AvatarEyeInput?.SetLookRotationVector(Vector2.zero);
+            DesktopEyeInput?.SetLookRotationVector(Vector2.zero);
         }
 
         public void OnJumpActionPerformed(InputAction.CallbackContext ctx)

--- a/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalSeatDriver.cs
+++ b/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalSeatDriver.cs
@@ -91,6 +91,8 @@ namespace Basis.Scripts.Drivers
                 Stand();
             }
             _seat = seat;
+            // Offset the player's position/rotation to match the seat and keep track of the
+            // old position/rotation so that it can be restored later when exiting the seat.
             previousRelativePosition = _seat.transform.InverseTransformPoint(LocalPlayer.transform.position);
             if (BasisDesktopEye.Instance != null)
             {
@@ -99,9 +101,13 @@ namespace Basis.Scripts.Drivers
             }
             if (BasisDeviceManagement.Instance.FindDevice(out BasisInput Input, TransformBinders.BoneControl.BasisBoneTrackedRole.CenterEye))
             {
-                Vector3 Offset = -Input.ScaledDeviceCoord.position;
-                Offset.y = 0;
-                BasisInput.OffsetCoords = new Common.BasisCalibratedCoords(Offset, Quaternion.identity);
+                Vector3 offset = -Input.ScaledDeviceCoord.position;
+                offset.y = 0.0f;
+                Quaternion rot = Input.ScaledDeviceCoord.rotation;
+                rot.x = 0.0f;
+                rot.z = 0.0f;
+                rot.Normalize();
+                BasisInput.OffsetCoords = new Common.BasisCalibratedCoords(offset, Quaternion.Inverse(rot));
             }
             // Disable character movement and add a movement lock so other systems respect being seated.
             BasisLocalVirtualSpineDriver.HipsFreezeToTpose = true;
@@ -143,7 +149,7 @@ namespace Basis.Scripts.Drivers
             LocalPlayer.LocalCharacterDriver.MovementLock.Remove(nameof(BasisLocalSeatDriver));
             LocalPlayer.LocalCharacterDriver.CrouchingLock.Remove(nameof(BasisLocalSeatDriver));
             LocalPlayer.LocalCharacterDriver.IsEnabled = true;
-            BasisInput.OffsetCoords = new Common.BasisCalibratedCoords(Vector3.zero,Quaternion.identity);
+            BasisInput.OffsetCoords = new Common.BasisCalibratedCoords(Vector3.zero, Quaternion.identity);
             _setAllOverrideUsages(false);
             if (BasisDesktopEye.Instance != null)
             {


### PR DESCRIPTION
* Add Identity and `operator *` to BasisCalibratedCoords.
* Rename AvatarEyeInput to DesktopEyeInput because it's for desktop (the class was already renamed in a previous commit, this just renames the local variable).
* Compute the yaw rotation in BasisInput.OffsetCoords (it's not read from yet, so this does nothing right now).
* A few comment and formatting improvements.

So all of these have no immediate behavior change. And yes I tested that it still runs.