### PR TITLE
fix: replace TOCTOU on ConcurrentDictionary with atomic upsert and fix off-by-one

### DIFF
--- a/Basis/Packages/com.basis.framework/Networking/Handles/BasisNetworkGenericMessages.cs
+++ b/Basis/Packages/com.basis.framework/Networking/Handles/BasisNetworkGenericMessages.cs
@@ -104,14 +104,7 @@ public static class BasisNetworkGenericMessages
     }
     public static void HandleOwnership(OwnershipTransferMessage OwnershipTransferMessage)
     {
-        if (BasisNetworkPlayers.OwnershipPairing.ContainsKey(OwnershipTransferMessage.ownershipID))
-        {
-            BasisNetworkPlayers.OwnershipPairing[OwnershipTransferMessage.ownershipID] = OwnershipTransferMessage.playerIdMessage.playerID;
-        }
-        else
-        {
-            BasisNetworkPlayers.OwnershipPairing.TryAdd(OwnershipTransferMessage.ownershipID, OwnershipTransferMessage.playerIdMessage.playerID);
-        }
+        BasisNetworkPlayers.OwnershipPairing[OwnershipTransferMessage.ownershipID] = OwnershipTransferMessage.playerIdMessage.playerID;
         if (BasisNetworkConnection.TryGetLocalPlayerID(out ushort Id))
         {
             bool isLocalOwner = OwnershipTransferMessage.playerIdMessage.playerID == Id;
@@ -143,7 +136,7 @@ public static class BasisNetworkGenericMessages
             {
                 RemoteAvatarDataMessage output = SADM.avatarDataMessage;
 
-                if (player.NetworkBehaviours.Length >= output.messageIndex)
+                if (player.NetworkBehaviours.Length > output.messageIndex)
                 {
                     bool isDifferentAvatar = output.AvatarLinkIndex != player.LastLinkedAvatarIndex;
 


### PR DESCRIPTION
## Summary
- Replace `ContainsKey` + indexer set (TOCTOU race) with direct indexer assignment (atomic upsert) in `HandleOwnership`
- Fix off-by-one: `>=` changed to `>` for `NetworkBehaviours.Length` check — index equal to Length is out of bounds

## Test plan
- [ ] Verify ownership updates still work correctly
- [ ] Verify avatar data messages with boundary messageIndex values are handled correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)