### PR TITLE
Avatar List Page UI fixes

### DIFF
--- a/Basis/Packages/com.basis.framework/BasisUI/Elements/PanelAvatarList.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Elements/PanelAvatarList.cs
@@ -319,8 +319,8 @@ namespace Basis.BasisUI
 
             WindowsIcon.SetActive(false);
             MacIcon.SetActive(false);
-            AndroidIcon.SetActive(false);
             LinuxIcon.SetActive(false);
+            AndroidIcon.SetActive(false);
             IOSIcon.SetActive(false);
 
             NewAvatarPanel.Hide();
@@ -384,8 +384,8 @@ namespace Basis.BasisUI
 
             WindowsIcon.SetActive(false);
             MacIcon.SetActive(false);
-            AndroidIcon.SetActive(false);
             LinuxIcon.SetActive(false);
+            AndroidIcon.SetActive(false);
             IOSIcon.SetActive(false);
 
             foreach (string platform in platforms)
@@ -399,10 +399,10 @@ namespace Basis.BasisUI
                         MacIcon.SetActive(true);
                         break;
                     case "StandaloneLinux64":
-                        AndroidIcon.SetActive(true);
+                        LinuxIcon.SetActive(true);
                         break;
                     case "Android":
-                        LinuxIcon.SetActive(true);
+                        AndroidIcon.SetActive(true);
                         break;
                     case "iOS":
                         IOSIcon.SetActive(true);

--- a/Basis/Packages/com.basis.framework/BasisUI/Elements/PanelAvatarList.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Elements/PanelAvatarList.cs
@@ -318,8 +318,10 @@ namespace Basis.BasisUI
             AvatarPasswordField.SetPassword(string.Empty);
 
             WindowsIcon.SetActive(false);
+            MacIcon.SetActive(false);
             AndroidIcon.SetActive(false);
             LinuxIcon.SetActive(false);
+            IOSIcon.SetActive(false);
 
             NewAvatarPanel.Hide();
         }
@@ -381,8 +383,10 @@ namespace Basis.BasisUI
                 .Select(pair => pair.Platform).ToArray();
 
             WindowsIcon.SetActive(false);
+            MacIcon.SetActive(false);
             AndroidIcon.SetActive(false);
             LinuxIcon.SetActive(false);
+            IOSIcon.SetActive(false);
 
             foreach (string platform in platforms)
             {
@@ -391,7 +395,7 @@ namespace Basis.BasisUI
                     case "StandaloneWindows64":
                         WindowsIcon.SetActive(true);
                         break;
-                    case "StandaloineOSX":
+                    case "StandaloneOSX":
                         MacIcon.SetActive(true);
                         break;
                     case "StandaloneLinux64":
@@ -400,7 +404,7 @@ namespace Basis.BasisUI
                     case "Android":
                         LinuxIcon.SetActive(true);
                         break;
-                    case "IOS":
+                    case "iOS":
                         IOSIcon.SetActive(true);
                         break;
                 }

--- a/Basis/Packages/com.basis.framework/BasisUI/Elements/PanelAvatarList.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Elements/PanelAvatarList.cs
@@ -373,7 +373,7 @@ namespace Basis.BasisUI
             }
             else
             {
-                creationDate = DateTime.Parse(creationDate).ToString(CultureInfo.InvariantCulture);
+                creationDate = DateTime.Parse(creationDate, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal).ToString(CultureInfo.InvariantCulture);
                 creationDate += " UTC";
             }
 

--- a/Basis/Packages/com.basis.sdk/Prefabs/Panel Elements/Avatar List Page.prefab
+++ b/Basis/Packages/com.basis.sdk/Prefabs/Panel Elements/Avatar List Page.prefab
@@ -1776,7 +1776,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 223, y: -121.7486}
+  m_AnchoredPosition: {x: 223, y: -85.81}
   m_SizeDelta: {x: 446, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2264348884499747338
@@ -2247,7 +2247,7 @@ MonoBehaviour:
     m_Right: 0
     m_Top: 0
     m_Bottom: 15
-  m_ChildAlignment: 3
+  m_ChildAlignment: 0
   m_Spacing: 6
   m_ChildForceExpandWidth: 0
   m_ChildForceExpandHeight: 0
@@ -2883,7 +2883,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 223, y: -84.2886}
+  m_AnchoredPosition: {x: 223, y: -48.35}
   m_SizeDelta: {x: 446, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2095707598414003572
@@ -5824,7 +5824,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 223, y: -48.038597}
+  m_AnchoredPosition: {x: 223, y: -12.1}
   m_SizeDelta: {x: 446, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6646175121151104793
@@ -6426,6 +6426,10 @@ PrefabInstance:
     - target: {fileID: 7791356704880322332, guid: 03d5ffb0d97cf6244a79f2492ee2a81d, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8724686253533481963, guid: 03d5ffb0d97cf6244a79f2492ee2a81d, type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/Basis/Packages/com.basis.sdk/Prefabs/Panel Elements/Avatar List Page.prefab
+++ b/Basis/Packages/com.basis.sdk/Prefabs/Panel Elements/Avatar List Page.prefab
@@ -6427,10 +6427,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8724686253533481963, guid: 03d5ffb0d97cf6244a79f2492ee2a81d, type: 3}
-      propertyPath: m_IsActive
-      value: 1
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []


### PR DESCRIPTION
This PR brings together a collection of enhancements and fixes to provide a consistent experience with the OS platform support identification across avatars in the Basis framework.

- [fix: mac platform typo and missing false statements](https://github.com/BasisVR/Basis/commit/9da45edd4974cdf04b22db1dd7fde0ab5cc592c5)
- [feat: upper left align on avatar text field](https://github.com/BasisVR/Basis/pull/492/commits/4f9c0bf662fa664ec6ec49bd7bdea96bc4cb63e2)
- [feat: upper left child alignment for avatar description content](https://github.com/BasisVR/Basis/commit/b6f157a21fd82fe944bf7a29a65efeb6a4692cb4) (reverts unnecessary change)
- [fix: linux and android platform references swapped](https://github.com/BasisVR/Basis/pull/492/commits/c2caae5d364010480a97c3e304755a5f9a44aadb)
- [fix: updated creationDate to use UTC](https://github.com/BasisVR/Basis/pull/492/commits/02a45554ba997b933a086f7f92fadaa49843a2ed)

<img width="798" height="359" alt="image" src="https://github.com/user-attachments/assets/9f5d985f-175a-4d6b-8458-56571b0deb59" />

<img width="783" height="354" alt="image" src="https://github.com/user-attachments/assets/82dd9f4d-1c40-48b5-ab88-9a704a953c4f" />
