### PR TITLE
Removed unnecessary vector scale modifier

### DIFF
--- a/Basis/Assets/Basis/Settings/InputActions/InputAction.inputactions
+++ b/Basis/Assets/Basis/Settings/InputActions/InputAction.inputactions
@@ -278,7 +278,7 @@
                     "id": "c1f7a91b-d0fd-4a62-997e-7fb9b69bf235",
                     "path": "<Gamepad>/rightStick",
                     "interactions": "",
-                    "processors": "ScaleVector2(x=25,y=25),StickDeadzone",
+                    "processors": "StickDeadzone",
                     "groups": ";Gamepad;All",
                     "action": "Look Delta",
                     "isComposite": false,


### PR DESCRIPTION
This modifier resulted in the right gamepad joystick only outputting either 0 or it's max value. Removing this brought back the in-between values, and no issues were discovered when doing so.