### PR TITLE
AGC improvements for LocalMicrophoneDriver

### DIFF
--- a/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalMicrophoneDriver.cs
+++ b/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalMicrophoneDriver.cs
@@ -64,6 +64,8 @@ public static class BasisLocalMicrophoneDriver
     private static int warmupSamples = 0;
     private static bool inWarmup = false;
     private static float agcGainDb = 0f;
+
+    private static float _agcHoldTimer = 0f;
     private static float[] _denoiseDry;
     private static float[] _tmp480;
 
@@ -603,11 +605,27 @@ public static class BasisLocalMicrophoneDriver
     {
         if (frameRms <= 1e-6f) frameRms = 1e-6f;
 
+        if (_agcHoldTimer > 0f) _agcHoldTimer -= 0.02f;
+
+        // Skip updating gain if the sound is too quiet
+        if (frameRms < 0.003f) return;
+
         float neededDb = 20f * Mathf.Log10(Mathf.Max(1e-6f, targetRms) / frameRms);
         neededDb = Mathf.Clamp(neededDb, -maxGainDb, maxGainDb);
 
-        float k = (neededDb > agcGainDb) ? Mathf.Clamp01(attack) : Mathf.Clamp01(release);
-        agcGainDb = Mathf.Lerp(agcGainDb, neededDb, k);
+        // The timer provides a cooldown period when the audio hits a new peak volume before applying additional correction.
+        if (neededDb < agcGainDb)
+        {
+            agcGainDb = Mathf.Lerp(agcGainDb, neededDb, Mathf.Clamp01(attack));
+            _agcHoldTimer = 0.4f;
+        }
+        else
+        {
+            if (_agcHoldTimer <= 0f)
+            {
+                agcGainDb = Mathf.Lerp(agcGainDb, neededDb, Mathf.Clamp01(release));
+            }
+        }
     }
 
     private static void CreateOrResizeArray(int length, ref float[] arr)

--- a/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalMicrophoneDriver.cs
+++ b/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalMicrophoneDriver.cs
@@ -616,11 +616,14 @@ public static class BasisLocalMicrophoneDriver
 
     private static void UpdateAgc(float frameRms, float targetRms, float maxGainDb, float attack, float release)
     {
+        const float agcDecaySpeed = 0.020f; // ProcessFrameSize / 48000;
+        const float agcHoldTime   = 0.400f;
+
         if (frameRms <= 1e-6f) frameRms = 1e-6f;
 
-        if (_agcHoldTimer > 0f) _agcHoldTimer -= 0.02f;
+        if (_agcHoldTimer > 0f) _agcHoldTimer -= agcDecaySpeed;
 
-        // Skip updating gain if the sound is too quiet
+        // Skip updating gain if the sound is too quiet (below -50dB)
         if (frameRms < 0.003f) return;
 
         float neededDb = 20f * Mathf.Log10(Mathf.Max(1e-6f, targetRms) / frameRms);
@@ -630,7 +633,7 @@ public static class BasisLocalMicrophoneDriver
         if (neededDb < agcGainDb)
         {
             agcGainDb = Mathf.Lerp(agcGainDb, neededDb, Mathf.Clamp01(attack));
-            _agcHoldTimer = 0.4f;
+            _agcHoldTimer = agcHoldTime;
         }
         else
         {

--- a/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalMicrophoneDriver.cs
+++ b/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalMicrophoneDriver.cs
@@ -65,7 +65,11 @@ public static class BasisLocalMicrophoneDriver
     private static bool inWarmup = false;
     private static float agcGainDb = 0f;
 
+    public const int ProcessFrameSize = 960;  // 20ms at 48kHz
+    public const int DenoiserFrameSize = 480; // 10ms at 48kHz
+
     private static float _agcHoldTimer = 0f;
+
     private static float[] _denoiseDry;
     private static float[] _tmp480;
 
@@ -448,17 +452,17 @@ public static class BasisLocalMicrophoneDriver
         }
 
         int dataLength = GetDataLength(bufferLength, head, posSnapshot);
-        while (dataLength >= SampleRate)
+        while (dataLength >= ProcessFrameSize)
         {
             int remain = bufferLength - head;
-            if (remain < SampleRate)
+            if (remain < ProcessFrameSize)
             {
                 Array.Copy(microphoneBufferArray, head, processBufferArray, 0, remain);
-                Array.Copy(microphoneBufferArray, 0, processBufferArray, remain, SampleRate - remain);
+                Array.Copy(microphoneBufferArray, 0, processBufferArray, remain, ProcessFrameSize - remain);
             }
             else
             {
-                Array.Copy(microphoneBufferArray, head, processBufferArray, 0, SampleRate);
+                Array.Copy(microphoneBufferArray, head, processBufferArray, 0, ProcessFrameSize);
             }
 
             // --- Optional AGC ---
@@ -470,7 +474,7 @@ public static class BasisLocalMicrophoneDriver
                 float agcAmp = DbToAmp(agcGainDb);
                 if (!Mathf.Approximately(agcAmp, 1f))
                 {
-                    for (int i = 0; i < SampleRate; i++)
+                    for (int i = 0; i < ProcessFrameSize; i++)
                         processBufferArray[i] *= agcAmp;
                 }
             }
@@ -498,8 +502,8 @@ public static class BasisLocalMicrophoneDriver
                 Interlocked.Exchange(ref _scheduleMainHasAudio, 0);
             }
 
-            head = (head + SampleRate) % bufferLength;
-            dataLength -= SampleRate;
+            head = (head + ProcessFrameSize) % bufferLength;
+            dataLength -= ProcessFrameSize;
         }
     }
 
@@ -518,12 +522,13 @@ public static class BasisLocalMicrophoneDriver
     public static float GetRMS()
     {
         double sum = 0.0;
-        for (int i = 0; i < SampleRate; i++)
+        int len = processBufferArray.Length;
+        for (int i = 0; i < len; i++)
         {
             float v = processBufferArray[i];
             sum += v * v;
         }
-        return Mathf.Sqrt((float)(sum / SampleRate));
+        return Mathf.Sqrt((float)(sum / len));
     }
 
     public static int GetDataLength(int len, int h, int pos)
@@ -550,27 +555,24 @@ public static class BasisLocalMicrophoneDriver
         if (_denoiseDry == null || _denoiseDry.Length != processBufferArray.Length)
             CreateOrResizeArray(processBufferArray.Length, ref _denoiseDry);
 
-        Array.Copy(processBufferArray, _denoiseDry, SampleRate);
+        Array.Copy(processBufferArray, _denoiseDry, ProcessFrameSize);
 
-        const int hop = 480;
-        if (SampleRate == hop)
-        {
-            Denoiser?.Denoise(processBufferArray);
-        }
-        else
-        {
-            if (_tmp480 == null || _tmp480.Length != hop) _tmp480 = new float[hop];
+        int offset = 0;
 
-            int o = 0;
-            while (o < SampleRate)
-            {
-                int n = Math.Min(hop, SampleRate - o);
-                Array.Clear(_tmp480, 0, hop);
-                Array.Copy(processBufferArray, o, _tmp480, 0, n);
-                Denoiser?.Denoise(_tmp480);
-                Array.Copy(_tmp480, 0, processBufferArray, o, n);
-                o += n;
-            }
+        while (offset < ProcessFrameSize)
+        {
+            // Copy from process buffer to denoiser buffer
+            // Todo: This is a little fragile since it relies on DenoiserFrameSize being 480
+            if (_tmp480 == null || _tmp480.Length != DenoiserFrameSize)
+                _tmp480 = new float[DenoiserFrameSize];
+
+            Array.Copy(processBufferArray, offset, _tmp480, 0, DenoiserFrameSize);
+
+            Denoiser?.Denoise(_tmp480);
+
+            Array.Copy(_tmp480, 0, processBufferArray, offset, DenoiserFrameSize);
+
+            offset += DenoiserFrameSize;
         }
 
         float makeup = DbToAmp(s.DenoiseMakeupDb);
@@ -578,7 +580,7 @@ public static class BasisLocalMicrophoneDriver
 
         if (!Mathf.Approximately(wet, 1f) || !Mathf.Approximately(s.DenoiseMakeupDb, 0f))
         {
-            for (int i = 0; i < SampleRate; i++)
+            for (int i = 0; i < ProcessFrameSize; i++)
             {
                 float den = processBufferArray[i] * makeup;
                 processBufferArray[i] = Mathf.Lerp(_denoiseDry[i], den, wet);
@@ -588,10 +590,21 @@ public static class BasisLocalMicrophoneDriver
 
     public static void RollingRMS()
     {
-        float rms = GetRMS();
-        rmsValues[rmsIndex] = rms;
+        double sumSq = 0.0;
+        int len = processBufferArray.Length;
+        for (int i = 0; i < len; i++)
+        {
+            float v = processBufferArray[i];
+            sumSq += v * v;
+        }
+        float currentMeanSq = (float)(sumSq / len);
+
+        rmsValues[rmsIndex] = currentMeanSq;
         rmsIndex = (rmsIndex + 1) % LocalOpusSettings.rmsWindowSize;
-        averageRms = rmsValues.Average();
+
+        float averagePower = rmsValues.Average();
+
+        averageRms = Mathf.Sqrt(averagePower);
     }
 
     public static bool IsTransmitWorthy()


### PR DESCRIPTION
Changes:
* Add a noise floor to AGC. When the mic is inactive, the AGC update is skipped, preventing it from automatically increasing the gain correction when the user stop talking. 
* Added a hold timer to AGC. Reduces gain immediately when audio peaks (attack). If the volume is low, it waits for a 0.4s cooldown (hold) before gradually increasing the gain again (release).
* Only process a small portion of the incoming sound buffer, rather than the entire buffer. With a buffer the size of the sample rate, AGC would take 1 second to update. By performing AGC on a smaller chunk, the changes can take effect much faster. 
* This change also updates denoising to use the smaller buffer.
* RollingRMS was corrected to not average the values directly (which is incorrect as RMS is a non-linear scale) and instead average the power/mean square before taking the sqrt.