### PR TITLE
Set LocalPlayerIsConnected before firing player joined events

### DIFF
--- a/Basis/Packages/com.basis.framework/Networking/BasisNetworkConnection.cs
+++ b/Basis/Packages/com.basis.framework/Networking/BasisNetworkConnection.cs
@@ -176,10 +176,10 @@ namespace Basis.Scripts.Networking
 
                     transmitter.Initialize();
 
+                    LocalPlayerIsConnected = true;
+
                     BasisNetworkPlayer.OnLocalPlayerJoined?.Invoke(transmitter, BasisLocalPlayer.Instance);
                     BasisNetworkPlayer.OnPlayerJoined?.Invoke(transmitter);
-
-                    LocalPlayerIsConnected = true;
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
[`BasisNetworkBehaviour` expects `LocalPlayerIsConnected` to be set before `OnLocalPlayerJoined` is fired](https://github.com/BoatFloater/Basis/blob/3e2e4d67f28ffac5e32fa7952f92711123409974/Basis/Packages/com.basis.framework/Networking/BasisNetworkBehaviour/BasisNetworkBehaviour.cs#L72-L76)

It does seem like the appropriate order.
