### PR TITLE
fix: prevent stack trace disclosure to unauthenticated clients

### DIFF
--- a/Basis Server/BasisNetworkServer/Security/BasisDIDAuthIdentity.cs
+++ b/Basis Server/BasisNetworkServer/Security/BasisDIDAuthIdentity.cs
@@ -140,7 +140,7 @@ namespace BasisDidLink
             catch (Exception e)
             {
                 BNL.Log($"Error processing connection: {e.Message} {e.StackTrace}");
-                BasisServerHandleEvents.RejectWithReason(newPeer, $"{e.Message} {e.StackTrace}");
+                BasisServerHandleEvents.RejectWithReason(newPeer, "Authentication failed");
             }
         }
         public async Task TimeOut(NetPeer newPeer, string UUID, CancellationTokenSource cts)
@@ -201,7 +201,7 @@ namespace BasisDidLink
             catch (Exception e)
             {
                 BNL.Log($"Error during authentication: {e.Message} {e.StackTrace}");
-                BasisServerHandleEvents.RejectWithReason(newPeer, $"{e.Message} {e.StackTrace}");
+                BasisServerHandleEvents.RejectWithReason(newPeer, "Authentication failed");
             }
         }
         public Challenge MakeChallenge(Did ChallengingDID)

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/Security/BasisDIDAuthIdentity.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/Security/BasisDIDAuthIdentity.cs
@@ -140,7 +140,7 @@ namespace BasisDidLink
             catch (Exception e)
             {
                 BNL.Log($"Error processing connection: {e.Message} {e.StackTrace}");
-                BasisServerHandleEvents.RejectWithReason(newPeer, $"{e.Message} {e.StackTrace}");
+                BasisServerHandleEvents.RejectWithReason(newPeer, "Authentication failed");
             }
         }
         public async Task TimeOut(NetPeer newPeer, string UUID, CancellationTokenSource cts)
@@ -201,7 +201,7 @@ namespace BasisDidLink
             catch (Exception e)
             {
                 BNL.Log($"Error during authentication: {e.Message} {e.StackTrace}");
-                BasisServerHandleEvents.RejectWithReason(newPeer, $"{e.Message} {e.StackTrace}");
+                BasisServerHandleEvents.RejectWithReason(newPeer, "Authentication failed");
             }
         }
         public Challenge MakeChallenge(Did ChallengingDID)


### PR DESCRIPTION
## Summary
- Stop sending exception messages and stack traces to clients in rejection messages
- Internal error details (paths, class names, config) were being leaked to unauthenticated users
- Server-side logging of the full exception is preserved for debugging

## Test plan
- [ ] Verify auth errors still log full details server-side
- [ ] Verify clients receive a generic rejection message, not internal details

🤖 Generated with [Claude Code](https://claude.com/claude-code)