### PR TITLE
feat(shim): add UnityEngine.AnimatorTransitionInfo

### DIFF
--- a/Basis/Packages/com.basis.shim/Shims/CilboxPropBasis.cs
+++ b/Basis/Packages/com.basis.shim/Shims/CilboxPropBasis.cs
@@ -61,6 +61,7 @@ namespace Cilbox
 			// Unity types
 			"UnityEngine.Animator",
 			"UnityEngine.AnimatorStateInfo",
+			"UnityEngine.AnimatorTransitionInfo",
             "UnityEngine.AudioClip",
 			"UnityEngine.AudioSource",
 			"UnityEngine.Color",


### PR DESCRIPTION
Requirement: Allows AnimatorTransitionInfo.IsName (bool) checks against state names to prevent state changes during a transition. This helps to suppress overlapping animations and audioClip playback logic for Props.

Currently Basis Prop builds are failing due to these calls being made in the Cillboxable script.

Tested with proposed changes applied to local copy of project, and build passes.