### PR TITLE
Update network shims again

### DIFF
--- a/Basis/Packages/com.basis.framework/Networking/BasisNetworkBehaviour/BasisNetworkBehaviour.cs
+++ b/Basis/Packages/com.basis.framework/Networking/BasisNetworkBehaviour/BasisNetworkBehaviour.cs
@@ -235,16 +235,44 @@ namespace Basis
             Component[] components = obj.gameObject.GetComponents(obj.GetType());
             int index = System.Array.IndexOf(components, obj);
 
-            pathBuilder.Append($"{obj.gameObject.name}[{obj.transform.GetSiblingIndex()}]_{obj.GetType().FullName}_{index}");
+            pathBuilder.Append($"{obj.gameObject.name}{SiblingIndexIfNeeded(obj.transform)}:{obj.GetType().FullName}_{index}");
             Transform current = obj.transform.parent;
 
             while (current != null)
             {
-                pathBuilder.Insert(0, $"{current.name}[{current.GetSiblingIndex()}]/");
+                pathBuilder.Insert(0, $"{current.name}{SiblingIndexIfNeeded(current)}/");
                 current = current.parent;
             }
 
             return pathBuilder.ToString();
+        }
+        private static string SiblingIndexIfNeeded(Transform t)
+        {
+            Transform parent = t.parent;
+            string name = t.name;
+            if (parent == null)
+            {
+                foreach (var go in t.gameObject.scene.GetRootGameObjects())
+                {
+                    if (go != t.gameObject && go.name == name)
+                    {
+                        return $"[{t.GetSiblingIndex()}]";
+                    }
+                }
+            }
+            else
+            {
+                int childCount = parent.childCount;
+                for (int i = 0; i < childCount; i++)
+                {
+                    Transform sibling = parent.GetChild(i);
+                    if (sibling != t && sibling.name == name)
+                    {
+                        return $"[{t.GetSiblingIndex()}]";
+                    }
+                }
+            }
+            return string.Empty;
         }
         public async void TakeOwnership()
         {

--- a/Basis/Packages/com.basis.shim/Shims/BasisNetworkShim.cs
+++ b/Basis/Packages/com.basis.shim/Shims/BasisNetworkShim.cs
@@ -47,5 +47,10 @@ namespace Basis
         {
 			PlayerJoined?.Invoke( player );
         }
+
+        public void RequestOwnershipIfNone()
+        {
+	        RequestWhoIsOwnershipAsync();
+        }
 	}
 }

--- a/Basis/Packages/com.basis.shim/Shims/BasisShims.cs
+++ b/Basis/Packages/com.basis.shim/Shims/BasisShims.cs
@@ -22,28 +22,20 @@ namespace Basis
 
 		public static BasisNetworkShim MakeNetworkable( object o )
 		{
-			if (o is not MonoBehaviour)
+			if (o is not MonoBehaviour behaviour)
 			{
 				Debug.LogError( $"Object {o} is not a MonoBehaviour and cannot be made networkable." );
 				return null;
 			}
 
-			return MakeNetworkable( (MonoBehaviour)o );
+			return MakeNetworkable( behaviour );
 		}
 
 		public static BasisNetworkShim MakeNetworkable( MonoBehaviour mb )
 		{
-			BasisNetworkShim bi;
+			if( mb.gameObject.TryGetComponent<BasisNetworkShim>( out BasisNetworkShim bi ) ) return bi;
 
-			if( mb.gameObject.TryGetComponent<BasisNetworkShim>( out bi ) ) return bi;
-
-			bi = mb.gameObject.AddComponent<BasisNetworkShim>();
-			string setGUID = BasisNetworkBehaviour.LowLevelGetHierarchyPath(bi);
-
-			bi.AssignNetworkGUIDIdentifier(setGUID);
-			Debug.Log( $"ADDING ASSIGN: {bi} {setGUID}");
-
-			return bi;
+			return mb.gameObject.AddComponent<BasisNetworkShim>();
 		}
 
 		public static BasisInteractableShim MakeInteractable( object o )


### PR DESCRIPTION
* Add `RequestOwnershipIfNone` which just shims `RequestWhoIsOwnershipAsync` as void instead of Task for Cilbox

Rework fixes from this PR: https://github.com/BasisVR/Basis/pull/659
* Remove override logic in `BasisShims`.`MakeNetworkable` because the base `BasisNetworkBehaviour` will already do it automatically when `AddComponent` is called
* Make `LowLevelGetHierarchyPath` not add any sibling index if it is already a unique sibling

Let me know if this works for you @Toys0125 @Mr-Zero88 
