### PR TITLE
use .net10 for docker build

### DIFF
--- a/Basis Server/Docker/Dockerfile
+++ b/Basis Server/Docker/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the server
-FROM mcr.microsoft.com/dotnet/sdk:9.0-bookworm-slim AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0-noble AS build
 WORKDIR /src
 
 # Copy the entire server project (including .props, Contrib, LiteNetLib, etc.)
@@ -12,13 +12,13 @@ RUN dotnet restore ./BasisNetworkConsole.csproj
 RUN dotnet publish -c Release --no-restore -o /app/publish
 
 # Stage 2: Create runtime image
-FROM mcr.microsoft.com/dotnet/runtime:9.0-bookworm-slim
+FROM mcr.microsoft.com/dotnet/runtime:10.0-noble
 
 # Install Curl for healthcheck
 RUN apt-get update && \
     apt-get install -y --no-install-recommends curl && \
     rm -rf /var/lib/apt/lists/*
-    
+
 WORKDIR /app
 
 # Copy the published output
@@ -40,4 +40,4 @@ EXPOSE ${HealthCheckPort}/tcp
 EXPOSE ${PromethusPort}/tcp
 
 # Run the server
-ENTRYPOINT ["dotnet", "BasisNetworkConsole.dll"] 
+ENTRYPOINT ["dotnet", "BasisNetworkConsole.dll"]


### PR DESCRIPTION
I missed this in my last PR; the Docker build needs to be 10.0 as well.

The `bookworm-slim` variant is no longer provided for .net SDK 10; here is the new list:
* https://github.com/dotnet/dotnet-docker/discussions/6539

I chose `10.0-noble` for maximum compatibility
