### PR TITLE
Desktop line improvements

### DIFF
--- a/Basis/Packages/com.basis.examples/Interactable/InteractLine.shadergraph
+++ b/Basis/Packages/com.basis.examples/Interactable/InteractLine.shadergraph
@@ -128,6 +128,9 @@
         },
         {
             "m_Id": "36f4982647714c41956af5aa3a9d2ba4"
+        },
+        {
+            "m_Id": "5fb99bc882f2410299417adb17d76052"
         }
     ],
     "m_GroupDatas": [],
@@ -268,7 +271,7 @@
             },
             "m_InputSlot": {
                 "m_Node": {
-                    "m_Id": "8dd89c9da57447caa329786551626ec9"
+                    "m_Id": "5fb99bc882f2410299417adb17d76052"
                 },
                 "m_SlotId": 0
             }
@@ -311,6 +314,20 @@
             "m_InputSlot": {
                 "m_Node": {
                     "m_Id": "db9434ef6f62437cb6b8915449e7fc88"
+                },
+                "m_SlotId": 0
+            }
+        },
+        {
+            "m_OutputSlot": {
+                "m_Node": {
+                    "m_Id": "5fb99bc882f2410299417adb17d76052"
+                },
+                "m_SlotId": 3
+            },
+            "m_InputSlot": {
+                "m_Node": {
+                    "m_Id": "8dd89c9da57447caa329786551626ec9"
                 },
                 "m_SlotId": 0
             }
@@ -1636,10 +1653,10 @@
         "m_Expanded": true,
         "m_Position": {
             "serializedVersion": "2",
-            "x": 1424.0001220703125,
-            "y": 143.99998474121095,
+            "x": 1431.0,
+            "y": 144.0,
             "width": 208.0,
-            "height": 302.00006103515627
+            "height": 302.0
         }
     },
     "m_Slots": [
@@ -1748,6 +1765,56 @@
 
 {
     "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "373d1b33e2324d889b82e7466bae6f48",
+    "m_Id": 3,
+    "m_DisplayName": "Out",
+    "m_SlotType": 1,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Out",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "3d0cda86270f448c8bce886c3da43f7e",
+    "m_Id": 0,
+    "m_DisplayName": "In",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "In",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_LiteralMode": false
+}
+
+{
+    "m_SGVersion": 0,
     "m_Type": "UnityEditor.ShaderGraph.AddNode",
     "m_ObjectId": "3d9b305519ac4b468a0c3c94138a5248",
     "m_Group": {
@@ -1787,6 +1854,31 @@
     "m_CustomColors": {
         "m_SerializableColors": []
     }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "3e15e103ffc1429eaf220f8174f8ac9b",
+    "m_Id": 1,
+    "m_DisplayName": "Min",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Min",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_LiteralMode": false
 }
 
 {
@@ -2014,6 +2106,50 @@
         "e31": 0.0,
         "e32": 0.0,
         "e33": 1.0
+    }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.ClampNode",
+    "m_ObjectId": "5fb99bc882f2410299417adb17d76052",
+    "m_Group": {
+        "m_Id": ""
+    },
+    "m_Name": "Clamp",
+    "m_DrawState": {
+        "m_Expanded": true,
+        "m_Position": {
+            "serializedVersion": "2",
+            "x": 1670.0001220703125,
+            "y": -34.999996185302737,
+            "width": 208.0,
+            "height": 326.0
+        }
+    },
+    "m_Slots": [
+        {
+            "m_Id": "3d0cda86270f448c8bce886c3da43f7e"
+        },
+        {
+            "m_Id": "3e15e103ffc1429eaf220f8174f8ac9b"
+        },
+        {
+            "m_Id": "e0138672f19d4da8b9a338499ac214f7"
+        },
+        {
+            "m_Id": "373d1b33e2324d889b82e7466bae6f48"
+        }
+    ],
+    "synonyms": [
+        "limit"
+    ],
+    "m_Precision": 0,
+    "m_PreviewExpanded": true,
+    "m_DismissedVersion": 0,
+    "m_PreviewMode": 0,
+    "m_CustomColors": {
+        "m_SerializableColors": []
     }
 }
 
@@ -3971,6 +4107,31 @@
         "e32": 0.0,
         "e33": 1.0
     }
+}
+
+{
+    "m_SGVersion": 0,
+    "m_Type": "UnityEditor.ShaderGraph.DynamicVectorMaterialSlot",
+    "m_ObjectId": "e0138672f19d4da8b9a338499ac214f7",
+    "m_Id": 2,
+    "m_DisplayName": "Max",
+    "m_SlotType": 0,
+    "m_Hidden": false,
+    "m_ShaderOutputName": "Max",
+    "m_StageCapability": 3,
+    "m_Value": {
+        "x": 25.0,
+        "y": 1.0,
+        "z": 1.0,
+        "w": 1.0
+    },
+    "m_DefaultValue": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0,
+        "w": 0.0
+    },
+    "m_LiteralMode": false
 }
 
 {

--- a/Basis/Packages/com.basis.examples/Interactable/InteractLineMat.mat
+++ b/Basis/Packages/com.basis.examples/Interactable/InteractLineMat.mat
@@ -127,8 +127,8 @@ Material:
     - _GlossyReflections: 0
     - _Intervals: 0.1
     - _Laser_Pre_Attenuation_Min: 0.001
-    - _Line_Attenuation: 0.56
-    - _Line_Falloff_Power: 1.9
+    - _Line_Attenuation: 0.2
+    - _Line_Falloff_Power: 5
     - _Metallic: 0
     - _MiniMultiplier: 59.2
     - _Mode: 0
@@ -158,7 +158,7 @@ Material:
     - _BaseColor: {r: 0.48365337, g: 0.33490568, b: 1, a: 1}
     - _BaseColorAddSubDiff: {r: 0, g: 0, b: 0, a: 0}
     - _CameraFadeParams: {r: 0, g: 0, b: 0, a: 0}
-    - _Color: {r: 0.48235294, g: 0.33333334, b: 1, a: 1}
+    - _Color: {r: 0.40999997, g: 0.2833333, b: 0.85, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _SoftParticleFadeParams: {r: 0, g: 0, b: 0, a: 0}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}

--- a/Basis/Packages/com.basis.framework/Interactions/BasisPlayerInteract.cs
+++ b/Basis/Packages/com.basis.framework/Interactions/BasisPlayerInteract.cs
@@ -266,7 +266,7 @@ namespace Basis.Scripts.BasisSdk.Interactions
 
                         if (input.input.InteractionLineRenderer != null)
                         {
-                            Vector3 endPos = input.lastTarget.GetClosestPoint(origin);
+                            Vector3 endPos = input.lastTarget.GetClosestPoint(start);
                             input.input.InteractionLineRenderer.SetPosition(0, start);
                             input.input.InteractionLineRenderer.SetPosition(1, endPos);
                             input.input.InteractionLineRenderer.enabled = true;


### PR DESCRIPTION
* Move desktop line's closest point comparison to the actual origin of the line (gets it slightly more out of the way)
* Tone down the line a bit
  * It's my personal opinion that it causes too much bloom and is a bit obnoxious; let me know if you'd like me to revert this commit though

#### Comparison ####
Old:
<img width="1322" height="846" alt="image" src="https://github.com/user-attachments/assets/4249462d-bed8-4877-bc82-37b32839d9bc" />
New:
<img width="1243" height="814" alt="image" src="https://github.com/user-attachments/assets/1320558d-fc29-45a2-bebb-abc3cb5202d0" />
