### PR TITLE
Fix no network data sent for players with reused IDs

### DIFF
--- a/Basis Server/BasisNetworkServer/BasisNetworkingReductionSystem/BasisServerReductionSystemEvents.cs
+++ b/Basis Server/BasisNetworkServer/BasisNetworkingReductionSystem/BasisServerReductionSystemEvents.cs
@@ -204,6 +204,19 @@ namespace BasisNetworkServer.BasisNetworkingReductionSystem
                         }
                     }
 
+
+                    // Clear stale per-player tracking data for the removed ID across all remaining players.
+                    // Without this, when a new player reuses this ID, other players LastSeenGeneration
+                    // would still hold the old (high) generation value, causing the new-data check
+                    // (senderGen > seenGens[jId]) to fail -- no data would be sent for the new player.
+                    foreach (var kvp in playerStates)
+                    {
+                        var otherState = kvp.Value;
+                        if (id < otherState.LastSeenGeneration.Length)
+                            otherState.LastSeenGeneration[id] = 0;
+                        if (id < otherState.LastSentTimes.Length)
+                            otherState.LastSentTimes[id] = 0;
+                    }
                     BNL.Log($"Player {id} removed and cleaned up.");
                 }
                 else

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/BasisNetworkingReductionSystem/BasisServerReductionSystemEvents.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/BasisNetworkingReductionSystem/BasisServerReductionSystemEvents.cs
@@ -204,6 +204,19 @@ namespace BasisNetworkServer.BasisNetworkingReductionSystem
                         }
                     }
 
+
+                    // Clear stale per-player tracking data for the removed ID across all remaining players.
+                    // Without this, when a new player reuses this ID, other players LastSeenGeneration
+                    // would still hold the old (high) generation value, causing the new-data check
+                    // (senderGen > seenGens[jId]) to fail -- no data would be sent for the new player.
+                    foreach (var kvp in playerStates)
+                    {
+                        var otherState = kvp.Value;
+                        if (id < otherState.LastSeenGeneration.Length)
+                            otherState.LastSeenGeneration[id] = 0;
+                        if (id < otherState.LastSentTimes.Length)
+                            otherState.LastSentTimes[id] = 0;
+                    }
                     BNL.Log($"Player {id} removed and cleaned up.");
                 }
                 else


### PR DESCRIPTION
When a player disconnects and a new player later receives the same ID, other players' LastSeenGeneration arrays still held the old (high) generation value. The new player starts at DataGeneration=1, so the check (senderGen > seenGens[jId]) always returned false, preventing any avatar data from being sent.

Clear LastSeenGeneration and LastSentTimes entries for the removed player's ID across all remaining PlayerStates during removal.