### PR TITLE
fix: load blacklist synchronously in constructor to prevent race

### DIFF
--- a/Basis Server/BasisNetworkServer/Security/BasisBlackList.cs
+++ b/Basis Server/BasisNetworkServer/Security/BasisBlackList.cs
@@ -13,7 +13,24 @@ namespace BasisNetworkServer.Security
         public BasisBlackList(string path = "BasisBlackList.txt")
         {
             filePath = path;
-            _ = LoadBlacklistAsync(); // Fire and forget
+            LoadBlacklist();
+        }
+
+        private void LoadBlacklist()
+        {
+            blacklistedPlayers.Clear();
+            if (File.Exists(filePath))
+            {
+                string[] lines = File.ReadAllLines(filePath);
+                foreach (string line in lines)
+                {
+                    string trimmedLine = line.Trim();
+                    if (!string.IsNullOrEmpty(trimmedLine))
+                    {
+                        blacklistedPlayers.TryAdd(trimmedLine, 0);
+                    }
+                }
+            }
         }
 
         private async Task LoadBlacklistAsync()


### PR DESCRIPTION
## Summary
- Blacklist was loaded with fire-and-forget async, creating a race window where banned players could connect
- Changed constructor to load synchronously so blacklist is ready before any connections are accepted
- Kept async methods for reload/add/remove operations

## Test plan
- [ ] Verify blacklisted players are blocked immediately on server start
- [ ] Verify reload/add/remove still work asynchronously

🤖 Generated with [Claude Code](https://claude.com/claude-code)