### PR TITLE
Fix falling animation when clicking input fields in settings

### DIFF
--- a/Basis/Packages/com.basis.framework/Drivers/Local/Character Controller/BasisWalkMovementMode.cs
+++ b/Basis/Packages/com.basis.framework/Drivers/Local/Character Controller/BasisWalkMovementMode.cs
@@ -61,7 +61,8 @@ namespace Basis.Scripts.BasisCharacterController
 
             if (ctx.MovementLock)
             {
-                move = Vector3.zero;
+                move.x = 0;
+                move.z = 0;
             }
 
             ctx.Flags = ctx.characterController.Move(move);

--- a/Basis/Packages/com.basis.framework/UI/NamePlate/BasisRemoteNamePlate.cs
+++ b/Basis/Packages/com.basis.framework/UI/NamePlate/BasisRemoteNamePlate.cs
@@ -129,7 +129,7 @@ namespace Basis.Scripts.UI.NamePlate
             ChatText.fontSizeMin = 14;
             ChatText.fontSizeMax = 28;
             ChatText.color = Color.white;
-            ChatText.enableWordWrapping = true;
+            ChatText.textWrappingMode =  TextWrappingModes.Normal;
             ChatText.overflowMode = TextOverflowModes.Truncate;
 
             // Use same font as the loading text if available


### PR DESCRIPTION
## Summary
- When clicking into an input field in the settings provider window, the character would start playing the falling animation
- **Root cause**: `BasisWalkMovementMode.Tick()` zeroed the entire move vector (`move = Vector3.zero`) when `MovementLock` was active (input field focused), including the gravity/vertical component
- `CharacterController.Move(Vector3.zero)` produces no downward collision, so `isGrounded` returns false on the next frame. After the 0.1s `fallingGracePeriod`, `IsFalling` becomes true and the falling animation plays
- **Fix**: Only zero horizontal movement (`move.x = 0; move.z = 0`), preserving the vertical gravity component so the character stays grounded while the input field has focus

## Test plan
- [ ] Open the settings provider window in desktop mode
- [ ] Click into any text input field (e.g. Admin tab UUID/Reason fields)
- [ ] Verify the character does not play the falling animation
- [ ] Verify the character cannot move horizontally while typing
- [ ] Verify normal movement and jumping work correctly after deselecting the input field

🤖 Generated with [Claude Code](https://claude.com/claude-code)