### PR TITLE
fix: swap incorrectly assigned read/write permission flags

### DIFF
--- a/Basis Server/BasisNetworkServer/BasisServerHandleEvents.cs
+++ b/Basis Server/BasisNetworkServer/BasisServerHandleEvents.cs
@@ -555,7 +555,7 @@ namespace BasisServerHandle
         #endregion
         public static void HandleStoreDatabase(NetPacketReader reader, NetPeer peer)
         {
-            if (NetworkServer.Configuration.DisableReadUnlessAdminPersistentFlag)
+            if (NetworkServer.Configuration.DisableWriteUnlessAdminPersistentFlag)
             {
                 if (NetworkServer.AuthIdentity.NetIDToUUID(peer, out string uuid) == false)
                 {
@@ -579,7 +579,7 @@ namespace BasisServerHandle
 
         public static void HandleRequestStoreDatabase(NetPacketReader reader, NetPeer peer)
         {
-            if(NetworkServer.Configuration.DisableWriteUnlessAdminPersistentFlag)
+            if(NetworkServer.Configuration.DisableReadUnlessAdminPersistentFlag)
             {
                 if (NetworkServer.AuthIdentity.NetIDToUUID(peer, out string uuid) == false)
                 {

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/BasisServerHandleEvents.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/BasisServerHandleEvents.cs
@@ -555,7 +555,7 @@ namespace BasisServerHandle
         #endregion
         public static void HandleStoreDatabase(NetPacketReader reader, NetPeer peer)
         {
-            if (NetworkServer.Configuration.DisableReadUnlessAdminPersistentFlag)
+            if (NetworkServer.Configuration.DisableWriteUnlessAdminPersistentFlag)
             {
                 if (NetworkServer.AuthIdentity.NetIDToUUID(peer, out string uuid) == false)
                 {
@@ -579,7 +579,7 @@ namespace BasisServerHandle
 
         public static void HandleRequestStoreDatabase(NetPacketReader reader, NetPeer peer)
         {
-            if(NetworkServer.Configuration.DisableWriteUnlessAdminPersistentFlag)
+            if(NetworkServer.Configuration.DisableReadUnlessAdminPersistentFlag)
             {
                 if (NetworkServer.AuthIdentity.NetIDToUUID(peer, out string uuid) == false)
                 {


### PR DESCRIPTION
## Summary
- `HandleStoreDatabase` (write op) was checking `DisableReadUnlessAdminPersistentFlag`
- `HandleRequestStoreDatabase` (read op) was checking `DisableWriteUnlessAdminPersistentFlag`
- This inverted the access control: reads were gated by the write flag and vice versa
- Swapped the flag references so each operation checks the correct permission

## Test plan
- [ ] Verify admin-only write restriction blocks non-admin writes (not reads)
- [ ] Verify admin-only read restriction blocks non-admin reads (not writes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)