### PR TITLE
Use Tab for Free-Cursor

### DIFF
--- a/Basis/Assets/Basis/Settings/InputActions/InputAction.inputactions
+++ b/Basis/Assets/Basis/Settings/InputActions/InputAction.inputactions
@@ -149,6 +149,15 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": true
+                },
+                {
+                    "name": "Tab",
+                    "type": "Button",
+                    "id": "ebb32108-0caa-4287-8dce-cea9355734d9",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -734,6 +743,17 @@
                     "action": "MoveLocalUpDown",
                     "isComposite": false,
                     "isPartOfComposite": true
+                },
+                {
+                    "name": "",
+                    "id": "e0bebede-694f-4d81-b191-3c94f528f23d",
+                    "path": "<Keyboard>/tab",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";All",
+                    "action": "Tab",
+                    "isComposite": false,
+                    "isPartOfComposite": false
                 }
             ]
         }

--- a/Basis/Packages/com.basis.framework.editor/Editor/BasisCursorEditorWindow.cs
+++ b/Basis/Packages/com.basis.framework.editor/Editor/BasisCursorEditorWindow.cs
@@ -73,11 +73,9 @@ public class BasisCursorEditorWindow : EditorWindow
     {
         using (new EditorGUILayout.VerticalScope(EditorStyles.helpBox))
         {
-            EditorGUILayout.LabelField("Active Cursor Lock Requests", EditorStyles.boldLabel);
+            EditorGUILayout.LabelField("Active Cursor Unlock Requests", EditorStyles.boldLabel);
 
-            // This assumes you added an editor-safe debug accessor to BasisCursorManagement:
-            // public static IReadOnlyList<string> CursorLockRequestsDebug => cursorLockRequests;
-            IReadOnlyList<string> requests = BasisCursorManagement.CursorLockRequestsDebug;
+            IReadOnlyList<string> requests = BasisCursorManagement.CursorUnlockRequestsDebug;
 
             if (requests == null || requests.Count == 0)
             {

--- a/Basis/Packages/com.basis.framework/Camera/BasisHandHeldCameraInteractable.cs
+++ b/Basis/Packages/com.basis.framework/Camera/BasisHandHeldCameraInteractable.cs
@@ -799,6 +799,7 @@ public abstract class BasisHandHeldCameraInteractable : BasisPickupInteractable
             flyCamera.OnDestroy();
         }
 
+        BasisCursorManagement.LockCursor(nameof(BasisHandHeldCamera));
         base.OnDestroy();
     }
 }

--- a/Basis/Packages/com.basis.framework/Device Management/Devices/Base/BasisCursorManagement.cs
+++ b/Basis/Packages/com.basis.framework/Device Management/Devices/Base/BasisCursorManagement.cs
@@ -5,8 +5,8 @@ using Basis.Scripts.Device_Management;
 
 public static class BasisCursorManagement
 {
-    // A list to keep track of cursor lock requests
-    private static List<string> cursorLockRequests = new List<string>();
+    // A list of unique requests to unlock the cursor.
+    private static List<string> cursorUnlockRequests = new List<string>();
     // Event that gets triggered whenever the cursor state changes
     public static event Action<CursorLockMode, bool> OnCursorStateChange;
     public static CursorLockMode ActiveLockState()
@@ -20,13 +20,13 @@ public static class BasisCursorManagement
 
 #if UNITY_EDITOR
     /// <summary>
-    /// Editor-only debug view of active lock request owners.
+    /// Editor-only debug view of active unlock requests.
     /// </summary>
-    public static IReadOnlyList<string> CursorLockRequestsDebug => cursorLockRequests;
+    public static IReadOnlyList<string> CursorUnlockRequestsDebug => cursorUnlockRequests;
 #endif
     /// <summary>
-    /// Locks the cursor to the center of the screen and hides it.
-    /// Adds a request to lock the cursor.
+    /// Removes this unlock request.
+    /// If there are no remaining unlock requests, locks the cursor and makes it invisible.
     /// </summary>
     public static void LockCursor(string requestName)
     {
@@ -36,24 +36,18 @@ public static class BasisCursorManagement
             return;
         }
 
-        if (cursorLockRequests.Contains(requestName) == false)
+        cursorUnlockRequests.Remove(requestName);
+        if (cursorUnlockRequests.Count == 0)
         {
-
             Cursor.lockState = CursorLockMode.Locked;
             Cursor.visible = false;
-            // BasisDebug.Log("Cursor Locked");
-            cursorLockRequests.Add(requestName);
             OnCursorStateChange?.Invoke(CursorLockMode.Locked, false);
-        }
-        else
-        {
-            BasisDebug.LogError("already Has Cursor Lock Request");
         }
     }
 
     /// <summary>
     /// Unlocks the cursor and makes it visible.
-    /// Removes a request to lock the cursor.
+    /// Adds an unlock request, which prevents the cursor from being locked until this request is removed with LockCursor.
     /// </summary>
     public static void UnlockCursor(string requestName, bool FireCursorStateChange = true)
     {
@@ -76,10 +70,16 @@ public static class BasisCursorManagement
 
     private static void InternalUnlockCursor(string requestName, bool FireCursorStateChange)
     {
+        if (!cursorUnlockRequests.Contains(requestName))
+        {
+            cursorUnlockRequests.Add(requestName);
+        }
+        if (Cursor.lockState == CursorLockMode.None)
+        {
+            return;
+        }
         Cursor.lockState = CursorLockMode.None;
         Cursor.visible = true;
-        //  BasisDebug.Log("Cursor Unlocked");
-        cursorLockRequests.Remove(requestName);
         if (FireCursorStateChange)
         {
             OnCursorStateChange?.Invoke(CursorLockMode.None, true);
@@ -110,7 +110,7 @@ public static class BasisCursorManagement
     }
     public static void OnReset()
     {
-        cursorLockRequests.Clear();
+        cursorUnlockRequests.Clear();
         Cursor.lockState = CursorLockMode.None;
         Cursor.visible = true;
         OnCursorStateChange?.Invoke(CursorLockMode.None, true);

--- a/Basis/Packages/com.basis.framework/Device Management/Devices/Desktop/BasisLocalInputActions.cs
+++ b/Basis/Packages/com.basis.framework/Device Management/Devices/Desktop/BasisLocalInputActions.cs
@@ -33,6 +33,7 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
         public InputActionReference CrouchAction;
         public InputActionReference RunButton;
         public InputActionReference Escape;
+        public InputActionReference Tab;
         public InputActionReference PrimaryButtonGetState;
         public InputActionReference PointerAction;
 
@@ -68,6 +69,12 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
         #endregion
 
         private readonly BasisLocks.LockContext CrouchingLock = BasisLocks.GetContext(BasisLocks.Crouching);
+
+        private const string FreeCursorMode = nameof(FreeCursorMode);
+
+        /// <summary>Whether the free-cursor mode (Tab held) is active.</summary>
+        public bool IsFreeCursor { get; private set; }
+
         /// <summary>Whether crouch is currently held down.</summary>
         public bool IsJumpHeld { get; private set; }
 
@@ -166,6 +173,7 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
             CrouchAction.action.Enable();
             RunButton.action.Enable();
             Escape.action.Enable();
+            Tab.action.Enable();
             PrimaryButtonGetState.action.Enable();
             LeftMousePressed.action.Enable();
             RightMousePressed.action.Enable();
@@ -186,6 +194,7 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
             CrouchAction.action.Disable();
             RunButton.action.Disable();
             Escape.action.Disable();
+            Tab.action.Disable();
             PrimaryButtonGetState.action.Disable();
             LeftMousePressed.action.Disable();
             RightMousePressed.action.Disable();
@@ -218,6 +227,9 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
             Escape.action.performed += OnEscapePerformed;
             Escape.action.canceled += OnEscapeCancelled;
 
+            Tab.action.performed += OnTabPerformed;
+            Tab.action.canceled += OnTabCancelled;
+
             PrimaryButtonGetState.action.performed += OnPrimaryGet;
             PrimaryButtonGetState.action.canceled += OnCancelPrimaryGet;
 
@@ -238,6 +250,8 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
 
             VRSwitch.action.performed += OnSwitchOpenVR;
             XRSwitch.action.performed += OnSwitchOpenXR;
+
+            BasisCursorManagement.OnCursorStateChange += OnCursorStateChanged;
         }
 
         private void RemoveCallbacks()
@@ -264,6 +278,9 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
             Escape.action.performed -= OnEscapePerformed;
             Escape.action.canceled -= OnEscapeCancelled;
 
+            Tab.action.performed -= OnTabPerformed;
+            Tab.action.canceled -= OnTabCancelled;
+
             PrimaryButtonGetState.action.performed -= OnPrimaryGet;
             PrimaryButtonGetState.action.canceled -= OnCancelPrimaryGet;
 
@@ -284,6 +301,8 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
 
             VRSwitch.action.performed -= OnSwitchOpenVR;
             XRSwitch.action.performed -= OnSwitchOpenXR;
+
+            BasisCursorManagement.OnCursorStateChange -= OnCursorStateChanged;
         }
         #endregion
 
@@ -410,6 +429,18 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
 
         public void OnEscapeCancelled(InputAction.CallbackContext ctx) { }
 
+        public void OnTabPerformed(InputAction.CallbackContext ctx)
+        {
+            IsFreeCursor = true;
+            BasisCursorManagement.UnlockCursor(FreeCursorMode);
+        }
+
+        public void OnTabCancelled(InputAction.CallbackContext ctx)
+        {
+            IsFreeCursor = false;
+            BasisCursorManagement.LockCursor(FreeCursorMode);
+        }
+
         public void OnPrimaryGet(InputAction.CallbackContext ctx) => InputState.PrimaryButtonGetState = true;
         public void OnCancelPrimaryGet(InputAction.CallbackContext ctx) => InputState.PrimaryButtonGetState = false;
 
@@ -437,6 +468,15 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
         public void OnMouseScrollClick(InputAction.CallbackContext ctx) => InputState.Secondary2DAxisClick = ctx.ReadValue<float>() == 1;
 
         #endregion
+
+        private void OnCursorStateChanged(CursorLockMode lockMode, bool visible)
+        {
+            // When the cursor lock state changes, the cursor is already set to the center of the screen,
+            // but the input event is not triggered. This means that the previous hover position is kept, even
+            // when the cursor changes position. To ensure that the hover position is correct when altering the cursor state,
+            // manually set the position to the center of the screen.
+            Pointer = new Vector2(Screen.width / 2f, Screen.height / 2f);
+        }
 
         #region Helpers
 

--- a/Basis/Packages/com.basis.framework/Prefabs/BasisFramework.prefab
+++ b/Basis/Packages/com.basis.framework/Prefabs/BasisFramework.prefab
@@ -541,6 +541,7 @@ MonoBehaviour:
   CrouchAction: {fileID: 4281027790913896788, guid: 5e4c3601c6a155f43af19da3bdd35a64, type: 3}
   RunButton: {fileID: 4166653571123788975, guid: 5e4c3601c6a155f43af19da3bdd35a64, type: 3}
   Escape: {fileID: -8104914591799447859, guid: 5e4c3601c6a155f43af19da3bdd35a64, type: 3}
+  Tab: {fileID: 4302437416140599907, guid: 5e4c3601c6a155f43af19da3bdd35a64, type: 3}
   PrimaryButtonGetState: {fileID: 647096541409930546, guid: 5e4c3601c6a155f43af19da3bdd35a64, type: 3}
   PointerAction: {fileID: -5417877143265962151, guid: 5e4c3601c6a155f43af19da3bdd35a64, type: 3}
   DesktopSwitch: {fileID: -1278911692722073990, guid: 5e4c3601c6a155f43af19da3bdd35a64, type: 3}


### PR DESCRIPTION
I have been having muscle memory issues trying to hold Tab to interact with UI elements without moving my head in desktop mode, which is a much nicer user experience. It also applies to interactables.

As part of this implementation, I refactored the way cursor lock/unlock requests worked, so please let me know if you disagree or maybe give me more context on the way it was before. 

In this PR, the default case is to assume the cursor should be locked. If there is at least one unlock request, the cursor is unlocked. Once there are no unlock requests, the cursor is locked again. For example:
* Open Menu -> 1 unlock request; unlock the cursor
* Press Tab -> 2 unlock requests
* Release Tab -> 1 unlock request
* Close Menu -> 0 unlock requests; lock the cursor

I also cleaned up the one situation I found where a `UnlockCursor` was called without a subsequent `LockCursor`, so there shouldn't be any dangling unlock requests. It would be pertinent to make sure moving forward that all Unlock requests have a matching Lock though.

I only tested this in desktop as VR uses different logic and an override method, but it might be good to confirm that it still works as expected.