### PR TITLE
don't check lastTarget autoHoldDropped if it was not held

### DIFF
--- a/Basis/Packages/com.basis.framework/Interactions/BasisPlayerInteract.cs
+++ b/Basis/Packages/com.basis.framework/Interactions/BasisPlayerInteract.cs
@@ -351,8 +351,9 @@ namespace Basis.Scripts.BasisSdk.Interactions
                     // Not pressing interact: clear states from last target (if needed), then consider hover on new target.
                     bool removeTarget = false;
 
+                    bool lastTargetIsHeld = interactInput.lastTarget.IsInteractingWith(interactInput.input);
                     bool autoHoldDropped = true;
-                    if (IsDesktopCenterEye(interactInput.input))
+                    if (lastTargetIsHeld && IsDesktopCenterEye(interactInput.input))
                     {
                         autoHoldDropped =
                             interactInput.lastTarget.AutoHold != BasisAutoHold.Yes ||


### PR DESCRIPTION
Fixes a bug where hovering an interactable with AutoHold = Yes blocks hovering other interactables until the drop input is pressed, despite never being picked up.