### PR TITLE
Desktop pickup hand emulation / Pickup lerp

### DIFF
--- a/Basis/Packages/com.basis.framework/Interactions/BasisPickupInteractable.cs
+++ b/Basis/Packages/com.basis.framework/Interactions/BasisPickupInteractable.cs
@@ -344,7 +344,11 @@ namespace Basis.Scripts.BasisSdk.Interactions
 
         private void OnBootModeChanged(string mode)
         {
-            BasisLocalPlayer.Instance.OnLatePollData -= OverrideDesktopHandTarget;
+            if (BasisLocalPlayer.Instance != null)
+            {
+                BasisLocalPlayer.Instance.OnLatePollData -= OverrideDesktopHandTarget;
+            }
+
             Drop();
         }
 
@@ -499,14 +503,20 @@ namespace Basis.Scripts.BasisSdk.Interactions
                     transform.GetPositionAndRotation(out Vector3 ActivePosition, out Quaternion ActiveRotation);
 
                     Vector3 offsetPos;
-                    if (BasisDeviceManagement.IsUserInDesktop())
+                    bool inDesktop = BasisDeviceManagement.IsUserInDesktop();
+                    if (inDesktop)
                     {
                         EnableDesktopHandTracking();
                     }
 
                     if (LerpToHandOnPickup)
                     {
-                        offsetPos = Vector3.zero;
+                        Vector3 lerpTarget = inPos;
+                        if (inDesktop)
+                        {
+                            lerpTarget = inPos + inRot * (useMagicNumberHandOffset * BasisHeightDriver.ScaledToMatchValue);
+                        }
+                        offsetPos = ComputeClosestBoundsOffset(lerpTarget, inRot, ActivePosition);
                         InputConstraint.GlobalWeight = 0f;
                         _lerpElapsed = 0f;
                         _lerping = true;
@@ -1095,6 +1105,32 @@ namespace Basis.Scripts.BasisSdk.Interactions
             useMagicNumberHandOffset = BasisDominantHand.IsLeftHanded ? magicNumberHandOffsetLeft : magicNumberHandOffsetRight;
             useMagicNumberHandRotation = BasisDominantHand.IsLeftHanded ? magicNumberHandRotationLeft : magicNumberHandRotationRight;
             useMagicNumberItemDelta = BasisDominantHand.IsLeftHanded ? magicNumberItemDeltaLeft : magicNumberItemDeltaRight;
+        }
+
+        /// <summary>
+        /// Computes a constraint offset so that the closest point on the object's collider bounds
+        /// aligns with the hand, rather than the object center.
+        /// </summary>
+        private Vector3 ComputeClosestBoundsOffset(Vector3 inPos, Quaternion handRot, Vector3 objectPos)
+        {
+            Collider[] colliders = GetColliders();
+            if (colliders == null || colliders.Length == 0)
+                return Vector3.zero;
+
+            Vector3 bestPoint = objectPos;
+            float bestDistSq = float.MaxValue;
+            for (int i = 0; i < colliders.Length; i++)
+            {
+                if (colliders[i] == null) continue;
+                Vector3 point = colliders[i].ClosestPoint(inPos);
+                float distSq = (point - inPos).sqrMagnitude;
+                if (distSq < bestDistSq)
+                {
+                    bestDistSq = distSq;
+                    bestPoint = point;
+                }
+            }
+            return Quaternion.Inverse(handRot) * (objectPos - bestPoint);
         }
 
         /// <summary>

--- a/Basis/Packages/com.basis.framework/Interactions/BasisPickupInteractable.cs
+++ b/Basis/Packages/com.basis.framework/Interactions/BasisPickupInteractable.cs
@@ -10,6 +10,7 @@ using UnityEngine.AddressableAssets;
 using UnityEngine.InputSystem;
 using UnityEngine.ResourceManagement.AsyncOperations;
 using System.Collections;
+using Basis.Scripts.BasisSdk.Players;
 using Unity.Mathematics;
 
 namespace Basis.Scripts.BasisSdk.Interactions
@@ -35,6 +36,12 @@ namespace Basis.Scripts.BasisSdk.Interactions
         /// </summary>
         [Tooltip("Enables the ability to self-steal")]
         public bool CanSelfSteal = true;
+
+        /// <summary>
+        /// If <see langword="true"/>, the object will smoothly interpolate to the hand position/rotation on pickup.
+        /// </summary>
+        [Tooltip("The object will move to the player's hand instead of keeping its offset on pickup")]
+        public bool LerpToHandOnPickup = true;
 
         /// <summary>
         /// Show Highlight on haver. does not effect on hover exit.
@@ -260,6 +267,22 @@ namespace Basis.Scripts.BasisSdk.Interactions
         private Coroutine _autoReturnCoroutine;
         # endregion
 
+        private const float lerpToHandDuration = 0.05f;
+        private float _lerpElapsed;
+        private bool _lerping;
+
+        private Vector3 magicNumberHandOffsetRight = new(0.26f, -0.14f, 0.24f); // right, down, forward
+        private Quaternion magicNumberHandRotationRight = Quaternion.Euler(00, 010, -100);
+        private Vector3 magicNumberHandOffsetLeft = new(-0.26f, -0.14f, 0.24f); // left, down, forward
+        private Quaternion magicNumberHandRotationLeft = Quaternion.Euler(0, -10, -80);
+        private Vector3 magicNumberItemDeltaRight = new(-.05f, .025f, .05f); // slightly inward from right hand
+        private Vector3 magicNumberItemDeltaLeft = new(.05f, .025f, .05f);   // slightly inward from left hand
+
+        private BasisLocalBoneControl useHandBoneControl;
+        private Vector3 useMagicNumberHandOffset;
+        private Quaternion useMagicNumberHandRotation;
+        private Vector3 useMagicNumberItemDelta;
+
         private float _previousDistance = 0;
         /// <summary>
         /// Unity start hook. Ensures references, allocates constraint, loads highlight material, and optionally builds the collider highlight mesh.
@@ -306,6 +329,23 @@ namespace Basis.Scripts.BasisSdk.Interactions
                 }
             }
             OnInteractStartEvent.AddListener(OnInteractionEventFired);
+        }
+
+        private void OnEnable()
+        {
+            BasisDeviceManagement.OnBootModeChanged += OnBootModeChanged;
+        }
+
+        private void OnDisable()
+        {
+            BasisDeviceManagement.OnBootModeChanged -= OnBootModeChanged;
+            Drop();
+        }
+
+        private void OnBootModeChanged(string mode)
+        {
+            BasisLocalPlayer.Instance.OnLatePollData -= OverrideDesktopHandTarget;
+            Drop();
         }
 
         internal void OnInteractionEventFired(BasisInput input)
@@ -458,8 +498,26 @@ namespace Basis.Scripts.BasisSdk.Interactions
 
                     transform.GetPositionAndRotation(out Vector3 ActivePosition, out Quaternion ActiveRotation);
 
-                    var offsetPos = Quaternion.Inverse(inRot) * (ActivePosition - inPos);
-                    var offsetRot = Quaternion.Inverse(inRot) * ActiveRotation;
+                    Vector3 offsetPos;
+                    if (BasisDeviceManagement.IsUserInDesktop())
+                    {
+                        EnableDesktopHandTracking();
+                    }
+
+                    if (LerpToHandOnPickup)
+                    {
+                        offsetPos = Vector3.zero;
+                        InputConstraint.GlobalWeight = 0f;
+                        _lerpElapsed = 0f;
+                        _lerping = true;
+                        InputConstraint.GlobalWeight = 1f;
+                    }
+                    else
+                    {
+                        offsetPos = Quaternion.Inverse(inRot) * (ActivePosition - inPos);
+                    }
+
+                    Quaternion offsetRot = Quaternion.Inverse(inRot) * ActiveRotation;
 
                     InputConstraint.SetOffsetPositionAndRotation(0, offsetPos, offsetRot);
 
@@ -514,6 +572,7 @@ namespace Basis.Scripts.BasisSdk.Interactions
                     }
 
                     InputConstraint.Enabled = false;
+                    _lerping = false;
                     InputConstraint.sources = new BasisConstraintSourceData[] { new() { weight = 1f } };
 
                     if (RigidRef != null)
@@ -533,6 +592,11 @@ namespace Basis.Scripts.BasisSdk.Interactions
                         }
                     }
                     BasisDebug.Log($"OnInteractEnd", BasisDebug.LogTag.Pickups);
+
+                    if (BasisDeviceManagement.IsUserInDesktop())
+                    {
+                        DisableDesktopHandTracking();
+                    }
 
                     OnInteractEndEvent?.Invoke(input);
                 }
@@ -611,9 +675,27 @@ namespace Basis.Scripts.BasisSdk.Interactions
         {
             if (!GetActiveInteracting(out BasisInputWrapper interactingInput)) return;
 
-            Vector3 inPos = interactingInput.BoneControl.OutgoingWorldData.position;
+            if (_lerping)
+            {
+                _lerpElapsed += Time.deltaTime;
+                float t = Mathf.Clamp01(_lerpElapsed / lerpToHandDuration);
+                InputConstraint.GlobalWeight = t * t;
+                if (t >= 1f)
+                    _lerping = false;
+            }
+
+            Vector3 inPos;
             Quaternion inRot = interactingInput.BoneControl.OutgoingWorldData.rotation;
 
+            if (LerpToHandOnPickup)
+            {
+                inPos = useHandBoneControl.OutgoingWorldData.position
+                        + interactingInput.BoneControl.OutgoingWorldData.rotation * useMagicNumberItemDelta * BasisHeightDriver.ScaledToMatchValue;
+            }
+            else
+            {
+                inPos = interactingInput.BoneControl.OutgoingWorldData.position;
+            }
 
             if (BasisDeviceManagement.IsUserInDesktop())
             {
@@ -979,6 +1061,41 @@ namespace Basis.Scripts.BasisSdk.Interactions
             }
         }
 #endif
+
+        private void EnableDesktopHandTracking()
+        {
+            UpdateDominantHandValues();
+            BasisLocalPlayer.Instance.OnLatePollData -= OverrideDesktopHandTarget;
+            BasisLocalPlayer.Instance.OnLatePollData += OverrideDesktopHandTarget;
+            useHandBoneControl.HasTracked = BasisHasTracked.HasTracker;
+            useHandBoneControl.HasRigLayer = BasisHasRigLayer.HasRigLayer;
+        }
+
+        private void DisableDesktopHandTracking()
+        {
+            useHandBoneControl.HasTracked = BasisHasTracked.HasNoTracker;
+            useHandBoneControl.HasRigLayer = BasisHasRigLayer.HasNoRigLayer;
+            BasisLocalPlayer.Instance.OnLatePollData -= OverrideDesktopHandTarget;
+        }
+
+        private void OverrideDesktopHandTarget()
+        {
+            BasisLocalBoneControl eye = BasisLocalBoneDriver.EyeControl;
+            BasisLocalBoneControl hand = useHandBoneControl;
+
+            Vector3 offset = useMagicNumberHandOffset * BasisHeightDriver.ScaledToMatchValue;
+
+            hand.IncomingData.position = eye.IncomingData.position + eye.IncomingData.rotation * offset;
+            hand.IncomingData.rotation = eye.IncomingData.rotation * useMagicNumberHandRotation;
+        }
+
+        private void UpdateDominantHandValues()
+        {
+            useHandBoneControl = BasisDominantHand.IsLeftHanded ? BasisLocalBoneDriver.LeftHandControl : BasisLocalBoneDriver.RightHandControl;
+            useMagicNumberHandOffset = BasisDominantHand.IsLeftHanded ? magicNumberHandOffsetLeft : magicNumberHandOffsetRight;
+            useMagicNumberHandRotation = BasisDominantHand.IsLeftHanded ? magicNumberHandRotationLeft : magicNumberHandRotationRight;
+            useMagicNumberItemDelta = BasisDominantHand.IsLeftHanded ? magicNumberItemDeltaLeft : magicNumberItemDeltaRight;
+        }
 
         /// <summary>
         /// Convenience method to force a drop by clearing all influencers.

--- a/Basis/Packages/com.basis.framework/Interactions/BasisPickupInteractable.cs
+++ b/Basis/Packages/com.basis.framework/Interactions/BasisPickupInteractable.cs
@@ -267,6 +267,8 @@ namespace Basis.Scripts.BasisSdk.Interactions
         private Coroutine _autoReturnCoroutine;
         # endregion
 
+        public bool CanSelfStealResolved => CanSelfSteal && !BasisDeviceManagement.IsUserInDesktop();
+
         private const float lerpToHandDuration = 0.05f;
         private float _lerpElapsed;
         private bool _lerping;
@@ -379,7 +381,7 @@ namespace Basis.Scripts.BasisSdk.Interactions
         {
             // NOTE: see CanInteract note
             return InteractableEnabled &&
-                (!Inputs.AnyInteracting() || CanSelfSteal) &&               // self-steal
+                (!Inputs.AnyInteracting() || CanSelfStealResolved) &&               // self-steal
                 !input.BasisUIRaycast.HadRaycastUITarget &&                 // didn't hit UI target this frame
                 Inputs.IsInputAdded(input) &&                               // input exists
                 input.TryGetRole(out BasisBoneTrackedRole role) &&          // has role
@@ -395,7 +397,7 @@ namespace Basis.Scripts.BasisSdk.Interactions
             // NOTE: Injected checks must be called at the end so that we can safely assume that at the time this was invoked, everything was valid.
             //       Important for net sync: pending steal requests shouldn't re-invoke with stale data.
             return InteractableEnabled &&
-                (!Inputs.AnyInteracting() || CanSelfSteal) &&               // self-steal
+                (!Inputs.AnyInteracting() || CanSelfStealResolved) &&               // self-steal
                 !input.BasisUIRaycast.HadRaycastUITarget &&                 // didn't hit UI target this frame
                 Inputs.IsInputAdded(input) &&                               // input exists
                 input.TryGetRole(out BasisBoneTrackedRole role) &&          // has role
@@ -409,7 +411,7 @@ namespace Basis.Scripts.BasisSdk.Interactions
         public override bool CanDirectGrab(BasisInput input)
         {
             if (!base.CanDirectGrab(input)) return false;
-            if (Inputs.AnyInteracting() && !CanSelfSteal) return false;
+            if (Inputs.AnyInteracting() && !CanSelfStealResolved) return false;
             return CanInteractInjected.AllTrue(input);
         }
 
@@ -469,7 +471,7 @@ namespace Basis.Scripts.BasisSdk.Interactions
             }
 
             // Clean up interacting ourselves (system won't do this for us) when self-steal is allowed.
-            if (CanSelfSteal)
+            if (CanSelfStealResolved)
                 Inputs.ForEachWithState(OnInteractEnd, BasisInteractInputState.Interacting);
 
             if (input.TryGetRole(out BasisBoneTrackedRole role) && Inputs.TryGetByRole(role, out BasisInputWrapper wrapper))
@@ -520,11 +522,11 @@ namespace Basis.Scripts.BasisSdk.Interactions
                         InputConstraint.GlobalWeight = 0f;
                         _lerpElapsed = 0f;
                         _lerping = true;
-                        InputConstraint.GlobalWeight = 1f;
                     }
                     else
                     {
                         offsetPos = Quaternion.Inverse(inRot) * (ActivePosition - inPos);
+                        InputConstraint.GlobalWeight = 1f;
                     }
 
                     Quaternion offsetRot = Quaternion.Inverse(inRot) * ActiveRotation;
@@ -546,7 +548,7 @@ namespace Basis.Scripts.BasisSdk.Interactions
             }
 
             // Clean up hovers if self-steal is disabled.
-            if (!CanSelfSteal)
+            if (!CanSelfStealResolved)
                 Inputs.ForEachWithState(i => OnHoverEnd(i, false), BasisInteractInputState.Hovering);
         }
 
@@ -696,8 +698,9 @@ namespace Basis.Scripts.BasisSdk.Interactions
 
             Vector3 inPos;
             Quaternion inRot = interactingInput.BoneControl.OutgoingWorldData.rotation;
+            bool inDesktop = BasisDeviceManagement.IsUserInDesktop();
 
-            if (LerpToHandOnPickup)
+            if (inDesktop && LerpToHandOnPickup)
             {
                 inPos = useHandBoneControl.OutgoingWorldData.position
                         + interactingInput.BoneControl.OutgoingWorldData.rotation * useMagicNumberItemDelta * BasisHeightDriver.ScaledToMatchValue;
@@ -707,7 +710,7 @@ namespace Basis.Scripts.BasisSdk.Interactions
                 inPos = interactingInput.BoneControl.OutgoingWorldData.position;
             }
 
-            if (BasisDeviceManagement.IsUserInDesktop())
+            if (inDesktop)
             {
                 PollDesktopControl(Inputs.desktopCenterEye.Source);
             }
@@ -1016,7 +1019,7 @@ namespace Basis.Scripts.BasisSdk.Interactions
                 // special case for desktop (right-click)
                 input.TryGetRole(out var role) &&
                 role == BasisBoneTrackedRole.CenterEye &&
-                input.CurrentInputState.SecondaryTrigger == 1; ;
+                input.CurrentInputState.SecondaryTrigger > .8f;
         }
 
         private IEnumerator MoveAfterDelayCoroutine() {

--- a/Basis/Packages/com.basis.framework/Interactions/BasisPlayerInteract.cs
+++ b/Basis/Packages/com.basis.framework/Interactions/BasisPlayerInteract.cs
@@ -207,9 +207,10 @@ namespace Basis.Scripts.BasisSdk.Interactions
                     {
                         // Implementation could allow for hovering and holding of the same object, clear independently
                         bool autoHold = BasisDeviceManagement.IsUserInDesktop() && interactInput.lastTarget.AutoHold == BasisAutoHold.Yes;
+                        bool holdDropTriggered = interactInput.lastTarget.IsHoldDropTriggered(interactInput.input);
 
-                        // Drop logic: only drop when not triggered
-                        if (!interactInput.lastTarget.IsInteractTriggered(interactInput.input) && interactInput.lastTarget.IsInteractingWith(interactInput.input) && !autoHold)
+                        // Drop logic: drop when not triggered, or when autohold drop is pressed
+                        if (!interactInput.lastTarget.IsInteractTriggered(interactInput.input) && interactInput.lastTarget.IsInteractingWith(interactInput.input) && (!autoHold || holdDropTriggered))
                         {
                             interactInput.lastTarget.OnInteractEnd(interactInput.input);
                         }


### PR DESCRIPTION
There's two main features in this PR
* Raise the desktop user's hand when picking up an item
  * Hand is chosen by dominant hand setting at time of pickup
* Lerp an item to the user's hand position (optionally, default `true`) (works in VR)
  * Lerping is done by choosing the nearest point on any collider as the offset
  * A good future feature would be to provide an optional grip transform which, if present, would be used as the lerp target


https://github.com/user-attachments/assets/79870629-1ed7-46bd-a3ef-553f6d334bc4

There are a couple of minor tweaks
* Desktop explicitly can't self steal (there is only one input on desktop)
* Fix dropping an auto-hold while not hovering it

For calculating the position of the hand and item I just tried values until I found some that were okay, so feel free to tinker with it some more.