### PR TITLE
fix: use Interlocked.CompareExchange to prevent concurrent reboots

### DIFF
--- a/Basis/Packages/com.basis.framework/Networking/BasisNetworkLifeCycle.cs
+++ b/Basis/Packages/com.basis.framework/Networking/BasisNetworkLifeCycle.cs
@@ -40,15 +40,14 @@ public static class BasisNetworkLifeCycle
         BasisNetworkManagement.OnEnableInstanceCreate?.Invoke();
         BasisNetworkManagement.NetworkRunning = true;
     }
-    public static bool GoingThroughReboot = false;
+    private static int _rebootGuard = 0;
     /// <summary>
     /// allows us to reset before continuing on the operation.
     /// </summary>
     public static async Task RebootManagement(BasisNetworkManagement Management, bool DisplayReason, NetPeer peer, DisconnectInfo disconnectInfo)
     {
-        if (GoingThroughReboot == false)
+        if (System.Threading.Interlocked.CompareExchange(ref _rebootGuard, 1, 0) == 0)
         {
-            GoingThroughReboot = true;
             BasisDebug.Log($"Rebooting Network Connection", BasisDebug.LogTag.Networking);
             if (BasisNetworkConnection.LocalPlayerPeer != null && BasisNetworkPlayers.Players.TryGetValue((ushort)BasisNetworkConnection.LocalPlayerPeer.RemoteId, out var networkedPlayer))
             {
@@ -80,7 +79,7 @@ public static class BasisNetworkLifeCycle
                 BasisDebug.Log($"Client disconnected from server [{peer?.RemoteId}] [{disconnectInfo.Reason}]");
                 BasisNetworkEvents.HandleDisconnectionReason(disconnectInfo);
             }
-            GoingThroughReboot = false;
+            System.Threading.Interlocked.Exchange(ref _rebootGuard, 0);
         }
     }
     /// <summary>


### PR DESCRIPTION
## Summary
- `GoingThroughReboot` was a non-atomic bool check-then-set, allowing two concurrent disconnect events to trigger double reboot
- Replaced with `Interlocked.CompareExchange` for atomic guard, preventing concurrent reboot execution

## Test plan
- [ ] Verify reboot still works on disconnection
- [ ] Verify rapid successive disconnects don't cause double-cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)