### PR TITLE
Add full left/right/up/down keyboard look

### DIFF
--- a/Basis/Assets/Basis/Settings/InputActions/InputAction.inputactions
+++ b/Basis/Assets/Basis/Settings/InputActions/InputAction.inputactions
@@ -133,24 +133,6 @@
                     "initialStateCheck": true
                 },
                 {
-                    "name": "Desktop Left",
-                    "type": "Button",
-                    "id": "e030056a-bc4b-4cb1-bce1-8acf3cde04c9",
-                    "expectedControlType": "",
-                    "processors": "",
-                    "interactions": "",
-                    "initialStateCheck": false
-                },
-                {
-                    "name": "Desktop Right",
-                    "type": "Button",
-                    "id": "993c2420-16b9-4f6c-83f9-3b9ce0eb4edc",
-                    "expectedControlType": "",
-                    "processors": "",
-                    "interactions": "",
-                    "initialStateCheck": false
-                },
-                {
                     "name": "Pointer Position",
                     "type": "Value",
                     "id": "1a52cb69-ee91-40d3-92fb-452be4a39647",
@@ -314,6 +296,83 @@
                     "action": "Look Delta",
                     "isComposite": false,
                     "isPartOfComposite": false
+                },
+                {
+                    "name": "IJKL",
+                    "id": "3fd3dff6-cec4-474e-afef-5d1d271d8914",
+                    "path": "Dpad",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Look Delta",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "up",
+                    "id": "51f1a2fe-df15-4c63-9ca9-5c7dedd8b1fa",
+                    "path": "<Keyboard>/i",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "All",
+                    "action": "Look Delta",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "down",
+                    "id": "c22f22f7-21df-4823-aa6d-72b010e8ce3a",
+                    "path": "<Keyboard>/k",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "All",
+                    "action": "Look Delta",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "left",
+                    "id": "d873943d-9125-47cf-ab81-d362f918a0ab",
+                    "path": "<Keyboard>/j",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "All",
+                    "action": "Look Delta",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "left",
+                    "id": "e813f13e-0fd7-4197-b61c-dcd1a7d5fb5b",
+                    "path": "<Keyboard>/comma",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "All",
+                    "action": "Look Delta",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "right",
+                    "id": "f10ccab4-8fab-44ac-beab-cf087f2a10d0",
+                    "path": "<Keyboard>/l",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "All",
+                    "action": "Look Delta",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "right",
+                    "id": "cdbdbce8-383b-4d95-99c6-332c6b25abba",
+                    "path": "<Keyboard>/period",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "All",
+                    "action": "Look Delta",
+                    "isComposite": false,
+                    "isPartOfComposite": true
                 },
                 {
                     "name": "",
@@ -554,28 +613,6 @@
                     "processors": "",
                     "groups": "",
                     "action": "MiddleMouse",
-                    "isComposite": false,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "",
-                    "id": "20839d3c-32aa-4639-851e-33a180379edd",
-                    "path": "<Keyboard>/comma",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": ";All",
-                    "action": "Desktop Left",
-                    "isComposite": false,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "",
-                    "id": "8ffec8d5-370f-450c-a506-664aa9124a55",
-                    "path": "<Keyboard>/period",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": ";All",
-                    "action": "Desktop Right",
                     "isComposite": false,
                     "isPartOfComposite": false
                 },

--- a/Basis/Packages/com.basis.framework/Device Management/Devices/Desktop/BasisLocalInputActions.cs
+++ b/Basis/Packages/com.basis.framework/Device Management/Devices/Desktop/BasisLocalInputActions.cs
@@ -47,15 +47,12 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
         public InputActionReference MiddleMouseScroll;
         public InputActionReference MiddleMouseScrollClick;
 
-        [Header("Extra Desktop Controls")]
-        public InputActionReference DesktopLeftMove;
-        public InputActionReference DesktopRightMove;
-
         #endregion
 
         [Header("Sensitivity Settings")]
         public float MouseSensitivity = 1f;
         public float JoystickSensitivity = 1f;
+        public float KeyboardSensitivity = 5f;
 
         #region References
 
@@ -173,8 +170,6 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
             RightMousePressed.action.Enable();
             MiddleMouseScroll.action.Enable();
             MiddleMouseScrollClick.action.Enable();
-            DesktopLeftMove.action.Enable();
-            DesktopRightMove.action.Enable();
         }
 
         private void DisableActions()
@@ -194,8 +189,6 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
             RightMousePressed.action.Disable();
             MiddleMouseScroll.action.Disable();
             MiddleMouseScrollClick.action.Disable();
-            DesktopLeftMove.action.Disable();
-            DesktopRightMove.action.Disable();
         }
 
         private void AddCallbacks()
@@ -242,11 +235,6 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
 
             VRSwitch.action.performed += OnSwitchOpenVR;
             XRSwitch.action.performed += OnSwitchOpenXR;
-
-            DesktopLeftMove.action.performed += StartGoingLeft;
-            DesktopLeftMove.action.canceled += StopGoingLeft;
-            DesktopRightMove.action.performed += StartGoingRight;
-            DesktopRightMove.action.canceled += StopGoingRight;
         }
 
         private void RemoveCallbacks()
@@ -293,64 +281,7 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
 
             VRSwitch.action.performed -= OnSwitchOpenVR;
             XRSwitch.action.performed -= OnSwitchOpenXR;
-
-            DesktopLeftMove.action.performed -= StartGoingLeft;
-            DesktopLeftMove.action.canceled -= StopGoingLeft;
-            DesktopRightMove.action.performed -= StartGoingRight;
-            DesktopRightMove.action.canceled -= StopGoingRight;
         }
-
-        #endregion
-
-        #region Movement Helpers
-
-        public void StartGoingLeft(InputAction.CallbackContext ctx) => StartGoingLeft();
-        public void StopGoingLeft(InputAction.CallbackContext ctx) => StopGoingLeft();
-        public void StartGoingRight(InputAction.CallbackContext ctx) => StartGoingRight();
-        public void StopGoingRight(InputAction.CallbackContext ctx) => StopGoingRight();
-
-        public void StartGoingLeft()
-        {
-            if (BasisInputModuleHandler.Instance.HasHoverONInput == false)
-            {
-                manualMoveVector.x = -1;
-                ApplyManualMovement();
-            }
-        }
-
-        public void StopGoingLeft()
-        {
-            if (manualMoveVector.x < 0) manualMoveVector.x = 0;
-            ApplyManualMovement();
-        }
-        public void StartGoingRight()
-        {
-            if (BasisInputModuleHandler.Instance.HasHoverONInput == false)
-            {
-                manualMoveVector.x = 1;
-                ApplyManualMovement();
-            }
-        }
-
-        public void StopGoingRight()
-        {
-            if (manualMoveVector.x > 0) manualMoveVector.x = 0;
-            ApplyManualMovement();
-        }
-
-        private void ApplyManualMovement()
-        {
-            var lookDelta = manualMoveVector;
-
-            if (IsCrouchHeld)
-            {
-                LocalCharacterDriver.SetCrouchBlendDelta(lookDelta.y);
-                lookDelta.y = 0;
-            }
-
-            DesktopEyeInput?.SetLookRotationVector(lookDelta);
-        }
-
         #endregion
 
         #region Input Action Handlers
@@ -382,7 +313,19 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
 
         public void OnLookActionPerformed(InputAction.CallbackContext ctx)
         {
-            var sensitivity = IsMonoStableInput(ctx.control.device) ? JoystickSensitivity : MouseSensitivity;
+            float sensitivity;
+            if (ctx.control.device is Mouse)
+            {
+                sensitivity = MouseSensitivity;
+            }
+            else if (IsMonoStableInput(ctx.control.device))
+            {
+                sensitivity = JoystickSensitivity;
+            }
+            else
+            {
+                sensitivity = KeyboardSensitivity;
+            }
             OnLookAction(ctx.ReadValue<Vector2>(), sensitivity);
         }
         public void OnLookAction(Vector2 delta, float sensitivity)
@@ -397,7 +340,6 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
                 LocalCharacterDriver.SetCrouchBlendDelta(lookDelta.y);
                 lookDelta.y = 0;
             }
-
             DesktopEyeInput?.SetLookRotationVector(lookDelta);
         }
 

--- a/Basis/Packages/com.basis.sdk/Prefabs/Boot/BasisFramework.prefab
+++ b/Basis/Packages/com.basis.sdk/Prefabs/Boot/BasisFramework.prefab
@@ -485,10 +485,9 @@ MonoBehaviour:
   RightMousePressed: {fileID: -240064975923332847, guid: 5e4c3601c6a155f43af19da3bdd35a64, type: 3}
   MiddleMouseScroll: {fileID: 3017921969231114889, guid: 5e4c3601c6a155f43af19da3bdd35a64, type: 3}
   MiddleMouseScrollClick: {fileID: -4813832520851000306, guid: 5e4c3601c6a155f43af19da3bdd35a64, type: 3}
-  DesktopLeftMove: {fileID: 405334284703550776, guid: 5e4c3601c6a155f43af19da3bdd35a64, type: 3}
-  DesktopRightMove: {fileID: -8048210062446332474, guid: 5e4c3601c6a155f43af19da3bdd35a64, type: 3}
   MouseSensitivity: 1
   JoystickSensitivity: 1
+  KeyboardSensitivity: 5
   Input: {fileID: 297858091515769489}
   InputState:
     gripButton: 0


### PR DESCRIPTION
Take 2 of https://github.com/BasisVR/Basis/pull/423

Basis already had the <kbd>,</kbd> comma and <kbd>.</kbd> period keys bound to rotating the desktop player left/right. However, there was no way to rotate up and down with the keyboard.

This PR updates this code to allow up/down as well. The existing <kbd>,</kbd> comma and <kbd>.</kbd> period keys have been kept, and now <kbd>I</kbd>, <kbd>J</kbd>, <kbd>K</kbd>, and <kbd>L</kbd> keys have been added for up/left/down/right respectively. The pattern these are laid out in mimics WASD, just on the right side of the keyboard.

https://github.com/user-attachments/assets/87cfbd29-fb19-404a-82fb-5ca8276a74cb

