### PR TITLE
increased timeout for repository checkout and build server steps in compilation workflow

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -60,7 +60,7 @@ jobs:
           docker-images: false
           swap-storage: false
       - name: "Checkout repository"
-        timeout-minutes: 5
+        timeout-minutes: 10
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -191,7 +191,7 @@ jobs:
           - win-x64
     steps:
       - name: "Checkout repository"
-        timeout-minutes: 5
+        timeout-minutes: 10
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -201,7 +201,7 @@ jobs:
         with:
           dotnet-version: "10.0.x"
       - name: "Build server"
-        timeout-minutes: 2
+        timeout-minutes: 10
         run: "dotnet publish '${{ matrix.projectPath }}' -f net10.0 --self-contained --runtime '${{ matrix.runtimes }}' -o build -c Release"
       - name: "Upload server artifact"
         timeout-minutes: 2


### PR DESCRIPTION
As the repo has grown in size, a bunch of CI jobs fail to checkout the repo if not already in cache. This doubles the time to checkout and also the server build.

Fixes failed CI runs like:
- Checkout without cache timeout: https://github.com/BasisVR/Basis/actions/runs/22674463744/job/65727087376
- Server Build timeout: https://github.com/BasisVR/Basis/actions/runs/22678334200/job/65741316276