### PR TITLE
fix server Dockerfile COPY location

### DIFF
--- a/Basis Server/Docker/Dockerfile
+++ b/Basis Server/Docker/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0-noble AS build
 WORKDIR /src
 
 # Copy the entire server project (including .props, Contrib, LiteNetLib, etc.)
-COPY ["../", "Server/"]
+COPY ["./", "Server/"]
 
 WORKDIR "/src/Server/BasisServerConsole"
 


### PR DESCRIPTION
The `docker-compose.yml` [build context](https://github.com/BasisVR/Basis/blob/001d6885b1bf3ec58808aa5a101595bcd5a5fd84/Basis%20Server/Docker/docker-compose.yml#L4) is already set to `Basis Server`, so the files that need to be copied are actually in `./`. 

The CI build process happens to truncate `../` to `./` as a security measure, but not all Docker deployments can do that.
