### PR TITLE
fix: send rejection reason to client before disconnecting

### DIFF
--- a/Basis Server/BasisNetworkServer/BasisServerHandleEvents.cs
+++ b/Basis Server/BasisNetworkServer/BasisServerHandleEvents.cs
@@ -122,7 +122,7 @@ namespace BasisServerHandle
             NetDataWriter writer = NetworkServer.RentWriter();
             writer.Put(reason);
             NetworkServer.AuthenticatedPeers.TryRemove(Id, out _);
-            request.Disconnect();
+            request.Disconnect(writer);
             NetworkServer.ReturnWriter(writer);
             BNL.LogError($"Rejected after accept with reason: {reason}");
         }

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/BasisServerHandleEvents.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/BasisServerHandleEvents.cs
@@ -122,7 +122,7 @@ namespace BasisServerHandle
             NetDataWriter writer = NetworkServer.RentWriter();
             writer.Put(reason);
             NetworkServer.AuthenticatedPeers.TryRemove(Id, out _);
-            request.Disconnect();
+            request.Disconnect(writer);
             NetworkServer.ReturnWriter(writer);
             BNL.LogError($"Rejected after accept with reason: {reason}");
         }


### PR DESCRIPTION
## Summary
- `RejectWithReason(NetPeer)` was writing the reason to a writer but calling `Disconnect()` without sending it
- The client never received the rejection reason
- Changed to use `Disconnect(writer)` which sends the data as part of the disconnect, matching the ConnectionRequest overload's behavior

## Test plan
- [ ] Verify rejected peers receive the disconnect reason
- [ ] Verify peer is properly removed from AuthenticatedPeers

🤖 Generated with [Claude Code](https://claude.com/claude-code)