### PR TITLE
fix: make JoiningPlayers thread-safe with ConcurrentDictionary

### DIFF
--- a/Basis/Packages/com.basis.framework/Networking/BasisNetworkPlayers.cs
+++ b/Basis/Packages/com.basis.framework/Networking/BasisNetworkPlayers.cs
@@ -17,7 +17,7 @@ namespace Basis.Scripts.Networking
         // --- Collections (thread-safe) -------------------------------------
         public static readonly ConcurrentDictionary<ushort, BasisNetworkPlayer> Players = new();
         public static readonly ConcurrentDictionary<ushort, BasisNetworkReceiver> RemotePlayers = new();
-        public static readonly List<ushort> JoiningPlayers = new(); // used as a set
+        public static readonly ConcurrentDictionary<ushort, byte> JoiningPlayers = new(); // used as a concurrent set
         public static readonly ConcurrentDictionary<string, ushort> OwnershipPairing = new();
 
         // Receiver snapshot for multi-threaded compute/apply phases.
@@ -155,7 +155,7 @@ namespace Basis.Scripts.Networking
                 return true;
             }
 
-            if (JoiningPlayers.Contains(id))
+            if (JoiningPlayers.ContainsKey(id))
                 BasisDebug.LogError("Player was still connecting when this was called!");
             else
                 BasisDebug.LogError("Player was not found, including joining list; something is very wrong!");

--- a/Basis/Packages/com.basis.framework/Networking/Handles/BasisRemotePlayerFactory.cs
+++ b/Basis/Packages/com.basis.framework/Networking/Handles/BasisRemotePlayerFactory.cs
@@ -27,7 +27,7 @@ namespace Basis.Scripts.Networking
 
             if (avatarID.byteArray != null)
             {
-                BasisNetworkPlayers.JoiningPlayers.Add(ServerReadyMessage.playerIdMessage.playerID);
+                BasisNetworkPlayers.JoiningPlayers.TryAdd(ServerReadyMessage.playerIdMessage.playerID, 0);
 
                 // Start both tasks simultaneously
                 BasisRemotePlayer remote = BasisPlayerFactory.CreateRemotePlayer(instantiationParameters, avatarID, ServerReadyMessage.localReadyMessage.playerMetaDataMessage);
@@ -56,7 +56,7 @@ namespace Basis.Scripts.Networking
                 BasisNetworkPlayer.OnRemotePlayerJoined?.Invoke(BasisNetworkReceiver, remote);
                 BasisNetworkPlayer.OnPlayerJoined?.Invoke(BasisNetworkReceiver);
 
-                BasisNetworkPlayers.JoiningPlayers.Remove(ServerReadyMessage.playerIdMessage.playerID);
+                BasisNetworkPlayers.JoiningPlayers.TryRemove(ServerReadyMessage.playerIdMessage.playerID, out _);
 
                 return BasisNetworkReceiver;
             }


### PR DESCRIPTION
## Summary
- Replace non-thread-safe `List<ushort>` with `ConcurrentDictionary<ushort, byte>` for `JoiningPlayers`
- This collection is accessed from both network callback threads and the main thread
- All other collections in the same class already use ConcurrentDictionary

## Test plan
- [ ] Verify player join/leave flow still works
- [ ] Verify no race conditions under concurrent joins

🤖 Generated with [Claude Code](https://claude.com/claude-code)