### PR TITLE
Overhaul VR keyboard: fix bugs, add missing keys, add symbol layer

### DIFF
--- a/Basis/Packages/com.basis.framework.editor/Editor/BasisVirtualKeyboardDefaultLanguagesAndStyles.cs
+++ b/Basis/Packages/com.basis.framework.editor/Editor/BasisVirtualKeyboardDefaultLanguagesAndStyles.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using static Basis.Scripts.Virtual_keyboard.KeyboardLayoutData;
 namespace Basis.Scripts.Virtual_keyboard.Editor
 {
@@ -6,7 +6,6 @@ public partial class KeyboardLayoutDataEditor
 {
     public class BasisVirtualKeyboardDefaultLanguagesAndStyles
     {
-        // If you have default items you want to add after clearing, you can define a method like this:
         public static List<LanguageStyle> DefaultLanguagesAndStyles()
         {
             return new List<LanguageStyle>()
@@ -21,7 +20,6 @@ public partial class KeyboardLayoutDataEditor
                         new RowCollection() { innerCollection = new List<string> { "Q", "W", "E", "R", "T", "Y", "U", "I", "O", "P" } },
                         new RowCollection() { innerCollection = new List<string> { "A", "S", "D", "F", "G", "H", "J", "K", "L" } },
                         new RowCollection() { innerCollection = new List<string> { "Z", "X", "C", "V", "B", "N", "M" } },
-                        new RowCollection() { innerCollection = new List<string> { " " } }
                     }
                 },
                 new LanguageStyle()
@@ -33,7 +31,7 @@ public partial class KeyboardLayoutDataEditor
                         new RowCollection() { innerCollection = new List<string> { "1", "2", "3", "4", "5", "6", "7", "8", "9", "0" } },
                         new RowCollection() { innerCollection = new List<string> { "Q", "W", "E", "R", "T", "Y", "U", "I", "O", "P" } },
                         new RowCollection() { innerCollection = new List<string> { "A", "S", "D", "F", "G", "H", "J", "K", "L" } },
-                        new RowCollection() { innerCollection = new List<string> { "Z", "X", "C", "V", "B", "N", "M" } }
+                        new RowCollection() { innerCollection = new List<string> { "Z", "X", "C", "V", "B", "N", "M" } },
                     }
                 },
                 new LanguageStyle()
@@ -43,10 +41,10 @@ public partial class KeyboardLayoutDataEditor
                     rows = new List<RowCollection>()
                     {
                         new RowCollection() { innerCollection = new List<string> { "1", "2", "3", "4", "5", "6", "7", "8", "9", "0" } },
-                        new RowCollection() { innerCollection = new List<string> { "अ", "आ", "इ", "ई", "उ", "ऊ", "ऋ", "ए", "ऐ", "ओ", "औ" } },
-                        new RowCollection() { innerCollection = new List<string> { "क", "ख", "ग", "घ", "च", "छ", "ज", "झ", "ञ" } },
-                        new RowCollection() { innerCollection = new List<string> { "ट", "ठ", "ड", "ढ", "ण" } },
-                        new RowCollection() { innerCollection = new List<string> { "त", "थ", "द", "ध", "न", "प", "फ", "ब", "भ", "म", "य", "र", "ल", "व", "श", "ष", "स", "ह" } }
+                        new RowCollection() { innerCollection = new List<string> { "\u0905", "\u0906", "\u0907", "\u0908", "\u0909", "\u090A", "\u090B", "\u090F", "\u0910", "\u0913", "\u0914" } },
+                        new RowCollection() { innerCollection = new List<string> { "\u0915", "\u0916", "\u0917", "\u0918", "\u091A", "\u091B", "\u091C", "\u091D", "\u091E" } },
+                        new RowCollection() { innerCollection = new List<string> { "\u091F", "\u0920", "\u0921", "\u0922", "\u0923" } },
+                        new RowCollection() { innerCollection = new List<string> { "\u0924", "\u0925", "\u0926", "\u0927", "\u0928", "\u092A", "\u092B", "\u092C", "\u092D", "\u092E", "\u092F", "\u0930", "\u0932", "\u0935", "\u0936", "\u0937", "\u0938", "\u0939" } },
                     }
                 },
                 new LanguageStyle()
@@ -57,8 +55,8 @@ public partial class KeyboardLayoutDataEditor
                     {
                         new RowCollection() { innerCollection = new List<string> { "1", "2", "3", "4", "5", "6", "7", "8", "9", "0" } },
                         new RowCollection() { innerCollection = new List<string> { "Q", "W", "E", "R", "T", "Y", "U", "I", "O", "P" } },
-                        new RowCollection() { innerCollection = new List<string> { "A", "S", "D", "F", "G", "H", "J", "K", "L", "Ñ" } },
-                        new RowCollection() { innerCollection = new List<string> { "Z", "X", "C", "V", "B", "N", "M" } }
+                        new RowCollection() { innerCollection = new List<string> { "A", "S", "D", "F", "G", "H", "J", "K", "L", "\u00D1" } },
+                        new RowCollection() { innerCollection = new List<string> { "Z", "X", "C", "V", "B", "N", "M" } },
                     }
                 },
                 new LanguageStyle()
@@ -71,7 +69,6 @@ public partial class KeyboardLayoutDataEditor
                         new RowCollection() { innerCollection = new List<string> { "A", "Z", "E", "R", "T", "Y", "U", "I", "O", "P" } },
                         new RowCollection() { innerCollection = new List<string> { "Q", "S", "D", "F", "G", "H", "J", "K", "L", "M" } },
                         new RowCollection() { innerCollection = new List<string> { "W", "X", "C", "V", "B", "N" } },
-                        new RowCollection() { innerCollection = new List<string> { " " } }
                     }
                 },
                 new LanguageStyle()
@@ -81,10 +78,9 @@ public partial class KeyboardLayoutDataEditor
                     rows = new List<RowCollection>()
                     {
                         new RowCollection() { innerCollection = new List<string> { "1", "2", "3", "4", "5", "6", "7", "8", "9", "0" } },
-                        new RowCollection() { innerCollection = new List<string> { "ا", "ت", "ن", "م", "ك", "ط", "ظ", "ذ", "ء", "ئ", "ؤ", "ر", "ى", "ة", "و", "ز", "ح" } },
-                        new RowCollection() { innerCollection = new List<string> { "ض", "ص", "ث", "ق", "ف", "غ", "ع", "ه", "خ" } },
-                        new RowCollection() { innerCollection = new List<string> { "ش", "س", "ي", "ب", "ل" } },
-                        new RowCollection() { innerCollection = new List<string> { " " } }
+                        new RowCollection() { innerCollection = new List<string> { "\u0627", "\u062A", "\u0646", "\u0645", "\u0643", "\u0637", "\u0638", "\u0630", "\u0621", "\u0626", "\u0624", "\u0631", "\u0649", "\u0629", "\u0648", "\u0632", "\u062D" } },
+                        new RowCollection() { innerCollection = new List<string> { "\u0636", "\u0635", "\u062B", "\u0642", "\u0641", "\u063A", "\u0639", "\u0647", "\u062E" } },
+                        new RowCollection() { innerCollection = new List<string> { "\u0634", "\u0633", "\u064A", "\u0628", "\u0644" } },
                     }
                 },
                 new LanguageStyle()
@@ -94,10 +90,10 @@ public partial class KeyboardLayoutDataEditor
                     rows = new List<RowCollection>()
                     {
                         new RowCollection() { innerCollection = new List<string> { "1", "2", "3", "4", "5", "6", "7", "8", "9", "0" } },
-                        new RowCollection() { innerCollection = new List<string> { "অ", "আ", "ই", "ঈ", "উ", "ঊ", "ঋ", "এ", "ঐ", "ও", "ঔ" } },
-                        new RowCollection() { innerCollection = new List<string> { "ক", "খ", "গ", "ঘ", "ঙ", "চ", "ছ", "জ", "ঝ", "ঞ" } },
-                        new RowCollection() { innerCollection = new List<string> { "ট", "ঠ", "ড", "ঢ", "ণ" } },
-                        new RowCollection() { innerCollection = new List<string> { "ত", "থ", "দ", "ধ", "ন", "প", "ফ", "ব", "ভ", "ম", "য", "র", "ল", "শ", "ষ", "স", "হ" } }
+                        new RowCollection() { innerCollection = new List<string> { "\u0985", "\u0986", "\u0987", "\u0988", "\u0989", "\u098A", "\u098B", "\u098F", "\u0990", "\u0993", "\u0994" } },
+                        new RowCollection() { innerCollection = new List<string> { "\u0995", "\u0996", "\u0997", "\u0998", "\u0999", "\u099A", "\u099B", "\u099C", "\u099D", "\u099E" } },
+                        new RowCollection() { innerCollection = new List<string> { "\u099F", "\u09A0", "\u09A1", "\u09A2", "\u09A3" } },
+                        new RowCollection() { innerCollection = new List<string> { "\u09A4", "\u09A5", "\u09A6", "\u09A7", "\u09A8", "\u09AA", "\u09AB", "\u09AC", "\u09AD", "\u09AE", "\u09AF", "\u09B0", "\u09B2", "\u09B6", "\u09B7", "\u09B8", "\u09B9" } },
                     }
                 },
                 new LanguageStyle()
@@ -106,22 +102,23 @@ public partial class KeyboardLayoutDataEditor
                     style = "QWERTY",
                     rows = new List<RowCollection>()
                     {
+                        new RowCollection() { innerCollection = new List<string> { "1", "2", "3", "4", "5", "6", "7", "8", "9", "0" } },
                         new RowCollection() { innerCollection = new List<string> { "Q", "W", "E", "R", "T", "Y", "U", "I", "O", "P" } },
-                         new RowCollection() { innerCollection = new List<string> { "A", "S", "D", "F", "G", "H", "J", "K", "L", "Ç" } },
-                        new RowCollection() { innerCollection = new List<string> { "Z", "X", "C", "V", "B", "N", "M" } }
+                        new RowCollection() { innerCollection = new List<string> { "A", "S", "D", "F", "G", "H", "J", "K", "L", "\u00C7" } },
+                        new RowCollection() { innerCollection = new List<string> { "Z", "X", "C", "V", "B", "N", "M" } },
                     }
                 },
                 new LanguageStyle()
                 {
                     language = "Russian",
-                    style = "ЙЦУКЕН",
+                    style = "\u0419\u0426\u0423\u041A\u0415\u041D",
                     rows = new List<RowCollection>()
                     {
                         new RowCollection() { innerCollection = new List<string> { "1", "2", "3", "4", "5", "6", "7", "8", "9", "0" } },
-                        new RowCollection() { innerCollection = new List<string> { "Й", "Ц", "У", "К", "Е", "Н", "Г", "Ш", "Щ", "З" } },
-                        new RowCollection() { innerCollection = new List<string> { "Х", "Ъ", "Ф", "Ы", "В", "А", "П", "Р", "О", "Л" } },
-                        new RowCollection() { innerCollection = new List<string> { "Д", "Ж", "Э" } },
-                        new RowCollection() { innerCollection = new List<string> { "Я", "Ч", "С", "М", "И", "Т", "Ь", "Б", "Ю" } }
+                        new RowCollection() { innerCollection = new List<string> { "\u0419", "\u0426", "\u0423", "\u041A", "\u0415", "\u041D", "\u0413", "\u0428", "\u0429", "\u0417" } },
+                        new RowCollection() { innerCollection = new List<string> { "\u0425", "\u042A", "\u0424", "\u042B", "\u0412", "\u0410", "\u041F", "\u0420", "\u041E", "\u041B" } },
+                        new RowCollection() { innerCollection = new List<string> { "\u0414", "\u0416", "\u042D" } },
+                        new RowCollection() { innerCollection = new List<string> { "\u042F", "\u0427", "\u0421", "\u041C", "\u0418", "\u0422", "\u042C", "\u0411", "\u042E" } },
                     }
                 },
                 new LanguageStyle()
@@ -131,10 +128,9 @@ public partial class KeyboardLayoutDataEditor
                     rows = new List<RowCollection>()
                     {
                         new RowCollection() { innerCollection = new List<string> { "1", "2", "3", "4", "5", "6", "7", "8", "9", "0" } },
-                        new RowCollection() { innerCollection = new List<string> { " ", "ق", "ک", "گ", "ل", "م", "ن", "و", "ہ", "ء", "ی", "ے", "ئ" } },
-                        new RowCollection() { innerCollection = new List<string> { "ر", "ڑ", "ز", "ژ", "س", "ش", "ص", "ض", "ط", "ظ", "ع", "غ", "ف" } },
-                        new RowCollection() { innerCollection = new List<string> { "ا", "ب", "پ", "ت", "ٹ", "ث", "ج", "چ", "ح", "خ", "د", "ڈ", "ذ" } },
-                        new RowCollection() { innerCollection = new List<string> { " " } }
+                        new RowCollection() { innerCollection = new List<string> { "\u0642", "\u06A9", "\u06AF", "\u0644", "\u0645", "\u0646", "\u0648", "\u06C1", "\u0621", "\u06CC", "\u06D2", "\u0626" } },
+                        new RowCollection() { innerCollection = new List<string> { "\u0631", "\u0691", "\u0632", "\u0698", "\u0633", "\u0634", "\u0635", "\u0636", "\u0637", "\u0638", "\u0639", "\u063A", "\u0641" } },
+                        new RowCollection() { innerCollection = new List<string> { "\u0627", "\u0628", "\u067E", "\u062A", "\u0679", "\u062B", "\u062C", "\u0686", "\u062D", "\u062E", "\u062F", "\u0688", "\u0630" } },
                     }
                 },
                 new LanguageStyle()
@@ -144,12 +140,11 @@ public partial class KeyboardLayoutDataEditor
                     rows = new List<RowCollection>()
                     {
                         new RowCollection() { innerCollection = new List<string> { "1", "2", "3", "4", "5", "6", "7", "8", "9", "0" } },
-                        new RowCollection() { innerCollection = new List<string> { "Q", "W", "E", "R", "T", "Z", "U", "I", "O", "P", "Ü" } },
-                        new RowCollection() { innerCollection = new List<string> { "A", "S", "D", "F", "G", "H", "J", "K", "L", "Ö", "Ä" } },
-                        new RowCollection() { innerCollection = new List<string> { "Y", "X", "C", "V", "B", "N", "M" } }
+                        new RowCollection() { innerCollection = new List<string> { "Q", "W", "E", "R", "T", "Z", "U", "I", "O", "P", "\u00DC" } },
+                        new RowCollection() { innerCollection = new List<string> { "A", "S", "D", "F", "G", "H", "J", "K", "L", "\u00D6", "\u00C4" } },
+                        new RowCollection() { innerCollection = new List<string> { "Y", "X", "C", "V", "B", "N", "M" } },
                     }
                 }
-                // Add more language styles as needed
             };
         }
     }

--- a/Basis/Packages/com.basis.framework/UI Panels/Virtual keyboard/BasisVirtualKeyboard.cs
+++ b/Basis/Packages/com.basis.framework/UI Panels/Virtual keyboard/BasisVirtualKeyboard.cs
@@ -26,11 +26,22 @@ namespace Basis.Scripts.Virtual_keyboard
         public string SelectedLanguage = "English";
         public string SelectedStyle = "QWERTY";
         public bool IsCapital;
+        public bool IsSymbolMode;
         public static InputField InputField;
         public static TMP_InputField TMPInputField;
         public LanguageStyle CurrentSelectedLanguage;
         public static string VirtualKeyboard = "Virtual Keyboard";
         public static bool HasInstance;
+
+        // Symbol layers for when the user toggles to symbols mode
+        private static readonly List<List<string>> SymbolRows = new List<List<string>>
+        {
+            new List<string> { "1", "2", "3", "4", "5", "6", "7", "8", "9", "0" },
+            new List<string> { "@", "#", "$", "%", "&", "*", "-", "+", "(", ")" },
+            new List<string> { "=", "\"", "'", ":", ";", "!", "?", "/", "\\" },
+            new List<string> { "~", "`", "^", "|", "{", "}", "[", "]", "<", ">" },
+        };
+
         public static void CreateMenu(InputField inputField, TMP_InputField tMP_InputField)
         {
             HasInstance = true;
@@ -42,10 +53,10 @@ namespace Basis.Scripts.Virtual_keyboard
         {
             HasInstance = false;
         }
-        // Start is called before the first frame update
         void OnEnable()
         {
             LanguageStyle Language = KeyboardLayoutData.GetLanguageStyle(SelectedLanguage, SelectedStyle);
+            IsSymbolMode = false;
             SetupKeyboard(Language, false);
         }
         public override void InitalizeEvent()
@@ -54,13 +65,30 @@ namespace Basis.Scripts.Virtual_keyboard
         }
         public void ClearOutOldData()
         {
-            // Clear existing rows and destroy previous keyboard parent
             if (keyboardParent != null)
             {
                 Destroy(keyboardParent);
             }
             rows.Clear();
         }
+
+        /// <summary>
+        /// Applies a text change to whichever input field is active and fires onValueChanged.
+        /// </summary>
+        private void ApplyTextChange(Action<InputField> legacyAction, Action<TMP_InputField> tmpAction)
+        {
+            if (InputField != null)
+            {
+                legacyAction(InputField);
+                InputField.onValueChanged.Invoke(InputField.text);
+            }
+            if (TMPInputField != null)
+            {
+                tmpAction(TMPInputField);
+                TMPInputField.onValueChanged.Invoke(TMPInputField.text);
+            }
+        }
+
         public void Callback(BasisVirtualKeyboardButton KeyInformation)
         {
             switch (KeyInformation.BasisVirtualKeyboardSpecialKey)
@@ -73,128 +101,135 @@ namespace Basis.Scripts.Virtual_keyboard
                 case BasisVirtualKeyboardSpecialKey.IsCaseSwitchKey:
                     SetupKeyboard(CurrentSelectedLanguage, !IsCapital);
                     break;
+                case BasisVirtualKeyboardSpecialKey.IsSymbolKey:
+                    IsSymbolMode = !IsSymbolMode;
+                    SetupKeyboard(CurrentSelectedLanguage, IsCapital);
+                    break;
+                case BasisVirtualKeyboardSpecialKey.IsDeleteKey:
+                    ApplyTextChange(
+                        f => { if (f.text.Length > 0) f.text = f.text.Substring(0, f.text.Length - 1); },
+                        f => { if (f.text.Length > 0) f.text = f.text.Substring(0, f.text.Length - 1); }
+                    );
+                    break;
+                case BasisVirtualKeyboardSpecialKey.IsSpaceKey:
+                    ApplyTextChange(
+                        f => f.text += " ",
+                        f => f.text += " "
+                    );
+                    break;
+                case BasisVirtualKeyboardSpecialKey.IsPasteKey:
+                    {
+                        string copiedText = GUIUtility.systemCopyBuffer;
+                        if (!string.IsNullOrEmpty(copiedText))
+                        {
+                            ApplyTextChange(
+                                f => f.text += copiedText,
+                                f => f.text += copiedText
+                            );
+                        }
+                        break;
+                    }
+                case BasisVirtualKeyboardSpecialKey.IsCopyKey:
+                    if (TMPInputField != null)
+                        GUIUtility.systemCopyBuffer = TMPInputField.text;
+                    else if (InputField != null)
+                        GUIUtility.systemCopyBuffer = InputField.text;
+                    break;
+                case BasisVirtualKeyboardSpecialKey.NotSpecial:
                 default:
                     {
-                        if (InputField != null)
-                        {
-                            switch (KeyInformation.BasisVirtualKeyboardSpecialKey)
-                            {
-                                case BasisVirtualKeyboardSpecialKey.IsDeleteKey:
-                                    if (InputField.text.Length > 0)
-                                    {
-                                        InputField.text = InputField.text.Substring(0, InputField.text.Length - 1);
-                                    }
-                                    break;
-                                case BasisVirtualKeyboardSpecialKey.NotSpecial:
-                                    InputField.text += KeyInformation.Text.text;
-                                    break;
-                                case BasisVirtualKeyboardSpecialKey.IsPasteKey:
-                                    {
-                                        string copiedText = GUIUtility.systemCopyBuffer; // Get the clipboard text
-                                        if (Uri.IsWellFormedUriString(copiedText, UriKind.RelativeOrAbsolute))
-                                        {
-                                            InputField.text += copiedText;
-                                        }
-
-                                        break;
-                                    }
-                                case BasisVirtualKeyboardSpecialKey.IsCopyKey:
-                                    GUIUtility.systemCopyBuffer = InputField.text;
-                                    break;
-                            }
-                        }
-                        if (TMPInputField != null)
-                        {
-                            switch (KeyInformation.BasisVirtualKeyboardSpecialKey)
-                            {
-                                case BasisVirtualKeyboardSpecialKey.IsDeleteKey:
-                                    if (TMPInputField.text.Length > 0)
-                                    {
-                                        TMPInputField.text = TMPInputField.text.Substring(0, TMPInputField.text.Length - 1);
-                                    }
-                                    break;
-                                case BasisVirtualKeyboardSpecialKey.NotSpecial:
-                                    TMPInputField.text += KeyInformation.Text.text;
-                                    break;
-                                case BasisVirtualKeyboardSpecialKey.IsPasteKey:
-                                    {
-                                        string copiedText = GUIUtility.systemCopyBuffer; // Get the clipboard text
-
-                                        if (Uri.IsWellFormedUriString(copiedText, UriKind.RelativeOrAbsolute))
-                                        {
-                                            TMPInputField.text += copiedText;
-                                        }
-
-                                        break;
-                                    }
-                                case BasisVirtualKeyboardSpecialKey.IsCopyKey:
-                                    GUIUtility.systemCopyBuffer = TMPInputField.text;
-                                    break;
-                            }
-                        }
+                        string character = KeyInformation.Text.text;
+                        ApplyTextChange(
+                            f => f.text += character,
+                            f => f.text += character
+                        );
                         break;
                     }
             }
         }
-        // Setup the QWERTY keyboard layout
+
+        /// <summary>
+        /// Sets up the keyboard layout. Uses symbol rows when in symbol mode,
+        /// otherwise uses the language layout. Capitalization is applied to copies
+        /// of the row data so the ScriptableObject is never mutated.
+        /// </summary>
         public void SetupKeyboard(LanguageStyle Language, bool IsCapitalization)
         {
             IsCapital = IsCapitalization;
             CurrentSelectedLanguage = Language;
             ClearOutOldData();
-            // Create a parent object to hold all the rows
+
             keyboardParent = new GameObject(KeyboardParent);
             keyboardParent.transform.SetParent(this.transform);
             keyboardParent.transform.SetLocalPositionAndRotation(Vector3.zero, Quaternion.identity);
             keyboardParent.transform.localScale = Vector3.one;
 
-            // Ensure the parent object has a RectTransform component
             RectTransform keyboardParentRectTransform = keyboardParent.AddComponent<RectTransform>();
 
-            // Calculate the required width based on the widest row and fixed height of 50 units
-            float totalWidth = 0f;
-            List<RowCollection> Rows = Language.rows;
-            for (int Index = 0; Index < Rows.Count; Index++)
-            {
-                List<string> ItemsInRow = Rows[Index].innerCollection;
-                for (int RowIndex = 0; RowIndex < ItemsInRow.Count; RowIndex++)
-                {
-                    if (IsCapitalization)
-                    {
-                        ItemsInRow[RowIndex] = ItemsInRow[RowIndex].ToUpper();
-                    }
-                    else
-                    {
-                        ItemsInRow[RowIndex] = ItemsInRow[RowIndex].ToLower();
-                    }
+            // Build the display rows: either symbol layer or language layout + utility row
+            List<List<string>> displayRows = new List<List<string>>();
 
+            if (IsSymbolMode)
+            {
+                foreach (var symbolRow in SymbolRows)
+                {
+                    displayRows.Add(new List<string>(symbolRow));
                 }
             }
-            foreach (var row in Rows)
+            else
             {
-                float rowWidth = row.innerCollection.Count * (RowWidth + VerticalSpacing); // Assuming each button is 50 units wide
+                // Copy row data and apply capitalization without mutating the ScriptableObject
+                List<RowCollection> sourceRows = Language.rows;
+                for (int i = 0; i < sourceRows.Count; i++)
+                {
+                    List<string> items = sourceRows[i].innerCollection;
+                    List<string> rowCopy = new List<string>(items.Count);
+                    for (int j = 0; j < items.Count; j++)
+                    {
+                        rowCopy.Add(IsCapitalization ? items[j].ToUpper() : items[j].ToLower());
+                    }
+                    displayRows.Add(rowCopy);
+                }
+            }
+
+            // Add the punctuation row (before utility keys)
+            if (!IsSymbolMode)
+            {
+                displayRows.Add(new List<string> { ".", ",", "?", "!", "'", "-", "@", ":" });
+            }
+
+            // Add the bottom utility row with special keys
+            string capsLabel = IsCapital ? "abc" : "ABC";
+            string symbolLabel = IsSymbolMode ? "ABC" : "#+=";
+            displayRows.Add(new List<string> { capsLabel, symbolLabel, "Space", "Del", "Paste", "Copy", "Enter", "Close" });
+
+            // Calculate total width from the widest row
+            float totalWidth = 0f;
+            foreach (var row in displayRows)
+            {
+                float rowWidth = 0f;
+                foreach (var key in row)
+                {
+                    float keyWidth = GetKeyWidth(key, Language.SpecialKeys);
+                    rowWidth += keyWidth + HorizontalSpacing;
+                }
                 if (rowWidth > totalWidth)
                 {
                     totalWidth = rowWidth;
                 }
             }
 
-            // Set the size of the RectTransform to match the calculated width and fixed height
-            keyboardParentRectTransform.sizeDelta = new Vector2(totalWidth, (rowHeight + VerticalSpacing) * Rows.Count);
-
-            // Set the size of the Canvas to match the RectTransform
+            keyboardParentRectTransform.sizeDelta = new Vector2(totalWidth, (rowHeight + VerticalSpacing) * displayRows.Count);
             CanvasRectTransform.sizeDelta = keyboardParentRectTransform.sizeDelta;
 
-            // Add VerticalLayoutGroup to the parent object
             VerticalLayoutGroup verticalLayoutGroup = keyboardParent.AddComponent<VerticalLayoutGroup>();
             verticalLayoutGroup.childControlHeight = true;
             verticalLayoutGroup.childControlWidth = true;
             SetCommon(verticalLayoutGroup, VerticalSpacing);
 
-            // Create the rows and buttons based on the layout
-            foreach (var row in Rows)
+            // Build each row
+            foreach (var row in displayRows)
             {
-                // Create a new GameObject for the row
                 GameObject rowObject = new GameObject(RowName);
                 rowObject.transform.SetParent(keyboardParent.transform);
                 rowObject.transform.SetLocalPositionAndRotation(Vector3.zero, Quaternion.identity);
@@ -203,7 +238,6 @@ namespace Basis.Scripts.Virtual_keyboard
                 RectTransform rowRectTransform = rowObject.AddComponent<RectTransform>();
                 rowRectTransform.sizeDelta = new Vector2(totalWidth, rowHeight + VerticalSpacing);
 
-                // Add HorizontalLayoutGroup to the row object
                 HorizontalLayoutGroup horizontalLayoutGroup = rowObject.AddComponent<HorizontalLayoutGroup>();
                 horizontalLayoutGroup.childControlHeight = false;
                 horizontalLayoutGroup.childControlWidth = false;
@@ -212,30 +246,121 @@ namespace Basis.Scripts.Virtual_keyboard
                 BasisVirtualRow basisRow = new BasisVirtualRow();
                 basisRow.RowObject = rowObject;
 
-                List<string> ItemsInRow = row.innerCollection;
-                for (int RowIndex = 0; RowIndex < ItemsInRow.Count; RowIndex++)
+                for (int keyIndex = 0; keyIndex < row.Count; keyIndex++)
                 {
-                    BasisVirtualKeyboardButton button = CreateButton(ItemsInRow[RowIndex]);
+                    string keyLabel = row[keyIndex];
+                    BasisVirtualKeyboardButton button = CreateButton(keyLabel);
                     button.ButtonRect.SetParent(rowObject.transform);
                     button.ButtonRect.SetLocalPositionAndRotation(Vector3.zero, Quaternion.identity);
                     button.ButtonRect.localScale = Vector3.one;
-                    if (basisRow.SetupButton(button, Language.SpecialKeys, RowWidth, out SpecialKeySizes FoundSpecial))
+
+                    // Check for built-in utility keys first
+                    BasisVirtualKeyboardSpecialKey builtInKey = GetBuiltInSpecialKey(keyLabel);
+                    if (builtInKey != BasisVirtualKeyboardSpecialKey.NotSpecial)
+                    {
+                        button.BasisVirtualKeyboardSpecialKey = builtInKey;
+                        basisRow.SetScale(button, GetUtilityKeyWidth(builtInKey));
+                        // Apply display labels for utility keys
+                        button.Text.text = GetUtilityKeyDisplayLabel(builtInKey, keyLabel);
+                    }
+                    else if (basisRow.SetupButton(button, Language.SpecialKeys, RowWidth, out SpecialKeySizes FoundSpecial))
                     {
                         button.BasisVirtualKeyboardSpecialKey = FoundSpecial.BasisVirtualKeyboardSpecialKey;
                     }
+
                     button.Button.onClick.AddListener(() => Callback(button));
                     basisRow.RowButtons.Add(button);
-                    rows.Add(basisRow);
                 }
+                rows.Add(basisRow);
             }
         }
+
+        /// <summary>
+        /// Returns the special key type for built-in utility key labels.
+        /// </summary>
+        private BasisVirtualKeyboardSpecialKey GetBuiltInSpecialKey(string label)
+        {
+            switch (label)
+            {
+                case "Del": return BasisVirtualKeyboardSpecialKey.IsDeleteKey;
+                case "ABC":
+                case "abc": return BasisVirtualKeyboardSpecialKey.IsCaseSwitchKey;
+                case "Enter": return BasisVirtualKeyboardSpecialKey.IsEnterKey;
+                case "Close": return BasisVirtualKeyboardSpecialKey.IsCloseKey;
+                case "Paste": return BasisVirtualKeyboardSpecialKey.IsPasteKey;
+                case "Copy": return BasisVirtualKeyboardSpecialKey.IsCopyKey;
+                case "#+=": return BasisVirtualKeyboardSpecialKey.IsSymbolKey;
+                case "Space": return BasisVirtualKeyboardSpecialKey.IsSpaceKey;
+                default: return BasisVirtualKeyboardSpecialKey.NotSpecial;
+            }
+        }
+
+        /// <summary>
+        /// Returns the display width for a built-in utility key.
+        /// </summary>
+        private float GetUtilityKeyWidth(BasisVirtualKeyboardSpecialKey key)
+        {
+            switch (key)
+            {
+                case BasisVirtualKeyboardSpecialKey.IsSpaceKey: return RowWidth * 2.5f;
+                case BasisVirtualKeyboardSpecialKey.IsDeleteKey: return RowWidth * 1.5f;
+                case BasisVirtualKeyboardSpecialKey.IsCaseSwitchKey: return RowWidth * 1.5f;
+                case BasisVirtualKeyboardSpecialKey.IsSymbolKey: return RowWidth * 1.5f;
+                case BasisVirtualKeyboardSpecialKey.IsEnterKey: return RowWidth * 1.5f;
+                case BasisVirtualKeyboardSpecialKey.IsCloseKey: return RowWidth * 1.5f;
+                case BasisVirtualKeyboardSpecialKey.IsPasteKey: return RowWidth * 1.5f;
+                case BasisVirtualKeyboardSpecialKey.IsCopyKey: return RowWidth * 1.5f;
+                default: return RowWidth;
+            }
+        }
+
+        /// <summary>
+        /// Returns a user-friendly display label for utility keys.
+        /// </summary>
+        private string GetUtilityKeyDisplayLabel(BasisVirtualKeyboardSpecialKey key, string originalLabel)
+        {
+            switch (key)
+            {
+                case BasisVirtualKeyboardSpecialKey.IsSpaceKey: return " ";
+                case BasisVirtualKeyboardSpecialKey.IsDeleteKey: return "\u232B";
+                case BasisVirtualKeyboardSpecialKey.IsEnterKey: return "\u23CE";
+                case BasisVirtualKeyboardSpecialKey.IsCloseKey: return "\u2715";
+                default: return originalLabel;
+            }
+        }
+
+        /// <summary>
+        /// Gets the width for a specific key, checking special keys configuration first.
+        /// </summary>
+        private float GetKeyWidth(string keyLabel, List<SpecialKeySizes> specialKeys)
+        {
+            BasisVirtualKeyboardSpecialKey builtIn = GetBuiltInSpecialKey(keyLabel);
+            if (builtIn != BasisVirtualKeyboardSpecialKey.NotSpecial)
+            {
+                return GetUtilityKeyWidth(builtIn);
+            }
+
+            if (specialKeys != null)
+            {
+                foreach (var sk in specialKeys)
+                {
+                    if (keyLabel.Equals(sk.Match, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return sk.WidthSize;
+                    }
+                }
+            }
+
+            return RowWidth;
+        }
+
         public void SetCommon(HorizontalOrVerticalLayoutGroup HorizontalOrVerticalLayoutGroup, float Spacing)
         {
             HorizontalOrVerticalLayoutGroup.childForceExpandHeight = false;
             HorizontalOrVerticalLayoutGroup.childForceExpandWidth = false;
             HorizontalOrVerticalLayoutGroup.spacing = Spacing;
         }
-        // Helper method to create a button
+
         BasisVirtualKeyboardButton CreateButton(string label)
         {
             GameObject buttonObject = GameObject.Instantiate(CopyFrom.gameObject, this.transform);

--- a/Basis/Packages/com.basis.framework/UI Panels/Virtual keyboard/BasisVirtualKeyboardButton.cs
+++ b/Basis/Packages/com.basis.framework/UI Panels/Virtual keyboard/BasisVirtualKeyboardButton.cs
@@ -13,6 +13,6 @@ public struct BasisVirtualKeyboardButton
 }
 public enum BasisVirtualKeyboardSpecialKey
 {
-   NotSpecial, IsDeleteKey, IsCaseSwitchKey,IsEnterKey,IsCloseKey,IsPasteKey,IsCopyKey
+   NotSpecial, IsDeleteKey, IsCaseSwitchKey, IsEnterKey, IsCloseKey, IsPasteKey, IsCopyKey, IsSymbolKey, IsSpaceKey
 }
 }

--- a/Basis/Packages/com.basis.framework/UI Panels/Virtual keyboard/BasisVirtualRow.cs
+++ b/Basis/Packages/com.basis.framework/UI Panels/Virtual keyboard/BasisVirtualRow.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using UnityEngine;
 using static Basis.Scripts.Virtual_keyboard.KeyboardLayoutData;
 namespace Basis.Scripts.Virtual_keyboard
@@ -7,27 +7,29 @@ public class BasisVirtualRow
 {
     public List<BasisVirtualKeyboardButton> RowButtons = new List<BasisVirtualKeyboardButton>();
     public GameObject RowObject;
-    public bool SetupButton(BasisVirtualKeyboardButton button, List<SpecialKeySizes> SpecialKeys, float ScaleSize,out SpecialKeySizes SpecialKeySizes)
+    public bool SetupButton(BasisVirtualKeyboardButton button, List<SpecialKeySizes> SpecialKeys, float ScaleSize, out SpecialKeySizes SpecialKeySizes)
     {
-        SetScale(button, ScaleSize); // default size;
-        foreach (var SpecialKey in SpecialKeys)
+        SetScale(button, ScaleSize); // default size
+        if (SpecialKeys != null)
         {
-            if (button.Text.text.ToLower() == SpecialKey.Match.ToLower())
+            foreach (var SpecialKey in SpecialKeys)
             {
-                SetScale(button, SpecialKey.WidthSize);//check for special
-                button.Button.colors = SpecialKey.ColorBlock;
-                SpecialKeySizes = SpecialKey;
-                return true;
+                if (button.Text.text.Equals(SpecialKey.Match, System.StringComparison.OrdinalIgnoreCase))
+                {
+                    SetScale(button, SpecialKey.WidthSize);
+                    button.Button.colors = SpecialKey.ColorBlock;
+                    SpecialKeySizes = SpecialKey;
+                    return true;
+                }
             }
         }
         SpecialKeySizes = new SpecialKeySizes();
         return false;
     }
 
-
     public void SetScale(BasisVirtualKeyboardButton button, float width)
     {
-        button.ButtonRect.sizeDelta = new Vector2(width, button.ButtonRect.sizeDelta.y); // Adjust the width multiplier as needed
+        button.ButtonRect.sizeDelta = new Vector2(width, button.ButtonRect.sizeDelta.y);
     }
 }
 }


### PR DESCRIPTION
## Summary

The VR keyboard had several critical issues making it nearly unusable in practice. This PR fixes all of them and adds essential missing functionality.

### Bugs fixed
- **Paste only accepted URIs** — `Uri.IsWellFormedUriString` check rejected all normal text. Now accepts any non-empty clipboard content
- **ScriptableObject data corruption** — `SetupKeyboard` called `ToUpper()`/`ToLower()` directly on the `LanguageStyle.rows` collections, permanently mutating the source data. Caps lock toggle would corrupt the layout. Now operates on copies
- **Row tracking duplicates** — `rows.Add(basisRow)` was inside the inner button loop (per-key) instead of per-row, flooding the list with duplicates
- **Missing space bar** on 7 of 11 layouts (Mandarin, Hindi, Spanish, Bengali, Portuguese, Russian, German)
- **No utility keys placed** — Delete, Enter, Close, Caps, Copy, Paste were defined as enum types but never actually placed on any keyboard layout
- **No onValueChanged events** — text changes via the virtual keyboard didn't fire `onValueChanged`, breaking input validation and UI updates
- **Null reference in BasisVirtualRow** — `SetupButton` iterated `SpecialKeys` without null check
- **Duplicated callback logic** — identical `InputField` / `TMP_InputField` handling was copy-pasted in `Callback`

### New features
- **Unified utility row** automatically appended to every layout: ABC/abc, #+=, Space, Del, Paste, Copy, Enter, Close
- **Punctuation row** (. , ? ! ' - @ :) shown on the letter layer
- **Symbol layer toggle** (#+=) with 4 rows of symbols: @#$%&*-+(), =":;!?/\, ~backtick^|{}<>[], plus numbers
- **Unicode display glyphs** for utility keys for cleaner visual appearance
- **Proper key width scaling** — utility keys are 1.5x to 2.5x wider than character keys
- **New enum values** IsSymbolKey and IsSpaceKey for the new key types

### Files changed
| File | Change |
|------|--------|
| BasisVirtualKeyboard.cs | Core rewrite — symbol mode, utility row, safe capitalization, deduplicated callbacks, onValueChanged |
| BasisVirtualKeyboardButton.cs | Added IsSymbolKey, IsSpaceKey to enum |
| BasisVirtualRow.cs | Null-safe SpecialKeys handling, StringComparison.OrdinalIgnoreCase |
| BasisVirtualKeyboardDefaultLanguagesAndStyles.cs | Removed standalone space rows, added number row to Portuguese, cleaned up |

## Test plan
- [ ] Spawn VR keyboard by focusing an input field in VR mode
- [ ] Verify all utility keys appear on the bottom row (ABC, #+=, Space, Del, Paste, Copy, Enter, Close)
- [ ] Verify punctuation row (. , ? ! ' - @ :) appears above utility row
- [ ] Toggle caps lock — verify letters switch case without corrupting layout on repeated toggles
- [ ] Toggle symbol mode (#+=) — verify symbol rows appear, toggle back shows letters again
- [ ] Type characters and verify text appears in the input field
- [ ] Press delete and verify last character is removed
- [ ] Copy text, switch fields, paste — verify clipboard works with normal text (not just URIs)
- [ ] Press Enter/Close and verify keyboard dismisses
- [ ] Test with multiple language layouts (English, Russian, Arabic, Hindi)

Generated with [Claude Code](https://claude.com/claude-code)