### PR TITLE
Fix interact system crash on OpenXR eye-tracking headset disconnect

### DIFF
--- a/Basis/Packages/com.basis.framework/Interactions/BasisPlayerInteract.cs
+++ b/Basis/Packages/com.basis.framework/Interactions/BasisPlayerInteract.cs
@@ -111,6 +111,12 @@ namespace Basis.Scripts.BasisSdk.Interactions
                 return;
             }
 
+            // Guard against duplicate additions
+            if (InteractInputs.Any(x => x.input.UniqueDeviceIdentifier == input.UniqueDeviceIdentifier))
+            {
+                return;
+            }
+
             var interactInput = new BasisInteractInput
             {
                 input = input,
@@ -124,10 +130,10 @@ namespace Basis.Scripts.BasisSdk.Interactions
 
         private void OnInputRemoved(BasisInput input)
         {
-            if (input.HasRaycaster)
-            {
-                RemoveInput(input.UniqueDeviceIdentifier);
-            }
+            // Always attempt removal regardless of current HasRaycaster state.
+            // The raycaster state may have changed between when the input was added
+            // and when it is being removed (e.g., OpenXR eye tracking detected late).
+            RemoveInput(input.UniqueDeviceIdentifier);
         }
 
         // Simulate after IK update
@@ -521,7 +527,9 @@ namespace Basis.Scripts.BasisSdk.Interactions
 
             if (length == 0)
             {
-                BasisDebug.LogError($"Interact Inputs did not include {uid}. Please report this bug.");
+                // Not an error: the device may never have been a raycaster when it was
+                // added (e.g., OpenXR headset whose eye tracking was detected after
+                // the input was registered). See issue #389.
                 return;
             }
 


### PR DESCRIPTION
## Summary
- Fixes a crash when disconnecting an OpenXR headset with eye tracking (e.g., Samsung Galaxy XR) and switching to desktop mode
- The root cause is a state mismatch: `OnInputChanged` only adds devices to `InteractInputs` if `HasRaycaster` is `true` at add time, but `OnInputRemoved` checks `HasRaycaster` at remove time — if the raycaster capability was detected *after* the device was registered, the remove path tries to remove something that was never added
- Removes the `HasRaycaster` guard from `OnInputRemoved` so removal is always attempted
- Treats "not found" in `RemoveInput` as a no-op instead of an error (expected for devices whose raycaster state changed after registration)
- Adds a duplicate-addition guard in `OnInputChanged`

Fixes #389

## Test plan
- [ ] Connect an OpenXR headset with eye tracking (e.g., Samsung Galaxy XR)
- [ ] Enter VR mode, then switch to desktop mode — verify no error is logged
- [ ] Verify normal headset/controller connect/disconnect still works without errors
- [ ] Verify interaction raycasting still functions correctly in both VR and desktop modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)