### PR TITLE
fix: add lock around shared static NetDataWriter to prevent corruption

### DIFF
--- a/Basis/Packages/com.basis.framework/Networking/Transmitters/BasisNetworkTransmitter.cs
+++ b/Basis/Packages/com.basis.framework/Networking/Transmitters/BasisNetworkTransmitter.cs
@@ -66,6 +66,7 @@ namespace Basis.Scripts.Networking.Transmitters
         }
 
         public static NetDataWriter AvatarChangeWriter = new NetDataWriter();
+        private static readonly object AvatarChangeWriterLock = new object();
         public void SendOutAvatarChange()
         {
             LastLinkedAvatarIndex = (byte)((LastLinkedAvatarIndex + 1) % (byte.MaxValue + 1));
@@ -76,10 +77,13 @@ namespace Basis.Scripts.Networking.Transmitters
                 loadMode = Player.AvatarLoadMode,
                 LocalAvatarIndex = LastLinkedAvatarIndex,
             };
-            AvatarChangeWriter.Reset();
-            ClientAvatarChangeMessage.Serialize(AvatarChangeWriter);
-            BasisNetworkConnection.LocalPlayerPeer.Send(AvatarChangeWriter, BasisNetworkCommons.AvatarChangeMessageChannel, DeliveryMethod.ReliableOrdered);
-            BasisNetworkProfiler.AddToCounter(BasisNetworkProfilerCounter.AvatarChange, AvatarChangeWriter.Length);
+            lock (AvatarChangeWriterLock)
+            {
+                AvatarChangeWriter.Reset();
+                ClientAvatarChangeMessage.Serialize(AvatarChangeWriter);
+                BasisNetworkConnection.LocalPlayerPeer.Send(AvatarChangeWriter, BasisNetworkCommons.AvatarChangeMessageChannel, DeliveryMethod.ReliableOrdered);
+                BasisNetworkProfiler.AddToCounter(BasisNetworkProfilerCounter.AvatarChange, AvatarChangeWriter.Length);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- `AvatarChangeWriter` is a shared static `NetDataWriter` used without synchronization
- Concurrent calls to `SendOutAvatarChange` could interleave `Reset()`/`Serialize()`/`Send()`, corrupting network messages
- Added a static lock object to serialize access

## Test plan
- [ ] Verify avatar change messages still send correctly
- [ ] Verify no data corruption under concurrent avatar changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)