### PR TITLE
use animator transform for PoseHandler in remote players

### DIFF
--- a/Basis/Packages/com.basis.framework/Avatar/BasisAvatarFactory.cs
+++ b/Basis/Packages/com.basis.framework/Avatar/BasisAvatarFactory.cs
@@ -301,6 +301,7 @@ namespace Basis.Scripts.Avatar
             Player.IsConsideredFallBackAvatar = isFallback;
             Player.BasisAvatar = avatar;
             Player.AvatarTransform = avatar.transform;
+            Player.AvatarAnimatorTransform = avatar.Animator.transform;
             Player.BasisAvatar.Renders = avatar.GetComponentsInChildren<Renderer>(true);
             Player.BasisAvatar.IsOwnedLocally = Player.IsLocal;
 

--- a/Basis/Packages/com.basis.framework/Networking/BasisNetworkPlayer.cs
+++ b/Basis/Packages/com.basis.framework/Networking/BasisNetworkPlayer.cs
@@ -104,7 +104,7 @@ namespace Basis.Scripts.Networking.NetworkedAvatar
                 // All checks pas
                 PoseHandler = new HumanPoseHandler(
                     basisAvatar.Animator.avatar,
-                    basisAvatar.Animator.transform
+                    Player.AvatarAnimatorTransform
                 );
                // PoseHandler.GetHumanPose(ref HumanPose);
                 basisAvatar.LinkedPlayerID = playerId;

--- a/Basis/Packages/com.basis.framework/Networking/BasisNetworkPlayer.cs
+++ b/Basis/Packages/com.basis.framework/Networking/BasisNetworkPlayer.cs
@@ -104,7 +104,7 @@ namespace Basis.Scripts.Networking.NetworkedAvatar
                 // All checks pas
                 PoseHandler = new HumanPoseHandler(
                     basisAvatar.Animator.avatar,
-                    Player.AvatarTransform
+                    basisAvatar.Animator.transform
                 );
                // PoseHandler.GetHumanPose(ref HumanPose);
                 basisAvatar.LinkedPlayerID = playerId;

--- a/Basis/Packages/com.basis.framework/Players/Common/BasisPlayer.cs
+++ b/Basis/Packages/com.basis.framework/Players/Common/BasisPlayer.cs
@@ -65,6 +65,11 @@ namespace Basis.Scripts.BasisSdk.Players
         public Transform AvatarTransform;
 
         /// <summary>
+        /// Transform of the avatar's animator component
+        /// </summary>
+        public Transform AvatarAnimatorTransform;
+
+        /// <summary>
         /// Cached self transform for quick access.
         /// </summary>
         public Transform PlayerSelf; // yes caching myself is faster.


### PR DESCRIPTION
My avatar's animator is a child of the `BasisAvatar` component, which does not seem like it should be unsupported according to the docs and some comments I found in the code.

I changed the PoseHandler to reference the animator's transform (instead of the root transform of BasisAvatar) which seems to align with the [code on the sender side](https://github.com/BasisVR/Basis/blob/6795bd3eadfe4bdedfe57398329571e58ffd2493/Basis/Packages/com.basis.framework/Networking/NetworkedAvatar/BasisNetworkAvatarCompressor.cs#L51-L52).

I only tested this fix in desktop mode but before the change, the avatar was stuck in T-Pose at origin on remote clients, and after the change, it seemed to work normally.
