### PR TITLE
Fix IL2CPP reconnect crash [BasisRemoteNetworkDriver.GetMuscleArray]

### DIFF
--- a/Basis/Packages/com.basis.framework/Networking/Recievers/BasisRemoteNetworkDriver.cs
+++ b/Basis/Packages/com.basis.framework/Networking/Recievers/BasisRemoteNetworkDriver.cs
@@ -331,6 +331,15 @@ public static class BasisRemoteNetworkDriver
         int eyesAndMouthOffsetFloats,
         int eyesAndMouthCountBytes)
     {
+        if (!_initialized)
+        {
+            // Silent return if driver uninitialized (expected during shutdown/reconnect)
+            outScale = false;
+            outRot = quaternion.identity;
+            BodyPosition = float3.zero;
+            return;
+        }
+
         outScale = _HasScaleChange[index];
         outRot = _filteredRotations[index];
         BodyPosition = _scaledBodyPositions[index];


### PR DESCRIPTION
Handle uninitialized state in BasisRemoteNetworkDriver's GetMuscleArray to prevent errors during shutdown/reconnect (now returns default values if not initialized)