### PR TITLE
fix: set correct player ID in ownership transfer fallback path

### DIFF
--- a/Basis Server/BasisNetworkServer/BasisNetworking/BasisNetworkOwnership.cs
+++ b/Basis Server/BasisNetworkServer/BasisNetworking/BasisNetworkOwnership.cs
@@ -108,6 +108,7 @@ namespace Basis.Network.Server.Ownership
                 //the goal here is to make it so ownership understanding has to be requested.
                 //once a ownership has been requested there good for life or when a ownership switch happens.
                 NetworkRequestNewOrExisting(ownershipTransferMessage, out ushort currentOwner);
+                ownershipTransferMessage.playerIdMessage.playerID = currentOwner;
                 ownershipTransferMessage.Serialize(Writer);
                 NetworkServer.BroadcastMessageToClients(Writer, BasisNetworkCommons.ChangeCurrentOwnerRequestChannel, NetworkServer.PeerSnapshot, DeliveryMethod.ReliableOrdered);
             }

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/BasisNetworking/BasisNetworkOwnership.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/BasisNetworking/BasisNetworkOwnership.cs
@@ -108,6 +108,7 @@ namespace Basis.Network.Server.Ownership
                 //the goal here is to make it so ownership understanding has to be requested.
                 //once a ownership has been requested there good for life or when a ownership switch happens.
                 NetworkRequestNewOrExisting(ownershipTransferMessage, out ushort currentOwner);
+                ownershipTransferMessage.playerIdMessage.playerID = currentOwner;
                 ownershipTransferMessage.Serialize(Writer);
                 NetworkServer.BroadcastMessageToClients(Writer, BasisNetworkCommons.ChangeCurrentOwnerRequestChannel, NetworkServer.PeerSnapshot, DeliveryMethod.ReliableOrdered);
             }


### PR DESCRIPTION
## Summary
- When `SwitchOwnership` fails, `NetworkRequestNewOrExisting` returns the actual current owner
- But `ownershipTransferMessage.playerIdMessage.playerID` was not updated before serialization
- All clients received the requesting player's ID instead of the actual owner's ID
- Added the missing assignment to broadcast the correct owner

## Test plan
- [ ] Verify ownership transfer works when ownership switch succeeds
- [ ] Verify ownership query returns correct current owner in fallback path

🤖 Generated with [Claude Code](https://claude.com/claude-code)