### PR TITLE
fix: add null check for LocalPlayer in disconnect handlers

### DIFF
--- a/Basis/Packages/com.basis.framework/Networking/Handles/BasisNetworkHandleRemoval.cs
+++ b/Basis/Packages/com.basis.framework/Networking/Handles/BasisNetworkHandleRemoval.cs
@@ -23,7 +23,7 @@ public static class BasisNetworkHandleRemoval
 
     public static void HandleDisconnectId(ushort disconnectedID)
     {
-        if (disconnectedID == BasisNetworkPlayer.LocalPlayer.playerId)
+        if (BasisNetworkPlayer.LocalPlayer != null && disconnectedID == BasisNetworkPlayer.LocalPlayer.playerId)
         {
             BasisDebug.LogError("LocalPlayer Matched Disconnected ID returning early");
             return;
@@ -38,7 +38,7 @@ public static class BasisNetworkHandleRemoval
 
     public static void HandleDisconnectIdImmediate(ushort disconnectedID)
     {
-        if (disconnectedID == BasisNetworkPlayer.LocalPlayer.playerId)
+        if (BasisNetworkPlayer.LocalPlayer != null && disconnectedID == BasisNetworkPlayer.LocalPlayer.playerId)
         {
            // BasisDebug.LogError("LocalPlayer Matched Disconnected ID returning early");
             return;


### PR DESCRIPTION
## Summary
- `BasisNetworkPlayer.LocalPlayer` can be null during shutdown or before connection is established
- `HandleDisconnectId` and `HandleDisconnectIdImmediate` accessed `.playerId` without null checking
- Added null guards to prevent NullReferenceException during shutdown/reboot

## Test plan
- [ ] Verify disconnect handling still works normally
- [ ] Verify no crash when disconnect fires during shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)