### PR TITLE
fix: add lock around Array.Resize in Parallel.For to prevent data races

### DIFF
--- a/Basis Server/BasisNetworkServer/BasisNetworkingReductionSystem/BasisServerReductionSystemEvents.cs
+++ b/Basis Server/BasisNetworkServer/BasisNetworkingReductionSystem/BasisServerReductionSystemEvents.cs
@@ -302,11 +302,18 @@ namespace BasisNetworkServer.BasisNetworkingReductionSystem
                     // Bounds check — grow arrays if needed (rare, only when IDs exceed capacity)
                     if (jId >= sentTimes.Length)
                     {
-                        int newLen = Math.Max(sentTimes.Length * 2, jId + 1);
-                        Array.Resize(ref stateI.LastSentTimes, newLen);
-                        sentTimes = stateI.LastSentTimes;
-                        Array.Resize(ref stateI.LastSeenGeneration, newLen);
-                        seenGens = stateI.LastSeenGeneration;
+                        lock (stateI)
+                        {
+                            // Re-check after acquiring lock
+                            if (jId >= stateI.LastSentTimes.Length)
+                            {
+                                int newLen = Math.Max(stateI.LastSentTimes.Length * 2, jId + 1);
+                                Array.Resize(ref stateI.LastSentTimes, newLen);
+                                Array.Resize(ref stateI.LastSeenGeneration, newLen);
+                            }
+                            sentTimes = stateI.LastSentTimes;
+                            seenGens = stateI.LastSeenGeneration;
+                        }
                     }
 
                     float distSq = DistanceSquared(stateI.Position, stateJ.Position);


### PR DESCRIPTION
## Summary
- `Array.Resize` was called inside a `Parallel.For` without synchronization
- Two threads processing different receivers looking at the same sender could resize the same arrays simultaneously
- Added per-PlayerState lock with double-checked locking pattern to serialize resize operations

## Test plan
- [ ] Verify reduction system still functions correctly under load
- [ ] Verify no data corruption with many concurrent players

🤖 Generated with [Claude Code](https://claude.com/claude-code)