### PR TITLE
Improve local eye tracking: rotation space, axis calibration, offline bone actuation

### DIFF
--- a/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalEyeDriver.cs
+++ b/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalEyeDriver.cs
@@ -51,8 +51,6 @@ public class BasisLocalEyeDriver
     public static bool Override = false;
     public static bool IsEnabled = false;
 
-    public static quaternion leftEyeInitialRotation;
-    public static quaternion rightEyeInitialRotation;
     public static void Initalize()
     {
         Dispose();
@@ -70,8 +68,6 @@ public class BasisLocalEyeDriver
 
         _state = new NativeArray<EyeState>(1, Allocator.Persistent);
         _state[0] = EyeState.Create((uint)UnityEngine.Random.Range(1, int.MaxValue));
-        leftEyeInitialRotation = leftEyeTransform.localRotation;
-        rightEyeInitialRotation = rightEyeTransform.localRotation;
         CalibrateEyes();
         IsEnabled = true;
 
@@ -149,6 +145,7 @@ public class BasisLocalEyeDriver
         // canonical: +Z forward, +Y up, +X right
         public quaternion basis;
         public quaternion invBasis;
+        public quaternion initialRotation;
     }
     private static float3[] axes = new float3[]
 {
@@ -211,7 +208,7 @@ public class BasisLocalEyeDriver
         quaternion basis = new quaternion(m);
         quaternion inv = math.inverse(basis);
 
-        return new EyeCalibration { basis = basis, invBasis = inv };
+        return new EyeCalibration { basis = basis, invBasis = inv, initialRotation = eye.localRotation };
     }
 
     [BurstCompile]

--- a/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalEyeDriver.cs
+++ b/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalEyeDriver.cs
@@ -42,8 +42,8 @@ public class BasisLocalEyeDriver
 
     public static Transform leftEyeTransform, rightEyeTransform;
     private static Transform _headRef;     // used for calibration reference
-    private static EyeCalibration _calLeft;
-    private static EyeCalibration _calRight;
+    public static EyeCalibration calLeft;
+    public static EyeCalibration calRight;
 
     private static NativeArray<EyeState> _state;
 
@@ -51,7 +51,7 @@ public class BasisLocalEyeDriver
     public static bool Override = false;
     public static bool IsEnabled = false;
 
-    public static Quaternion leftEyeInitialRotation;
+    public static quaternion leftEyeInitialRotation;
     public static quaternion rightEyeInitialRotation;
     public static void Initalize()
     {
@@ -70,8 +70,8 @@ public class BasisLocalEyeDriver
 
         _state = new NativeArray<EyeState>(1, Allocator.Persistent);
         _state[0] = EyeState.Create((uint)UnityEngine.Random.Range(1, int.MaxValue));
-        leftEyeInitialRotation = leftEyeTransform.rotation;
-        rightEyeInitialRotation = rightEyeTransform.rotation;
+        leftEyeInitialRotation = leftEyeTransform.localRotation;
+        rightEyeInitialRotation = rightEyeTransform.localRotation;
         CalibrateEyes();
         IsEnabled = true;
 
@@ -107,10 +107,10 @@ public class BasisLocalEyeDriver
                 perEyeVarRad = perEyeVarianceDeg,
                 occasionalCenterReturn = occasionalCenterReturn,
 
-                calLeftBasis = _calLeft.basis,
-                calLeftInvBasis = _calLeft.invBasis,
-                calRightBasis = _calRight.basis,
-                calRightInvBasis = _calRight.invBasis,
+                calLeftBasis = calLeft.basis,
+                calLeftInvBasis = calLeft.invBasis,
+                calRightBasis = calRight.basis,
+                calRightInvBasis = calRight.invBasis,
                 rightBase = rightEyeTransform.localRotation,
                 leftBase = leftEyeTransform.localRotation,
 
@@ -138,8 +138,8 @@ public class BasisLocalEyeDriver
     private static void CalibrateEyes()
     {
         // Per-eye calibration against head reference directions
-        _calLeft = CalibrateOneEye(leftEyeTransform, _headRef);
-        _calRight = CalibrateOneEye(rightEyeTransform, _headRef);
+        calLeft = CalibrateOneEye(leftEyeTransform, _headRef);
+        calRight = CalibrateOneEye(rightEyeTransform, _headRef);
     }
 
     [System.Serializable]

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/Components/Actuation/EyeTrackingBoneActuation.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/Components/Actuation/EyeTrackingBoneActuation.cs
@@ -288,19 +288,34 @@ namespace HVR.Basis.Comms
 
             if (_eyeFollowDriverApplicable)
             {
-                var xDeg = Mathf.Asin(x) * Mathf.Rad2Deg * multiplyX;
-                var yDeg = Mathf.Asin(-y) * Mathf.Rad2Deg * multiplyY;
-                Quaternion Euler = Quaternion.Euler(yDeg, xDeg, 0);
+
+                // Uses EyeCalibration from BasisLocalEyeDriver to handle arbitrary eye bone orientations for local player.
+                // Retaining Hai's original FIXME: This could/should be replaced by a WIP normalized muscle system
+
+                float xRad = Mathf.Asin(x) * multiplyX;
+                float yRad = Mathf.Asin(-y) * multiplyY;
+                quaternion yaw = quaternion.AxisAngle(new float3(0, 1, 0), xRad);
+                quaternion pitch = quaternion.AxisAngle(new float3(1, 0, 0), yRad);
+                quaternion canonical = math.mul(yaw, pitch);
+
                 switch (side)
                 {
-                    // FIXME: This wrongly assumes that eye bone transforms are oriented the same.
-                    // This needs to be fixed later by using the work-in-progress normalized muscle system instead.
                     case EyeSide.Left:
-                        BasisLocalEyeDriver.leftEyeTransform.localRotation = math.mul(BasisLocalEyeDriver.leftEyeInitialRotation, Euler);
+                    {
+                        var cal = BasisLocalEyeDriver.calLeft;
+                        quaternion rigOffset = math.mul(math.mul(cal.basis, canonical), cal.invBasis);
+                        BasisLocalEyeDriver.leftEyeTransform.localRotation =
+                            math.mul(BasisLocalEyeDriver.leftEyeInitialRotation, rigOffset);
                         break;
+                    }
                     case EyeSide.Right:
-                        BasisLocalEyeDriver.rightEyeTransform.localRotation = math.mul(BasisLocalEyeDriver.rightEyeInitialRotation, Euler);
+                    {
+                        var cal = BasisLocalEyeDriver.calRight;
+                        quaternion rigOffset = math.mul(math.mul(cal.basis, canonical), cal.invBasis);
+                        BasisLocalEyeDriver.rightEyeTransform.localRotation =
+                            math.mul(BasisLocalEyeDriver.rightEyeInitialRotation, rigOffset);
                         break;
+                    }
                     default:
                         throw new ArgumentOutOfRangeException(nameof(side), side, null);
                 }

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/Components/Actuation/EyeTrackingBoneActuation.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/Components/Actuation/EyeTrackingBoneActuation.cs
@@ -161,7 +161,7 @@ namespace HVR.Basis.Comms
 
         private void Update()
         {
-            if (!IsLocal || !_trackingActive || !_eyeTrackingParametersActive)
+            if (!_eyeFollowDriverApplicable || !_trackingActive || !_eyeTrackingParametersActive)
             {
                 return;
             }
@@ -200,7 +200,7 @@ namespace HVR.Basis.Comms
                     return;
             }
 
-            if (IsLocal)
+            if (_eyeFollowDriverApplicable)
             {
                 _lastEyeParameterSampleTime = Time.unscaledTime;
                 if (!_eyeTrackingParametersActive)
@@ -225,20 +225,20 @@ namespace HVR.Basis.Comms
             }
 
             _trackingActive = isTrackingActive;
-            if (IsLocal && !_trackingActive)
+            if (_eyeFollowDriverApplicable && !_trackingActive)
             {
                 SetLocalEyeParameterState(false);
             }
 
             bool shouldApplyEyeTracking = ShouldApplyEyeTracking();
-            if (IsLocal)
+            if (_eyeFollowDriverApplicable)
             {
                 SetBuiltInEyeFollowDriverOverriden(shouldApplyEyeTracking);
             }
 
             if (_trackingActive)
             {
-                if (IsLocal)
+                if (_eyeFollowDriverApplicable)
                 {
                     if (shouldApplyEyeTracking)
                     {
@@ -259,7 +259,7 @@ namespace HVR.Basis.Comms
             ResetEyeValuesToZero();
             _eyeTrackingParametersActive = false;
 
-            if (IsLocal)
+            if (_eyeFollowDriverApplicable)
             {
                 SubmitNeutralEyesToNetwork();
             }

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/Components/Actuation/EyeTrackingBoneActuation.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/Components/Actuation/EyeTrackingBoneActuation.cs
@@ -305,7 +305,7 @@ namespace HVR.Basis.Comms
                         var cal = BasisLocalEyeDriver.calLeft;
                         quaternion rigOffset = math.mul(math.mul(cal.basis, canonical), cal.invBasis);
                         BasisLocalEyeDriver.leftEyeTransform.localRotation =
-                            math.mul(BasisLocalEyeDriver.leftEyeInitialRotation, rigOffset);
+                            math.mul(cal.initialRotation, rigOffset);
                         break;
                     }
                     case EyeSide.Right:
@@ -313,7 +313,7 @@ namespace HVR.Basis.Comms
                         var cal = BasisLocalEyeDriver.calRight;
                         quaternion rigOffset = math.mul(math.mul(cal.basis, canonical), cal.invBasis);
                         BasisLocalEyeDriver.rightEyeTransform.localRotation =
-                            math.mul(BasisLocalEyeDriver.rightEyeInitialRotation, rigOffset);
+                            math.mul(cal.initialRotation, rigOffset);
                         break;
                     }
                     default:


### PR DESCRIPTION
## Summary
- `BasisLocalEyeDriver.Initalize()` captured initial eye rotations using `.rotation` (world-space) but they were being used for `.localRotation` writes for eye tracking. This would bake the parent chain into a parent-relative value. I'm not fully sure how / if this manifested in practice, but I presume it wasn't too noticeable because the avatar is in T-pose when it's captured?
- `SetEyeRotation()` assumed a specific bone orientation. Hai flagged this in a comment, but was waiting on a WIP normalized muscle system. I integrated `BasisLocalEyeDriver`'s existing per-eye calibration (since that already accounts for eye bone axis orientation during init) as a stopgap for the local path.
- `EyeTrackingBoneActuation` gated local eye tracking on `IsLocal` which is only set during `OnHVRReadyBothAvatarAndNetwork` so bone actuation didn't work unless you were connected / in Host Mode. I switched it to `_eyeFollowDriverApplicable` (set on `OnHVRAvatarReady`) to match how `BlendshapeActuation` already handles this with `_isWearer`.
## Changes
- **`BasisLocalEyeDriver.cs`**:
  - Fix world-space to local-space for initial eye rotation capture
  - Refactors `leftEyeInitialRotation`/`rightEyeInitialRotation` into the `EyeCalibration` struct
  - Expose `calLeft`/`calRight` as `public static` for use by `EyeTrackingBoneActuation` [^1]
- **`EyeTrackingBoneActuation.cs`**:
  - Replace `Quaternion.Euler` on the local path with axis-aware rotation via `BasisLocalEyeDriver`
  - Gate local eye bone rotation tracking on `_eyeFollowDriverApplicable` instead of `IsLocal` so it works without a network connection

I smoke tested with a few avis and an iPhone app that sends face tracking data since I don't have any fancy eye tracking HMDs, so may benefit from someone with eye trackers giving this a review pass!

[^1]: I exposed `calLeft`/`calRight` as bare `public static` fields to be consistent with how other fields are exposed there. I presume they're never meant to be set outside of `CalibrateEyes()` though, so might be better to encapsulate them? Can change if you'd prefer that