### PR TITLE
Fix voice volume inconsistency and improve spatialization

### DIFF
--- a/Basis Server/BasisNetworkCore/BasisNetworkCommons.cs
+++ b/Basis Server/BasisNetworkCore/BasisNetworkCommons.cs
@@ -5,7 +5,7 @@ namespace Basis.Network.Core
         /// <summary>
         /// this is the maximum Connections that can occur under the hood.
         /// </summary>
-        public const int MaxConnections = 1024;
+        public const int MaxConnections = ushort.MaxValue;
 
         public const int NetworkIntervalPoll = 2;
         public const int PingInterval = 1500;

--- a/Basis Server/BasisNetworkCore/BasisServerConfiguration.cs
+++ b/Basis Server/BasisNetworkCore/BasisServerConfiguration.cs
@@ -10,7 +10,7 @@ public class Configuration
     public const string ConfigFolderName = "config";
     public const string LogsFolderName = "logs";
     public const string InitialResourcesFolderName = "initialresources";
-    public int PeerLimit = 1024;
+    public int PeerLimit = ushort.MaxValue;
     public ushort SetPort = 4296;
     public bool UseNativeSockets = true;
     public bool NatPunchEnabled = true;

--- a/Basis Server/BasisNetworkCore/Serializable/VoiceReceiversMessage.cs
+++ b/Basis Server/BasisNetworkCore/Serializable/VoiceReceiversMessage.cs
@@ -6,7 +6,7 @@ public static partial class SerializableBasis
     public struct VoiceReceiversMessage
     {
         // Hard cap to avoid giant allocations if data is corrupted
-        private const int MaxUsers = 1024;
+        private const int MaxUsers = ushort.MaxValue;
 
         public ushort[] Users;
 

--- a/Basis Server/BasisNetworkServer/BasisNetworkIDDatabase.cs
+++ b/Basis Server/BasisNetworkServer/BasisNetworkIDDatabase.cs
@@ -32,17 +32,19 @@ namespace BasisNetworkCore
                 // Log that we are assigning a new ID
                 BNL.Log($"No existing ID found for {UniqueStringID}. Assigning a new ID.");
 
-                // Check if we can assign a new ID
-                if (counter >= ushort.MaxValue)
+                // Generate a new unique ushort ID (thread-safe increment)
+                int newCounter = Interlocked.Increment(ref counter);
+
+                // Check if we exceeded the ushort range
+                if (newCounter > ushort.MaxValue)
                 {
-                    // Log and throw an error
+                    Interlocked.Decrement(ref counter); // Roll back
                     string errorMessage = $"Error: Cannot assign a new NetID for {UniqueStringID}. Maximum ID limit of {ushort.MaxValue} reached.";
                     BNL.Log(errorMessage);
                     throw new InvalidOperationException(errorMessage);
                 }
 
-                // Generate a new unique ushort ID
-                ushort newID = (ushort)Interlocked.Increment(ref counter); // Thread-safe increment
+                ushort newID = (ushort)newCounter;
 
                 // Add to the database
                 UshortNetworkDatabase[UniqueStringID] = newID;

--- a/Basis Server/BasisNetworkServer/BasisNetworkingReductionSystem/BasisServerReductionSystemEvents.cs
+++ b/Basis Server/BasisNetworkServer/BasisNetworkingReductionSystem/BasisServerReductionSystemEvents.cs
@@ -45,7 +45,7 @@ namespace BasisNetworkServer.BasisNetworkingReductionSystem
     public partial class BasisServerReductionSystemEvents
     {
         private static readonly CancellationTokenSource cts = new();
-        private static readonly int MaxConcurrentPlayers = 1024;
+        private static readonly int MaxConcurrentPlayers = ushort.MaxValue;
 
         private static readonly ParallelOptions parallelOptions = new()
         {

--- a/Basis Server/BasisNetworkServer/BasisServerHandleEvents.cs
+++ b/Basis Server/BasisNetworkServer/BasisServerHandleEvents.cs
@@ -410,7 +410,7 @@ namespace BasisServerHandle
         {
             try
             {
-                // Fetch all peers into an array (up to 1024)
+                // Fetch all peers into an array
                 NetPeer[] peers = NetworkServer.AuthenticatedPeers.Values.ToArray();
                 NetDataWriter writer = new NetDataWriter(true, 2);
                 foreach (var peer in peers)

--- a/Basis/Packages/com.basis.framework/BasisUI/Menus/Library/ContentLoader.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Menus/Library/ContentLoader.cs
@@ -346,11 +346,9 @@ namespace Basis.BasisUI
                             );
 
 
-                            if(scene != null)
+                            if(scene.IsValid())
                             {
-                                string UniqueID = BasisGenerateUniqueID.GenerateUniqueID();
-
-                                BasisDebug.Log($"Library provider successfully created scene {item.Url} with networking: {desiredNetworkType} with UID = {UniqueID}");
+                                BasisDebug.Log($"Library provider successfully created scene {item.Url} with networking: {desiredNetworkType}");
 
                                 BasisRuntimeSpawnRegistry.AddScene(
                                     item.Url,
@@ -369,6 +367,10 @@ namespace Basis.BasisUI
                                 BasisDebug.LogError($"Library provider failed to create desired scene with networking: {desiredNetworkType} with of url {item.Url}");
                             }
 
+                        }
+                        else
+                        {
+                            BasisDebug.LogError($"LoadWorld local: BasisBundleConnector is null for {item.Url}");
                         }
 
                     break;
@@ -391,6 +393,9 @@ namespace Basis.BasisUI
                             BasisDebug.LogError(ex);
                         }
                     break;
+                    default:
+                        BasisDebug.LogError($"LoadWorld {item.Url} was loaded with an unknown network type of {desiredNetworkType}!");
+                    break;
                 }
             }
             else
@@ -398,7 +403,6 @@ namespace Basis.BasisUI
                 BasisDebug.LogError( $"LoadWorld failed to find the cached meta for url {item.Url}" );
             }
 
-            await Task.CompletedTask;
         }
     }
 }

--- a/Basis/Packages/com.basis.framework/BasisUI/Menus/Library/LibraryProvider.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Menus/Library/LibraryProvider.cs
@@ -1788,7 +1788,7 @@ namespace Basis.BasisUI
 
                             case BasisRuntimeSpawnRegistry.SpawnMode.Scene:
 
-                                if(BasisRuntimeSpawnRegistry.SpawnedScenes.TryGetValue(itemKey.LoadedNetID, out Scene scene) && scene != null)
+                                if(BasisRuntimeSpawnRegistry.SpawnedScenes.TryGetValue(itemKey.LoadedNetID, out Scene scene) && scene.IsValid())
                                 {
                                     bool success = await BasisRuntimeSpawnRegistry.RemoveByLoadedNetId(itemKey.LoadedNetID);
                                     if(success)

--- a/Basis/Packages/com.basis.framework/Networking/BasisNetworkNetIDConversion.cs
+++ b/Basis/Packages/com.basis.framework/Networking/BasisNetworkNetIDConversion.cs
@@ -40,7 +40,7 @@ public static class BasisNetworkIdResolver
         try
         {
             NetDataWriter writer = new NetDataWriter();
-            NetIDMessage requestMessage = new NetIDMessage { UniqueID = stringId };
+            NetIDMessage requestMessage = new NetIDMessage { playerID = stringId };
             requestMessage.Serialize(writer);
 
             BasisNetworkConnection.LocalPlayerPeer.Send(writer, BasisNetworkCommons.netIDAssignChannel, DeliveryMethod.ReliableOrdered);
@@ -84,7 +84,7 @@ public static class BasisNetworkIdResolver
 
     public static void CompleteMessageDelegation(ServerNetIDMessage serverMessage)
     {
-        string stringId = serverMessage.NetIDMessage.UniqueID;
+        string stringId = serverMessage.NetIDMessage.playerID;
         ushort resolvedId = serverMessage.UshortUniqueIDMessage.UniqueIDUshort;
 
         if (string.IsNullOrEmpty(stringId))

--- a/Basis/Packages/com.basis.framework/Networking/Recievers/BasisAudioClipPool.cs
+++ b/Basis/Packages/com.basis.framework/Networking/Recievers/BasisAudioClipPool.cs
@@ -27,7 +27,8 @@ public static class BasisAudioClipPool
         }
         else
         {
-            return AudioClip.Create($"player [{LinkedPlayer}]", RemoteOpusSettings.FrameSize * (2 * 2), RemoteOpusSettings.Channels, AudioSettings.outputSampleRate, false, (buf) =>
+            int clipFrames = Mathf.CeilToInt(SharedOpusSettings.DesiredDurationInSeconds * 4 * AudioSettings.outputSampleRate);
+            return AudioClip.Create($"player [{LinkedPlayer}]", clipFrames, RemoteOpusSettings.Channels, AudioSettings.outputSampleRate, false, (buf) =>
             {
                 Array.Fill(buf, 1.0f);
             });

--- a/Basis/Packages/com.basis.framework/Networking/Recievers/BasisAudioReceiver.cs
+++ b/Basis/Packages/com.basis.framework/Networking/Recievers/BasisAudioReceiver.cs
@@ -508,11 +508,10 @@ namespace Basis.Scripts.Networking.Receivers
             int idx = 0;
             for (int f = 0; f < frames; f++)
             {
-                float sample = _inputScratch[f];
+                float sample = FastClamp(_inputScratch[f]);
                 for (int c = 0; c < channels; c++)
                 {
-                    float v = data[idx] * sample;
-                    data[idx++] = FastClamp(v);
+                    data[idx++] = sample;
                 }
             }
 
@@ -566,11 +565,10 @@ namespace Basis.Scripts.Networking.Receivers
             int idx = 0;
             for (int f = 0; f < frames; f++)
             {
-                float sample = _resampleScratch[f];
+                float sample = FastClamp(_resampleScratch[f]);
                 for (int c = 0; c < channels; c++)
                 {
-                    float v = data[idx] * sample;
-                    data[idx++] = FastClamp(v);
+                    data[idx++] = sample;
                 }
             }
 

--- a/Basis/Packages/com.basis.framework/Networking/Transmitters/BasisAudioTransmission.cs
+++ b/Basis/Packages/com.basis.framework/Networking/Transmitters/BasisAudioTransmission.cs
@@ -56,9 +56,8 @@ namespace Basis.Scripts.Networking.Transmitters
             );
 #endif
 
-            // Example: Configure Opus encoder here (optional)
-            // int complexity = 5;
-            // encoder.Ctl(EncoderCTL.OPUS_SET_COMPLEXITY, ref complexity);
+            encoder.Ctl(EncoderCTL.OPUS_SET_BITRATE, 32000);
+            encoder.Ctl(EncoderCTL.OPUS_SET_COMPLEXITY, 5);
         }
 
         private void AttachMicrophoneEvents()

--- a/Basis/Packages/com.basis.sdk/Prefabs/Players/AudioSource.prefab
+++ b/Basis/Packages/com.basis.sdk/Prefabs/Players/AudioSource.prefab
@@ -209,7 +209,7 @@ MonoBehaviour:
   transmissionHigh: 1
   maxTransmissionSurfaces: 4
   directMixLevel: 1
-  reflections: 1
+  reflections: 0
   reflectionsType: 0
   useDistanceCurveForReflections: 1
   currentBakedSource: {fileID: 0}

--- a/Basis/Packages/com.basis.sdk/Prefabs/Players/AudioSource.prefab
+++ b/Basis/Packages/com.basis.sdk/Prefabs/Players/AudioSource.prefab
@@ -133,8 +133,17 @@ AudioSource:
     m_Curve:
     - serializedVersion: 3
       time: 0
-      value: 0
+      value: 0.194
       inSlope: 0
+      outSlope: -0.194
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: -0.194
       outSlope: 0
       tangentMode: 0
       weightedMode: 0
@@ -189,7 +198,7 @@ MonoBehaviour:
   occlusion: 1
   occlusionInput: 0
   occlusionType: 1
-  occlusionRadius: 1
+  occlusionRadius: 0.15
   occlusionSamples: 16
   occlusionValue: 1
   transmission: 1
@@ -200,7 +209,7 @@ MonoBehaviour:
   transmissionHigh: 1
   maxTransmissionSurfaces: 4
   directMixLevel: 1
-  reflections: 0
+  reflections: 1
   reflectionsType: 0
   useDistanceCurveForReflections: 1
   currentBakedSource: {fileID: 0}

--- a/Basis/Packages/com.basis.server/BasisNetworkCore/BasisNetworkCommons.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkCore/BasisNetworkCommons.cs
@@ -5,7 +5,7 @@ namespace Basis.Network.Core
         /// <summary>
         /// this is the maximum Connections that can occur under the hood.
         /// </summary>
-        public const int MaxConnections = 1024;
+        public const int MaxConnections = ushort.MaxValue;
 
         public const int NetworkIntervalPoll = 2;
         public const int PingInterval = 1500;

--- a/Basis/Packages/com.basis.server/BasisNetworkCore/BasisServerConfiguration.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkCore/BasisServerConfiguration.cs
@@ -10,7 +10,7 @@ public class Configuration
     public const string ConfigFolderName = "config";
     public const string LogsFolderName = "logs";
     public const string InitialResourcesFolderName = "initialresources";
-    public int PeerLimit = 1024;
+    public int PeerLimit = ushort.MaxValue;
     public ushort SetPort = 4296;
     public bool UseNativeSockets = true;
     public bool NatPunchEnabled = true;

--- a/Basis/Packages/com.basis.server/BasisNetworkCore/Serializable/NetIDMessage.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkCore/Serializable/NetIDMessage.cs
@@ -6,14 +6,14 @@ namespace BasisNetworkCore.Serializable
     {
         public struct NetIDMessage
         {
-            public string UniqueID;
+            public string playerID;
 
             public void Deserialize(NetDataReader reader)
             {
                 int bytes = reader.AvailableBytes;
                 if (bytes != 0)
                 {
-                    UniqueID = reader.GetString();
+                    playerID = reader.GetString();
                 }
                 else
                 {
@@ -23,9 +23,9 @@ namespace BasisNetworkCore.Serializable
 
             public void Serialize(NetDataWriter writer)
             {
-                if (!string.IsNullOrEmpty(UniqueID))
+                if (!string.IsNullOrEmpty(playerID))
                 {
-                    writer.Put(UniqueID);
+                    writer.Put(playerID);
                 }
                 else
                 {

--- a/Basis/Packages/com.basis.server/BasisNetworkCore/Serializable/PlayerIdMessage.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkCore/Serializable/PlayerIdMessage.cs
@@ -3,33 +3,15 @@ public static partial class SerializableBasis
 {
     public struct PlayerIdMessage
     {
-        private ushort data; // Encodes both playerID and additional data.
+        public ushort playerID;
 
-        /// <summary>
-        /// 0 to 1023
-        /// </summary>
-        public ushort playerID// (0-1023)
+        public void Deserialize(NetDataReader Reader)
         {
-            get => (ushort)(data & 0x03FF); // Extract the lower 10 bits for PlayerID
-            set => data = (ushort)((data & 0xFC00) | (value & 0x03FF)); // Set PlayerID while preserving upper 6 bits
-        }
-
-        /// <summary>
-        /// 0 to 63
-        /// </summary>
-        public byte AdditionalData// (0–63)
-        {
-            get => (byte)((data >> 10) & 0x3F); // Extract the upper 6 bits for AdditionalData
-            set => data = (ushort)((data & 0x03FF) | ((value & 0x3F) << 10)); // Set AdditionalData while preserving lower 10 bits
-        }
-
-        public void Deserialize(NetDataReader Writer)
-        {
-            Writer.Get(out data); // Read the entire ushort value
+            Reader.Get(out playerID); // Read the entire ushort value
         }
         public void Serialize(NetDataWriter Writer)
         {
-            Writer.Put(data); // Write the entire ushort value
+            Writer.Put(playerID); // Write the entire ushort value
         }
     }
 }

--- a/Basis/Packages/com.basis.server/BasisNetworkCore/Serializable/VoiceReceiversMessage.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkCore/Serializable/VoiceReceiversMessage.cs
@@ -6,7 +6,7 @@ public static partial class SerializableBasis
     public struct VoiceReceiversMessage
     {
         // Hard cap to avoid giant allocations if data is corrupted
-        private const int MaxUsers = 1024;
+        private const int MaxUsers = ushort.MaxValue;
 
         public ushort[] Users;
 

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/BasisNetworkIDDatabase.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/BasisNetworkIDDatabase.cs
@@ -19,7 +19,7 @@ namespace BasisNetworkCore
                 // We already know about it, let's just give it back to that player
                 ServerNetIDMessage SNIM = new ServerNetIDMessage
                 {
-                    NetIDMessage = new NetIDMessage() { UniqueID = UniqueStringID },
+                    NetIDMessage = new NetIDMessage() { playerID = UniqueStringID },
                     UshortUniqueIDMessage = new UshortUniqueIDMessage() { UniqueIDUshort = Value }
                 };
                 NetDataWriter Writer = new NetDataWriter(true);
@@ -32,17 +32,19 @@ namespace BasisNetworkCore
                 // Log that we are assigning a new ID
                 BNL.Log($"No existing ID found for {UniqueStringID}. Assigning a new ID.");
 
-                // Check if we can assign a new ID
-                if (counter >= ushort.MaxValue)
+                // Generate a new unique ushort ID (thread-safe increment)
+                int newCounter = Interlocked.Increment(ref counter);
+
+                // Check if we exceeded the ushort range
+                if (newCounter > ushort.MaxValue)
                 {
-                    // Log and throw an error
+                    Interlocked.Decrement(ref counter); // Roll back
                     string errorMessage = $"Error: Cannot assign a new NetID for {UniqueStringID}. Maximum ID limit of {ushort.MaxValue} reached.";
                     BNL.Log(errorMessage);
                     throw new InvalidOperationException(errorMessage);
                 }
 
-                // Generate a new unique ushort ID
-                ushort newID = (ushort)Interlocked.Increment(ref counter); // Thread-safe increment
+                ushort newID = (ushort)newCounter;
 
                 // Add to the database
                 UshortNetworkDatabase[UniqueStringID] = newID;
@@ -51,7 +53,7 @@ namespace BasisNetworkCore
                 // Notify the requesting peer and broadcast to others
                 ServerNetIDMessage SUIMA = new ServerNetIDMessage
                 {
-                    NetIDMessage = new NetIDMessage() { UniqueID = UniqueStringID },
+                    NetIDMessage = new NetIDMessage() { playerID = UniqueStringID },
                     UshortUniqueIDMessage = new UshortUniqueIDMessage() { UniqueIDUshort = newID }
                 };
                 NetDataWriter Writer = new NetDataWriter(true);
@@ -70,7 +72,7 @@ namespace BasisNetworkCore
             {
                 ServerNetIDMessage SUIM = new ServerNetIDMessage
                 {
-                    NetIDMessage = new NetIDMessage() { UniqueID = pair.Key },
+                    NetIDMessage = new NetIDMessage() { playerID = pair.Key },
                     UshortUniqueIDMessage = new UshortUniqueIDMessage() { UniqueIDUshort = pair.Value }
                 };
                 ServerUniqueIDMessages.Add(SUIM);

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/BasisNetworkingReductionSystem/BasisServerReductionSystemEvents.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/BasisNetworkingReductionSystem/BasisServerReductionSystemEvents.cs
@@ -45,7 +45,7 @@ namespace BasisNetworkServer.BasisNetworkingReductionSystem
     public partial class BasisServerReductionSystemEvents
     {
         private static readonly CancellationTokenSource cts = new();
-        private static readonly int MaxConcurrentPlayers = 1024;
+        private static readonly int MaxConcurrentPlayers = ushort.MaxValue;
 
         private static readonly ParallelOptions parallelOptions = new()
         {

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/BasisServerHandleEvents.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/BasisServerHandleEvents.cs
@@ -322,8 +322,7 @@ namespace BasisServerHandle
 
             audioSegment.playerIdMessage = new PlayerIdMessage
             {
-                playerID = (ushort)sender.Id,
-                AdditionalData = 0
+                playerID = (ushort)sender.Id
             };
 
             var writer = new NetDataWriter(true, 3);
@@ -411,7 +410,7 @@ namespace BasisServerHandle
         {
             try
             {
-                // Fetch all peers into an array (up to 1024)
+                // Fetch all peers into an array
                 NetPeer[] peers = NetworkServer.AuthenticatedPeers.Values.ToArray();
                 NetDataWriter writer = new NetDataWriter(true, 2);
                 foreach (var peer in peers)
@@ -507,7 +506,7 @@ namespace BasisServerHandle
             ServerUniqueIDMessage.Deserialize(Reader);
             Reader.Recycle();
             //returns a message with the ushort back to the client, or it sends it to everyone if its new.
-            BasisNetworkIDDatabase.AddOrFindNetworkID(Peer, ServerUniqueIDMessage.UniqueID);
+            BasisNetworkIDDatabase.AddOrFindNetworkID(Peer, ServerUniqueIDMessage.playerID);
             //we need to convert the string int a  ushort.
         }
         public static void LoadResource(NetPacketReader Reader, NetPeer Peer,string UUID)


### PR DESCRIPTION
## Summary
- **Fix voice attenuation**: Replace multiplicative mixing with direct assignment in `OnAudioFilterRead` — eliminates the carrier clip loop bug that caused some voices to be quieter than others
- **Fix AudioClip sizing**: Calculate clip frame count from device output sample rate instead of hardcoded 48kHz network rate
- **Set Opus encoder params**: Explicit bitrate (32kbps) and complexity (5) so quiet speech gets enough bits
- **Improve spatialization**: Add spread curve (70→0 degrees) to prevent hard L/R panning at close range, reduce occlusion radius from 1m to 0.15m for realistic mouth-sized source

## Test plan
- [ ] Verify voice volume is consistent across multiple players with different microphones
- [ ] Confirm voices no longer drop to near-silence intermittently
- [ ] Test spatial audio: close-range voice should feel wider, not ping-pong L/R
- [ ] Test wall occlusion behavior with reduced radius
- [ ] Verify on a device with non-48kHz output sample rate (e.g. 44100) if possible