### PR TITLE
Add setting for microphone behavior at startup

### DIFF
--- a/Basis/Packages/com.basis.framework/BasisUI/BasisSettingsDefaults.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/BasisSettingsDefaults.cs
@@ -145,6 +145,8 @@ namespace Basis.BasisUI
 
         public static BasisSettingsBinding<string> MicrophoneMode => new("microphonemode", new BasisPlatformDefault<string>("onactivation"));
 
+        public static BasisSettingsBinding<string> MicStartBehavior => new("micstartbehavior", new BasisPlatformDefault<string>(BasisLocalMicrophoneDriver.SettingStartOff));
+
         public static BasisSettingsBinding<bool> UseAutomaticGain => new("automaticgainenabled", new BasisPlatformDefault<bool>
         {
             windows = true,
@@ -461,6 +463,7 @@ namespace Basis.BasisUI
             HearingRange.LoadBindingValue();
             MicrophoneDenoiser.LoadBindingValue();
             MicrophoneMode.LoadBindingValue();
+            MicStartBehavior.LoadBindingValue();
             UseAutomaticGain.LoadBindingValue();
             DenoiseMakeupDb.LoadBindingValue();
             DenoiseWet.LoadBindingValue();

--- a/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProvider.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProvider.cs
@@ -402,6 +402,17 @@ namespace Basis.BasisUI
             });
             dropdownMicrophoneIcon.AssignBinding(BasisSettingsDefaults.MicrophoneIcon);
 
+            // Mic Start Behavior dropdown
+            PanelDropdown dropdownMicStartBehavior = PanelDropdown.CreateNewEntry(microphoneGroup);
+            dropdownMicStartBehavior.Descriptor.SetTitle("Mic Start Behavior");
+            dropdownMicStartBehavior.AssignEntries(new List<string>
+            {
+                BasisLocalMicrophoneDriver.SettingStartOff,
+                BasisLocalMicrophoneDriver.SettingStartOn,
+                BasisLocalMicrophoneDriver.SettingStartRememberLast,
+            });
+            dropdownMicStartBehavior.AssignBinding(BasisSettingsDefaults.MicStartBehavior);
+
             // -------------------- DSP SETTINGS --------------------
 
             // Limiter

--- a/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalCameraDriver.cs
+++ b/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalCameraDriver.cs
@@ -202,7 +202,7 @@ namespace Basis.Scripts.Drivers
             }
 
 #if !BASIS_DISABLE_MICROPHONE
-            microphoneIconDriver.SpriteRendererIcon.gameObject.SetActive(false);
+            microphoneIconDriver.HardEnableVisuals(false);
             BasisLocalMicrophoneDriver.OnInitializedAction += OnMicrophoneDriverInitialized;
 #endif
 
@@ -277,11 +277,8 @@ namespace Basis.Scripts.Drivers
             if (initialized)
             {
                 microphoneIconDriver.Initalize(this);
-                // Cache icon half-size in camera-local RU for layout
-                microphoneIconDriver.iconHalfRU = microphoneIconDriver.GetIconHalfSizeRUInCameraSpace(Camera, ParentOfUI);
-                microphoneIconDriver.UpdateMicrophoneVisuals(BasisLocalMicrophoneDriver.isPaused, false);
             }
-            microphoneIconDriver.SpriteRendererIcon.gameObject.SetActive(initialized);
+            microphoneIconDriver.HardEnableVisuals(initialized);
         }
 #endif
 

--- a/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalCameraDriver.cs
+++ b/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalCameraDriver.cs
@@ -202,8 +202,8 @@ namespace Basis.Scripts.Drivers
             }
 
 #if !BASIS_DISABLE_MICROPHONE
-            microphoneIconDriver.Initalize(this);
-            microphoneIconDriver.UpdateMicrophoneVisuals(BasisLocalMicrophoneDriver.isPaused, false);
+            microphoneIconDriver.SpriteRendererIcon.gameObject.SetActive(false);
+            BasisLocalMicrophoneDriver.OnInitializedAction += OnMicrophoneDriverInitialized;
 #endif
 
 #if STEAMAUDIO_ENABLED
@@ -211,12 +211,6 @@ namespace Basis.Scripts.Drivers
             {
                 SteamAudioManager.NotifyAudioListenerChanged();
             }
-#endif
-#if !BASIS_DISABLE_MICROPHONE
-            microphoneIconDriver.SpriteRendererIcon.gameObject.SetActive(true);
-
-            // Cache icon half-size in camera-local RU for layout
-            microphoneIconDriver.iconHalfRU = microphoneIconDriver.GetIconHalfSizeRUInCameraSpace(Camera, ParentOfUI);
 #endif
         }
 
@@ -272,6 +266,24 @@ namespace Basis.Scripts.Drivers
             }
             UpdateCameraScale(BasisHeightDriver.HeightModeChange.OnTpose);
         }
+
+#if !BASIS_DISABLE_MICROPHONE
+        /// <summary>
+        /// Initializes microphone icon visibility and layout when the microphone driver signals it is ready.
+        /// </summary>
+        /// <param name="initialized"></param>
+        private void OnMicrophoneDriverInitialized(bool initialized)
+        {
+            if (initialized)
+            {
+                microphoneIconDriver.Initalize(this);
+                // Cache icon half-size in camera-local RU for layout
+                microphoneIconDriver.iconHalfRU = microphoneIconDriver.GetIconHalfSizeRUInCameraSpace(Camera, ParentOfUI);
+                microphoneIconDriver.UpdateMicrophoneVisuals(BasisLocalMicrophoneDriver.isPaused, false);
+            }
+            microphoneIconDriver.SpriteRendererIcon.gameObject.SetActive(initialized);
+        }
+#endif
 
         /// <summary>
         /// Gets world-space camera transform or returns zero/identity when no instance exists.

--- a/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalMicrophoneDriver.cs
+++ b/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalMicrophoneDriver.cs
@@ -16,6 +16,7 @@ public static class BasisLocalMicrophoneDriver
     public static int PacketSize;
 
     public static Action<bool> OnPausedAction;
+    public static Action<bool> OnInitializedAction;
 
     private static bool MicrophoneIsStarted = false;
     private static Thread processingThread;
@@ -28,6 +29,9 @@ public static class BasisLocalMicrophoneDriver
     private static JobHandle handle;
 
     public const string MicrophoneState = "MicrophoneState";
+    public const string SettingStartOff = "Muted";
+    public const string SettingStartOn = "Unmuted";
+    public const string SettingStartRememberLast = "Remember Last State";
 
     public static Action OnHasAudio;
     public static Action OnHasSilence;
@@ -110,11 +114,27 @@ public static class BasisLocalMicrophoneDriver
         }
     }
 
+    public static bool ResolvePausedFromSettings()
+    {
+        string behavior = Basis.BasisUI.BasisSettingsDefaults.MicStartBehavior.RawValue;
+        switch (behavior)
+        {
+            case SettingStartOn:
+                return false;
+            case SettingStartRememberLast:
+                return PlayerPrefs.GetInt(MicrophoneState, 1) == 1;
+            case SettingStartOff:
+            default:
+                return true;
+        }
+    }
+
     public static bool Initialize()
     {
         if (IsInitialize) return true;
         try
         {
+            isPaused = ResolvePausedFromSettings();
             RegisterEvents();
 
             // Load emits one change event; ApplyMicSettings reacts.
@@ -122,6 +142,7 @@ public static class BasisLocalMicrophoneDriver
 
             StartProcessingThread();
             IsInitialize = true;
+            OnInitializedAction?.Invoke(true);
             return true;
         }
         catch (Exception ex)
@@ -158,6 +179,7 @@ public static class BasisLocalMicrophoneDriver
 
         channels = 1;
         IsInitialize = false;
+        OnInitializedAction?.Invoke(false);
         BasisDebug.Log("Microphone Driver Deinitialized.");
     }
 

--- a/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalMicrophoneIconDriver.cs
+++ b/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalMicrophoneIconDriver.cs
@@ -26,7 +26,7 @@ namespace Basis.Scripts.Drivers
         [Range(0f, 0.2f)]
         public float VRextraViewportPad = 0.022f;
 
-        public Vector2 iconHalfRU;
+        private Vector2 iconHalfRU;
         private readonly Vector3[] corners = new Vector3[4];
         private Rect FrustumRequest = new Rect(0, 0, 1, 1);
 
@@ -71,6 +71,7 @@ namespace Basis.Scripts.Drivers
             this.CameraDriver = CameraDriver;
 
             halfDuration = duration / 2f;
+            iconHalfRU = GetIconHalfSizeRUInCameraSpace(CameraDriver.Camera, CameraDriver.ParentOfUI);
 
             if (SpriteRendererIcon != null)
             {
@@ -79,9 +80,21 @@ namespace Basis.Scripts.Drivers
                 largerScale = StartingScale * 1.2f;
             }
 
+            UpdateMicrophoneVisuals(BasisLocalMicrophoneDriver.isPaused, false);
+
             // Seed intents (no renderer writes here)
             RecomputeVisibilityIntent();
             RecomputeColorIntent();
+        }
+
+        // This is different from the user's setting of requestedVisual, which enables or disables the component.
+        // This is used in the initialization stage to force hide the visual until it is ready to be shown.
+        public void HardEnableVisuals(bool enabled)
+        {
+            if (SpriteRendererIcon != null)
+            {
+                SpriteRendererIcon.gameObject.SetActive(enabled);
+            }
         }
 
         // ---------------- Layout Helpers ----------------


### PR DESCRIPTION
The main feature of this PR is adding a setting to control what the microphone does at startup. The options are:
* Muted (new default)
* Unmuted (current behavior before merge)
* Remember Last State

I also hid the microphone icon until the microphone driver is initialized, so it doesn't show at the wrong color and position at start.

Let me know if you would like me to change the default or any of the verbiage.
