### PR TITLE
fix: set IsInUse flag in StartClient to prevent multiple connections

### DIFF
--- a/Basis Server/BasisNetworkClient/NetworkClient.cs
+++ b/Basis Server/BasisNetworkClient/NetworkClient.cs
@@ -28,6 +28,7 @@ public class NetworkClient
             AuthBytes.Serialize(Writer, AuthenticationMessage);
             ReadyMessage.Serialize(Writer);
             peer = client.Connect(IP, port, Writer);
+            IsInUse = true;
             return peer;
         }
         else

--- a/Basis/Packages/com.basis.server/BasisNetworkClient/NetworkClient.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkClient/NetworkClient.cs
@@ -28,6 +28,7 @@ public class NetworkClient
             AuthBytes.Serialize(Writer, AuthenticationMessage);
             ReadyMessage.Serialize(Writer);
             peer = client.Connect(IP, port, Writer);
+            IsInUse = true;
             return peer;
         }
         else


### PR DESCRIPTION
## Summary
- `IsInUse` was never set to `true` after `StartClient` succeeded
- The guard check `if (IsInUse == false)` was therefore useless
- Multiple calls to `StartClient` could create multiple connections and leak resources

## Test plan
- [ ] Verify client connects successfully on first call
- [ ] Verify second call to StartClient without Disconnect logs error and returns null

🤖 Generated with [Claude Code](https://claude.com/claude-code)