### PR TITLE
Add dedicated vertical movement to the character controller

### DIFF
--- a/Basis/Assets/Basis/Settings/InputActions/InputAction.inputactions
+++ b/Basis/Assets/Basis/Settings/InputActions/InputAction.inputactions
@@ -140,6 +140,15 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": true
+                },
+                {
+                    "name": "MoveLocalUpDown",
+                    "type": "Value",
+                    "id": "d4f90fd6-bf60-4bcb-9357-b3f6ac36f2b4",
+                    "expectedControlType": "Axis",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
                 }
             ],
             "bindings": [
@@ -659,6 +668,72 @@
                     "action": "Pointer Position",
                     "isComposite": false,
                     "isPartOfComposite": false
+                },
+                {
+                    "name": "RF",
+                    "id": "7d48d1e0-a9c8-4132-ae0a-600c5f024bfb",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "MoveLocalUpDown",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "positive",
+                    "id": "2c491300-1719-431b-b1f4-f2face82dd64",
+                    "path": "<Keyboard>/r",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";All",
+                    "action": "MoveLocalUpDown",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "negative",
+                    "id": "f27ecc65-f4b6-4a6e-810c-cb47eac45384",
+                    "path": "<Keyboard>/f",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";All",
+                    "action": "MoveLocalUpDown",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "DPadUD",
+                    "id": "786e17ff-255f-4e01-920e-9b6750329dea",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "MoveLocalUpDown",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "positive",
+                    "id": "bfaa627a-b02d-4c03-b514-06b07b221c7d",
+                    "path": "<Gamepad>/dpad/up",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";All",
+                    "action": "MoveLocalUpDown",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "negative",
+                    "id": "391e31c5-f1a4-4004-a596-1617b6e244dd",
+                    "path": "<Gamepad>/dpad/down",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";All",
+                    "action": "MoveLocalUpDown",
+                    "isComposite": false,
+                    "isPartOfComposite": true
                 }
             ]
         }

--- a/Basis/Packages/com.basis.framework/Device Management/Devices/Base/BasisActionDriver.cs
+++ b/Basis/Packages/com.basis.framework/Device Management/Devices/Base/BasisActionDriver.cs
@@ -454,6 +454,7 @@ public static class BasisActionDriver
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void JumpOnPrimaryButton(ref BasisInputState current, ref BasisInputState last)
     {
+        BasisLocalPlayer.Instance.LocalCharacterDriver.IsJumpHeld = current.PrimaryButtonGetState;
         if (current.PrimaryButtonGetState)
         {
             BasisLocalPlayer.Instance.LocalCharacterDriver.HandleJumpRequest();

--- a/Basis/Packages/com.basis.framework/Device Management/Devices/Desktop/BasisLocalInputActions.cs
+++ b/Basis/Packages/com.basis.framework/Device Management/Devices/Desktop/BasisLocalInputActions.cs
@@ -47,6 +47,7 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
         public InputActionReference MiddleMouseScroll;
         public InputActionReference MiddleMouseScrollClick;
 
+        public InputActionReference MoveLocalUpDown;
         #endregion
 
         [Header("Sensitivity Settings")]
@@ -170,6 +171,7 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
             RightMousePressed.action.Enable();
             MiddleMouseScroll.action.Enable();
             MiddleMouseScrollClick.action.Enable();
+            MoveLocalUpDown.action.Enable();
         }
 
         private void DisableActions()
@@ -189,6 +191,7 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
             RightMousePressed.action.Disable();
             MiddleMouseScroll.action.Disable();
             MiddleMouseScrollClick.action.Disable();
+            MoveLocalUpDown.action.Disable();
         }
 
         private void AddCallbacks()
@@ -352,12 +355,14 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
         public void OnJumpActionPerformed(InputAction.CallbackContext ctx)
         {
             IsJumpHeld = true;
+            LocalCharacterDriver.IsJumpHeld = true;
             LocalCharacterDriver.HandleJumpRequest();
         }
 
         public void OnJumpActionCancelled(InputAction.CallbackContext ctx)
         {
             IsJumpHeld = false;
+            LocalCharacterDriver.IsJumpHeld = false;
         }
 
         public void OnCrouchPerformed(InputAction.CallbackContext ctx)

--- a/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalCharacterDriver.cs
+++ b/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalCharacterDriver.cs
@@ -32,6 +32,7 @@ namespace Basis.Scripts.BasisCharacterController
         public SimulationHandler JustLanded;
         public bool LastWasGrounded = true;
         public bool IsFalling;
+        public bool IsJumpHeld = false;
         public bool HasJumpAction = false;
         public float jumpHeight = 1.0f; // Jump height set to 1 meter
         public float currentVerticalSpeed = 0f; // Vertical speed of the character
@@ -187,6 +188,15 @@ namespace Basis.Scripts.BasisCharacterController
             float HeightOffset = (characterController.height / 2) - characterController.radius;
             bottomPointLocalSpace = FinalRotation + (characterController.center - new Vector3(0, HeightOffset, 0));
         }
+
+        public float GetVerticalMovement()
+        {
+            float moveLocal = BasisLocalInputActions.Instance.MoveLocalUpDown.action.ReadValue<float>();
+            float ascend = IsJumpHeld ? 1.0f : 0.0f; // This works for both VR and desktop.
+            float descend = BasisLocalInputActions.Instance.IsCrouchHeld ? -1.0f : 0.0f; // No crouch button in VR.
+            return Mathf.Clamp(moveLocal + ascend + descend, -1.0f, 1.0f);
+        }
+
         public void HandleJumpRequest()
         {
             if (groundedPlayer && !HasJumpAction)

--- a/Basis/Packages/com.basis.framework/Drivers/Local/Character Controller/BasisFlyMovementMode.cs
+++ b/Basis/Packages/com.basis.framework/Drivers/Local/Character Controller/BasisFlyMovementMode.cs
@@ -39,20 +39,7 @@ namespace Basis.Scripts.BasisCharacterController
             Vector3 move = facing * planar * ctx.CurrentSpeed * dt;
 
             // ===== Vertical input (held) =====
-            float ascendHeld = 0f;
-            float descendHeld = 0f;
-
-            // Prefer your input system if available:
-            if (BasisLocalInputActions.Instance != null)
-            {
-                ascendHeld = BasisLocalInputActions.Instance.IsJumpHeld ? 1f : 0f;
-                descendHeld = BasisLocalInputActions.Instance.IsCrouchHeld ? 1f : 0f;
-            }
-
-            if (ctx.HasJumpAction) ascendHeld = 1f;
-
-            float verticalInput = ascendHeld - descendHeld; // -1..+1
-            move.y = verticalInput * ctx.CurrentSpeed * dt;
+            move.y = ctx.GetVerticalMovement() * ctx.CurrentSpeed * dt;
 
             // Clear tap
             ctx.HasJumpAction = false;

--- a/Basis/Packages/com.basis.framework/Drivers/Local/Character Controller/BasisNoClipMovementMode.cs
+++ b/Basis/Packages/com.basis.framework/Drivers/Local/Character Controller/BasisNoClipMovementMode.cs
@@ -67,15 +67,7 @@ namespace Basis.Scripts.BasisCharacterController
             Vector3 move = facing * planar * ctx.CurrentSpeed * dt;
 
             // Vertical input
-            float ascendHeld = 0f, descendHeld = 0f;
-            if (BasisLocalInputActions.Instance != null)
-            {
-                ascendHeld = BasisLocalInputActions.Instance.IsJumpHeld ? 1f : 0f;
-                descendHeld = BasisLocalInputActions.Instance.IsCrouchHeld ? 1f : 0f;
-            }
-            if (ctx.HasJumpAction) ascendHeld = 1f;
-            float verticalInput = ascendHeld - descendHeld;
-            move.y = verticalInput * ctx.CurrentSpeed * dt;
+            move.y = ctx.GetVerticalMovement() * ctx.CurrentSpeed * dt;
             ctx.HasJumpAction = false;
 
             if (ctx.MovementLock) move = Vector3.zero;

--- a/Basis/Packages/com.basis.sdk/Prefabs/Boot/BasisFramework.prefab
+++ b/Basis/Packages/com.basis.sdk/Prefabs/Boot/BasisFramework.prefab
@@ -485,6 +485,7 @@ MonoBehaviour:
   RightMousePressed: {fileID: -240064975923332847, guid: 5e4c3601c6a155f43af19da3bdd35a64, type: 3}
   MiddleMouseScroll: {fileID: 3017921969231114889, guid: 5e4c3601c6a155f43af19da3bdd35a64, type: 3}
   MiddleMouseScrollClick: {fileID: -4813832520851000306, guid: 5e4c3601c6a155f43af19da3bdd35a64, type: 3}
+  MoveLocalUpDown: {fileID: -8761834997978577808, guid: 5e4c3601c6a155f43af19da3bdd35a64, type: 3}
   MouseSensitivity: 1
   JoystickSensitivity: 1
   KeyboardSensitivity: 5


### PR DESCRIPTION
This PR adds dedicated vertical movement to the character controller, with a new read-only `public float GetVerticalMovement()` function in `BasisLocalCharacterDriver`. This replaces the duplicated vertical movement functionality in the currently-unused Fly and NoClip movement modes, and I also plan to use this in a future PR. The VR jump, and desktop jump/crouch keys contribute to this. But also, there are additional bindings for these, notably R/F and the D-pad up/down.