### PR TITLE
fix: remove plaintext password logging on auth failure

### DIFF
--- a/Basis Server/BasisNetworkServer/Auth/Password.cs
+++ b/Basis Server/BasisNetworkServer/Auth/Password.cs
@@ -61,7 +61,7 @@ namespace Basis.Network.Server.Auth
             }
             else
             {
-                BNL.LogError($"Passwords do not match: ServerPassword [{serverPassword.V}], UserPassword [{userPassword.V}]");
+                BNL.LogError("Passwords do not match, user is rejected");
                 return false;
             }
         }

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/Auth/Password.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/Auth/Password.cs
@@ -61,7 +61,7 @@ namespace Basis.Network.Server.Auth
             }
             else
             {
-                BNL.LogError($"Passwords do not match: ServerPassword [{serverPassword.V}], UserPassword [{userPassword.V}]");
+                BNL.LogError("Passwords do not match, user is rejected");
                 return false;
             }
         }


### PR DESCRIPTION
## Summary
- Removes plaintext logging of both server and user passwords when authentication fails
- Passwords should never appear in log files as this is a critical security vulnerability
- Replaces with a generic "passwords do not match" message

## Test plan
- [ ] Verify auth failure still logs a message (without passwords)
- [ ] Verify successful auth is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)