### PR TITLE
fix: add null check in BasisRemoteAudioDriver.OnDestroy

### DIFF
--- a/Basis/Packages/com.basis.framework/Drivers/Remote/BasisRemoteAudioDriver.cs
+++ b/Basis/Packages/com.basis.framework/Drivers/Remote/BasisRemoteAudioDriver.cs
@@ -52,8 +52,11 @@ namespace Basis.Scripts.Drivers
         }
         public void OnDestroy()
         {
-            BasisAudioAndVisemeDriver.OnDestroy();
-            Drivers.Remove(BasisAudioAndVisemeDriver);
+            if (BasisAudioAndVisemeDriver != null)
+            {
+                BasisAudioAndVisemeDriver.OnDestroy();
+                Drivers.Remove(BasisAudioAndVisemeDriver);
+            }
         }
         /// <summary>
         /// Initializes the driver with a viseme processor and marks it ready.


### PR DESCRIPTION
## Summary
- `BasisAudioAndVisemeDriver` can be null if `Initalize()` was never called
- `OnDestroy` was accessing it unconditionally, causing NullReferenceException during scene teardown

## Test plan
- [ ] Verify no crash when BasisRemoteAudioDriver is destroyed before initialization

🤖 Generated with [Claude Code](https://claude.com/claude-code)