### PR TITLE
organize CilboxSceneBasis, add CilboxPropBasis, modify BasisLocalPlayer

### DIFF
--- a/Basis/Packages/com.basis.framework/Players/Local/BasisLocalPlayer.cs
+++ b/Basis/Packages/com.basis.framework/Players/Local/BasisLocalPlayer.cs
@@ -30,7 +30,7 @@ namespace Basis.Scripts.BasisSdk.Players
         /// <summary>
         /// Singleton-like reference to the active local player instance.
         /// </summary>
-        public static BasisLocalPlayer Instance;
+        public static BasisLocalPlayer Instance { get; private set; }
 
         /// <summary>
         /// True when the local player has completed initialization and is ready for interaction.
@@ -276,6 +276,17 @@ namespace Basis.Scripts.BasisSdk.Players
                 BasisDebug.Log("failed to load last used : url was not found on disc", BasisDebug.LogTag.Avatar);
                 await CreateAvatar(LoadModeLocal, BasisAvatarFactory.LoadingAvatar);
             }
+        }
+
+        /// <summary>
+        /// Retrieves the current world position and rotation of the local player.
+        /// </summary>
+        /// <param name="position"></param>
+        /// <param name="rotation"></param>
+        public void GetPositionAndRotation(out Vector3 position, out Quaternion rotation)
+        {
+            position = this.transform.position;
+            rotation = this.transform.rotation;
         }
 
         /// <summary>

--- a/Basis/Packages/com.basis.sdk/Settings/PropContentPoliceSelector.asset
+++ b/Basis/Packages/com.basis.sdk/Settings/PropContentPoliceSelector.asset
@@ -336,7 +336,7 @@ MonoBehaviour:
   - Basis.Scripts.Vehicles.Parts.BasisVehicleHoverThruster
   - ExampleMovingChair
   - ExampleRotatingChair
-  - Cilbox.CilboxScene
+  - Cilbox.CilboxPropBasis
   - BasisNetworkedVehicles
   - Basis.Scripts.Vehicles.Parts.BasisVehicleSteeringWheel
   - Basis.Scripts.Vehicles.Parts.BasisVehicleEngineAudio

--- a/Basis/Packages/com.basis.shim/Shims/CilboxPropBasis.cs
+++ b/Basis/Packages/com.basis.shim/Shims/CilboxPropBasis.cs
@@ -5,41 +5,20 @@ using System.Collections.Specialized;
 using System.Collections;
 using System.Runtime.InteropServices;
 using System.Reflection;
-using Basis.Scripts.BasisSdk.Players;
 using Cilbox;
 
 namespace Cilbox
 {
 	[CilboxTarget]
-	public class CilboxSceneBasis : Cilbox
+	public class CilboxPropBasis : Cilbox
 	{
 		static HashSet<String> whiteListType = new HashSet<String>(){
 			// Basis types
-			"Basis.BasisImageDownloader",
-			"Basis.BasisInteractableShim",
-			"Basis.BasisInteractableShim+ClickEvent",
-			"Basis.BasisNetworkBehaviour",
-			"Basis.BasisNetworkShim",
-			"Basis.BasisNetworkShim+NetworkMessageEvent",
-			"Basis.BasisNetworkShim+NetworkReadyEvent",
-			"Basis.BasisNetworkShim+OwnershipTransferEvent",
-			"Basis.BasisNetworkShim+PlayerJoinedEvent",
-			"Basis.BasisNetworkShim+PlayerLeftEvent",
-			"Basis.BasisNetworkShim+ServerOwnershipDestroyedEvent",
-			"Basis.BasisUrl",
-			"Basis.IBasisImageDownload",
-			"Basis.Network.Core.DeliveryMethod",
-			"Basis.SafeUtil",
-			"Basis.Scripts.BasisSdk.Players.BasisLocalPlayer",
-			"Basis.Scripts.Networking.NetworkedAvatar.BasisNetworkPlayer",
-			"BasisSDKMirror",
-			"BasisSDKMirror+MirrorClearFlags",
 
 			// Cilbox types
 			"Cilbox.CilboxPublicUtils",
 
 			// System types
-			"System.Action",
 			"System.Array",
 			"System.BitConverter", // HMMMMMMMMM SUSSY
 			"System.Boolean",
@@ -49,18 +28,12 @@ namespace Cilbox
 			"System.Convert", // HMMMMMMMMM SUSSY
 			"System.DateTime",
 			"System.DayOfWeek",
-			"System.Delegate",
 			"System.Diagnostics.Stopwatch",
 			"System.Double",
 			"System.Exception",
-			"System.IDisposable",
 			"System.Int16",
 			"System.Int32",
 			"System.Int64",
-			"System.IO.BinaryReader",
-			"System.IO.BinaryWriter",
-			"System.IO.MemoryStream",
-			"System.IO.Stream",
 			"System.Math",
 			"System.MathF",
 			"System.Object",
@@ -77,33 +50,23 @@ namespace Cilbox
 			// Unity types
 			"UnityEngine.AudioClip",
 			"UnityEngine.AudioSource",
-			"UnityEngine.Behaviour",
 			"UnityEngine.Color",
 			"UnityEngine.Component",
-			"UnityEngine.CustomRenderTexture",
 			"UnityEngine.Debug",
-			"UnityEngine.DynamicGI",
 			"UnityEngine.Events.UnityAction",
 			"UnityEngine.Events.UnityEvent",
 			"UnityEngine.GameObject",     // Hyper restrictive.
-			"UnityEngine.Gradient",
-			"UnityEngine.Light",
 			"UnityEngine.Material",
 			"UnityEngine.MaterialPropertyBlock",
 			"UnityEngine.Mathf",
 			"UnityEngine.MeshRenderer",
 			"UnityEngine.MonoBehaviour",   // Note this is needed for the 'ctor, but we can be very restrictive.
 			"UnityEngine.Object",
-			"UnityEngine.Quaternion",
 			"UnityEngine.Random",
 			"UnityEngine.Renderer",
-			"UnityEngine.Rendering.AmbientMode",
-			"UnityEngine.RenderSettings",
-			"UnityEngine.Shader",
 			"UnityEngine.TextAsset",
 			"UnityEngine.Texture",
 			"UnityEngine.Texture2D",
-			"UnityEngine.Texture2DArray",
 			"UnityEngine.Time",
 			"UnityEngine.Transform",
 			"UnityEngine.UI.Button",
@@ -114,10 +77,9 @@ namespace Cilbox
 			"UnityEngine.UI.Selectable",
 			"UnityEngine.UI.Slider",
 			"UnityEngine.UI.Text",
-			"UnityEngine.Vector2",
 			"UnityEngine.Vector3",
 			"UnityEngine.Vector4",
-        };
+		};
 
 		static HashSet<String> whiteListFields = new HashSet<String>(){
 			// Unity fields
@@ -145,16 +107,12 @@ namespace Cilbox
 
 		// Whitelist methods on native types.
 		// If a type is not in this dictionary, then all methods are allowed.
-		static Dictionary<Type, HashSet<string>> whiteListMethods = new Dictionary<Type, HashSet<string>>()
+		static Dictionary<Type, HashSet<string>> methodWhitelist = new Dictionary<Type, HashSet<string>>()
 		{
 			{ typeof(UnityEngine.MonoBehaviour),       new HashSet<string>{ ".ctor" } },
 			{ typeof(UnityEngine.Events.UnityAction),  new HashSet<string>{ ".ctor" } },
 			{ typeof(UnityEngine.GameObject),          new HashSet<string>{ nameof(GameObject.SetActive), nameof(GameObject.GetComponents) } },
 			{ typeof(System.Type),                     new HashSet<string>() }, // nothing allowed
-			{ typeof(BasisLocalPlayer), new HashSet<string>{ nameof(BasisLocalPlayer.GetPositionAndRotation),
-				nameof(BasisLocalPlayer.Teleport),
-				nameof(BasisLocalPlayer.Respawn),
-				$"get_{nameof(BasisLocalPlayer.Instance)}", }},
 		};
 
 		// After a type is allowed, this is called to see if the specific method is OK.
@@ -164,7 +122,7 @@ namespace Cilbox
 
 			if( name.Contains( "Invoke" ) ) return false;
 
-			if( whiteListMethods.TryGetValue( declaringType, out var allowed ) )
+			if( methodWhitelist.TryGetValue( declaringType, out var allowed ) )
 			{
 				if( !allowed.Contains( name ) ) return false;
 			}

--- a/Basis/Packages/com.basis.shim/Shims/CilboxPropBasis.cs.meta
+++ b/Basis/Packages/com.basis.shim/Shims/CilboxPropBasis.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ad0be8d14210ca945bf03d4e12a72861


### PR DESCRIPTION
A few cilbox related changes in this PR.

* CilboxSceneBasis
  * I sorted all the types allowed. This should make it easier to edit and review the whitelist (well, after this PR..)
  * The only actual change to the whitelist is BasisLocalPlayer with tight restrictions:
    * `GetPositionAndRotation`, `Teleport`, `Respawn`, `get_Instance`
* CilboxPropBasis
  * I saw that the content police for props currently reference the `CilboxScene` from the Cilbox package, but it's probably better to control the rules internally to the Basis project, so I created `CilboxPropBasis` with the exact rules from `CilboxScene` unchanged.
* PropContentPoliceSelector
  * Reference `CilboxPropBasis` instead of `CilboxScene`
* BasisLocalPlayer
  * Add GetPositionAndRotation
  * Change `Instance` from a field to a field accessor with private setter
    * Generally this is source-compatible but binary incompatible, so I can approach this another way if you'd like.