### PR TITLE
Fix ownership transfer race condition

### DIFF
--- a/Basis/Packages/com.basis.framework/Networking/BasisNetworkBehaviour/BasisNetworkBehaviour.cs
+++ b/Basis/Packages/com.basis.framework/Networking/BasisNetworkBehaviour/BasisNetworkBehaviour.cs
@@ -99,8 +99,11 @@ namespace Basis
                 //convert GUID into Ushort for network transport.
                 BasisIdResolutionResult IDResolverResult = await IDResolverAsync;
                 var InitalOwnershipStatus = await output;
-                CurrentOwnerId = InitalOwnershipStatus.PlayerId;
-                BasisNetworkPlayers.GetPlayerById(CurrentOwnerId, out currentOwnedPlayer);
+                if (InitalOwnershipStatus.Success)
+                {
+                    CurrentOwnerId = InitalOwnershipStatus.PlayerId;
+                    BasisNetworkPlayers.GetPlayerById(CurrentOwnerId, out currentOwnedPlayer);
+                }
                 HasNetworkID = IDResolverResult.Success;
                 NetworkID = IDResolverResult.Id;
                 if (HasNetworkID)

--- a/Basis/Packages/com.basis.framework/Networking/BasisNetworkOwnership.cs
+++ b/Basis/Packages/com.basis.framework/Networking/BasisNetworkOwnership.cs
@@ -20,7 +20,6 @@ public static partial class BasisNetworkOwnership
             if (ownershipID == UniqueNetworkId)
             {
                 BasisNetworkPlayer.OnOwnershipTransfer -= OnOwnershipTransferred;
-                cancellationTokenSource.Cancel(); // Stop timeout countdown
                 tcs.TrySetResult(new BasisOwnershipResult(true, playerID));
             }
         }
@@ -74,7 +73,6 @@ public static partial class BasisNetworkOwnership
             if (ownershipID == UniqueNetworkId && playerID == NewOwner)
             {
                 BasisNetworkPlayer.OnOwnershipTransfer -= OnOwnershipTransferred;
-                cancellationTokenSource.Cancel(); // Stop timeout countdown
                 tcs.TrySetResult(new BasisOwnershipResult(true, playerID));
             }
         }
@@ -150,7 +148,6 @@ public static partial class BasisNetworkOwnership
             if (ownershipID == UniqueNetworkId)
             {
                 BasisNetworkPlayer.OnOwnershipTransfer -= OnOwnershipTransferred;
-                cancellationTokenSource.Cancel(); // Stop timeout countdown
                 tcs.TrySetResult(new BasisOwnershipResult(true, playerID));
             }
         }


### PR DESCRIPTION
Canceling the timeout countdown before setting `tcs.TrySetResult` with success creates a race condition where `tcs.TrySetResult(BasisOwnershipResult.Failed);` will actually run first, and the success will be rejected.

Moving `cancellationTokenSource.Cancel();` to after `tcs.TrySetResult` creates a separate race condition where the `using` block resolves and disposes the `CancellationTokenSource` before Cancel can be called.

It's safe to just remove this line because it is automatically disposed at that point anyway.
