### PR TITLE
make network ID resolution more robust

### DIFF
--- a/Basis/Packages/com.basis.framework/Networking/BasisNetworkBehaviour/BasisNetworkBehaviour.cs
+++ b/Basis/Packages/com.basis.framework/Networking/BasisNetworkBehaviour/BasisNetworkBehaviour.cs
@@ -4,6 +4,7 @@ using Basis.Scripts.Networking.NetworkedAvatar;
 using Basis.Network.Core;
 using System;
 using System.Collections;
+using System.Text;
 using System.Threading.Tasks;
 using UnityEngine;
 using static BasisNetworkCommon;
@@ -229,20 +230,21 @@ namespace Basis
         }
         public static string LowLevelGetHierarchyPath(BasisNetworkContentBase obj)
         {
+            StringBuilder pathBuilder = new StringBuilder();
             // Get the index of the component on the GameObject
             Component[] components = obj.gameObject.GetComponents(obj.GetType());
             int index = System.Array.IndexOf(components, obj);
 
-            string path = obj.gameObject.name + obj.GetType() + index;
+            pathBuilder.Append($"{obj.gameObject.name}[{obj.transform.GetSiblingIndex()}]_{obj.GetType().FullName}_{index}");
             Transform current = obj.transform.parent;
 
             while (current != null)
             {
-                path = current.name + "/" + path;
+                pathBuilder.Insert(0, $"{current.name}[{current.GetSiblingIndex()}]/");
                 current = current.parent;
             }
 
-            return path;
+            return pathBuilder.ToString();
         }
         public async void TakeOwnership()
         {

--- a/Basis/Packages/com.basis.shim/Shims/BasisShims.cs
+++ b/Basis/Packages/com.basis.shim/Shims/BasisShims.cs
@@ -22,27 +22,23 @@ namespace Basis
 
 		public static BasisNetworkShim MakeNetworkable( object o )
 		{
-			// Actually needs to be CilboxProxies.
-			GameObject go = null;
-			string setGUID = "";
-			if( o is CilboxProxy )
+			if (o is not MonoBehaviour)
 			{
-				CilboxProxy p = (CilboxProxy)o;
-				go = p.gameObject;
-				setGUID = p.buildTimeGuid + p.initialLoadPath;
-			}
-			else
-			{
-				MonoBehaviour p = (MonoBehaviour)o;
-				go = p.gameObject;
-				setGUID = p.GetInstanceID().ToString();
+				Debug.LogError( $"Object {o} is not a MonoBehaviour and cannot be made networkable." );
+				return null;
 			}
 
+			return MakeNetworkable( (MonoBehaviour)o );
+		}
+
+		public static BasisNetworkShim MakeNetworkable( MonoBehaviour mb )
+		{
 			BasisNetworkShim bi;
 
-			if( go.TryGetComponent<BasisNetworkShim>( out bi ) ) return bi;
+			if( mb.gameObject.TryGetComponent<BasisNetworkShim>( out bi ) ) return bi;
 
-			bi = go.AddComponent<BasisNetworkShim>();
+			bi = mb.gameObject.AddComponent<BasisNetworkShim>();
+			string setGUID = BasisNetworkBehaviour.LowLevelGetHierarchyPath(bi);
 
 			bi.AssignNetworkGUIDIdentifier(setGUID);
 			Debug.Log( $"ADDING ASSIGN: {bi} {setGUID}");
@@ -124,7 +120,7 @@ namespace Basis
 					InFlight.Remove( www );
 					callback( new IBasisImageDownload( www, dht, null ) );
 				}
-			}; 
+			};
 
 			req.completed += eventcb;
 
@@ -166,7 +162,7 @@ namespace Basis
 					DownloadHandler dh = www.downloadHandler;
 					callback( www.result == UnityWebRequest.Result.Success, dh.error, dh.GetData() );
 				}
-			}; 
+			};
 
 			if( !bCompleted && req.isDone )
 			{


### PR DESCRIPTION
* Make `LowLevelGetHierarchyPath` more resilient against poorly formed hierarchy 
* Make BasisShims use `LowLevelGetHierarchyPath` of `BasisNetworkShim` because `p.buildTimeGuid` is unique per-platform and `p.GetInstanceID` is unique per run
