### PR TITLE
fix: use bool.TryParse for case-insensitive config overrides

### DIFF
--- a/Basis Server/BasisNetworkCore/BasisServerConfiguration.cs
+++ b/Basis Server/BasisNetworkCore/BasisServerConfiguration.cs
@@ -139,19 +139,14 @@ public class Configuration
                 }
                 else if (field.FieldType == typeof(bool))
                 {
-                    if (value == "true")
+                    if (bool.TryParse(value, out bool boolResult))
                     {
-                        field.SetValue(config, true);
-                    }
-                    else if (value == "false")
-                    {
-                        field.SetValue(config, false);
+                        field.SetValue(config, boolResult);
                     }
                     else
                     {
-                        BNL.LogWarning("Boolean field was not a true or false string. Failed Override");
+                        BNL.LogWarning($"Could not parse '{value}' as bool for field {field.Name}. Failed Override");
                     }
-
                 }
                 else
                 {


### PR DESCRIPTION
## Summary
- Boolean env var overrides only accepted lowercase "true"/"false", silently rejecting "True", "TRUE", etc.
- Replaced with `bool.TryParse` which handles all case variants
- Improved the warning message to include the field name and rejected value

## Test plan
- [ ] Verify env vars with "True", "TRUE", "False" are accepted
- [ ] Verify invalid values still produce a warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)