### PR TITLE
fix: remove double recycle of NetPacketReader in FallChannel redirect

### DIFF
--- a/Basis Server/BasisNetworkServer/BasisNetworkMessageProcessor/BasisNetworkMessageProcessor.cs
+++ b/Basis Server/BasisNetworkServer/BasisNetworkMessageProcessor/BasisNetworkMessageProcessor.cs
@@ -193,9 +193,8 @@ public static class BasisNetworkMessageProcessor
             else
             {
                 BNL.LogError($"FallChannel redirection failed, no data remains: {reader.AvailableBytes}");
+                reader.Recycle();
             }
-
-            reader.Recycle();
             return true;
         }
 

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/BasisNetworkMessageProcessor/BasisNetworkMessageProcessor.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/BasisNetworkMessageProcessor/BasisNetworkMessageProcessor.cs
@@ -193,9 +193,8 @@ public static class BasisNetworkMessageProcessor
             else
             {
                 BNL.LogError($"FallChannel redirection failed, no data remains: {reader.AvailableBytes}");
+                reader.Recycle();
             }
-
-            reader.Recycle();
             return true;
         }
 


### PR DESCRIPTION
## Summary
- ProcessMessage already recycles the reader in every code path
- TryRedirectFallChannel was recycling it again after ProcessMessage returned
- Double-recycling a pooled reader corrupts the pool and can cause data races
- Moved `reader.Recycle()` into the error branch so it only fires when ProcessMessage was not called

## Test plan
- [ ] Verify FallChannel messages still process correctly
- [ ] Verify reader is recycled exactly once

🤖 Generated with [Claude Code](https://claude.com/claude-code)