### PR TITLE
expose BasisInteractableObject.RequiresUpdateLoop

### DIFF
--- a/Basis/Packages/com.basis.framework/Interactions/BasisInteractableObject.cs
+++ b/Basis/Packages/com.basis.framework/Interactions/BasisInteractableObject.cs
@@ -114,8 +114,7 @@ namespace Basis.Scripts.BasisSdk.Interactions
         /// Flag indicating whether this object requires an update loop
         /// while being influenced by inputs.
         /// </summary>
-        [NonSerialized]
-        internal bool RequiresUpdateLoop = false;
+        public bool RequiresUpdateLoop { get; protected set; } = false;
 
         #region Interaction Events
 


### PR DESCRIPTION
When extending `BasisInteractableObject` in my own application, I need to access `RequiresUpdateLoop`. It is not possible to do so with `internal`, so I made it a property with a public getter and protected setter, which is compatible with the existing implementations in Basis.
