### PR TITLE
Prevent Face Tracking from sending when disconnected from server.

### DIFF
--- a/Basis/Packages/com.basis.framework/Networking/BasisNetworkConnection.cs
+++ b/Basis/Packages/com.basis.framework/Networking/BasisNetworkConnection.cs
@@ -22,22 +22,7 @@ namespace Basis.Scripts.Networking
     {
         public static NetPeer LocalPlayerPeer { get; set; }
         public static NetworkClient NetworkClient { get; set; } = new NetworkClient();
-        private static bool _localPlayerIsConnected;
-        public static bool LocalPlayerIsConnected
-        {
-            get => _localPlayerIsConnected;
-            set
-            {
-                if (_localPlayerIsConnected == value)
-                {
-                    return;
-                }
-
-                _localPlayerIsConnected = value;
-                OnLocalPlayerConnectionStateChanged?.Invoke(value);
-            }
-        }
-        public static event Action<bool> OnLocalPlayerConnectionStateChanged;
+        public static bool LocalPlayerIsConnected { get; set; }
         public static BasisNetworkServerRunner BasisNetworkServerRunner = null;
         private static void LogErrorOutput(string msg) => BasisDebug.LogError(msg, BasisDebug.LogTag.Networking);
         private static void LogWarningOutput(string msg) => BasisDebug.LogWarning(msg);

--- a/Basis/Packages/com.basis.framework/Networking/BasisNetworkConnection.cs
+++ b/Basis/Packages/com.basis.framework/Networking/BasisNetworkConnection.cs
@@ -22,7 +22,22 @@ namespace Basis.Scripts.Networking
     {
         public static NetPeer LocalPlayerPeer { get; set; }
         public static NetworkClient NetworkClient { get; set; } = new NetworkClient();
-        public static bool LocalPlayerIsConnected { get; set; }
+        private static bool _localPlayerIsConnected;
+        public static bool LocalPlayerIsConnected
+        {
+            get => _localPlayerIsConnected;
+            set
+            {
+                if (_localPlayerIsConnected == value)
+                {
+                    return;
+                }
+
+                _localPlayerIsConnected = value;
+                OnLocalPlayerConnectionStateChanged?.Invoke(value);
+            }
+        }
+        public static event Action<bool> OnLocalPlayerConnectionStateChanged;
         public static BasisNetworkServerRunner BasisNetworkServerRunner = null;
         private static void LogErrorOutput(string msg) => BasisDebug.LogError(msg, BasisDebug.LogTag.Networking);
         private static void LogWarningOutput(string msg) => BasisDebug.LogWarning(msg);

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/Components/Networking/StreamedAvatarFeature.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/Components/Networking/StreamedAvatarFeature.cs
@@ -43,13 +43,14 @@ namespace HVR.Basis.Comms
         private void Awake()
         {
             EnsureBuffers();
-            _canSendNetworkData = BasisNetworkConnection.LocalPlayerIsConnected;
-            BasisNetworkConnection.OnLocalPlayerConnectionStateChanged += OnLocalPlayerConnectionStateChanged;
+            BasisNetworkConnection.NetworkClient.listener.PeerConnectedEvent += OnLocalPlayerPeerConnected;
+            BasisNetworkConnection.NetworkClient.listener.PeerDisconnectedEvent += OnLocalPlayerPeerDisconnected;
         }
 
         private void OnDestroy()
         {
-            BasisNetworkConnection.OnLocalPlayerConnectionStateChanged -= OnLocalPlayerConnectionStateChanged;
+            BasisNetworkConnection.NetworkClient.listener.PeerConnectedEvent -= OnLocalPlayerPeerConnected;
+            BasisNetworkConnection.NetworkClient.listener.PeerDisconnectedEvent -= OnLocalPlayerPeerDisconnected;
         }
 
         private void OnDisable()
@@ -143,6 +144,17 @@ namespace HVR.Basis.Comms
             {
                 _timeLeft = 0;
             }
+        }
+
+        private void OnLocalPlayerPeerConnected(NetPeer peer)
+        {
+            _canSendNetworkData = true;
+        }
+
+        private void OnLocalPlayerPeerDisconnected(NetPeer peer,DisconnectInfo disconnectInfo)
+        {
+            _canSendNetworkData = false;
+            _timeLeft = 0;
         }
 
         private void OnReceiver()

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/Components/Networking/StreamedAvatarFeature.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/Components/Networking/StreamedAvatarFeature.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Basis.Network.Core;
+using Basis.Scripts.Networking;
 using UnityEngine;
 
 namespace HVR.Basis.Comms
@@ -34,6 +35,7 @@ namespace HVR.Basis.Comms
         private float _timeLeft;
         private bool _isOutOfTape;
         private bool _writtenThisFrame;
+        private bool _canSendNetworkData;
 
         public event InterpolatedDataChanged OnInterpolatedDataChanged;
         public delegate void InterpolatedDataChanged(float[] current);
@@ -41,6 +43,13 @@ namespace HVR.Basis.Comms
         private void Awake()
         {
             EnsureBuffers();
+            _canSendNetworkData = BasisNetworkConnection.LocalPlayerIsConnected;
+            BasisNetworkConnection.OnLocalPlayerConnectionStateChanged += OnLocalPlayerConnectionStateChanged;
+        }
+
+        private void OnDestroy()
+        {
+            BasisNetworkConnection.OnLocalPlayerConnectionStateChanged -= OnLocalPlayerConnectionStateChanged;
         }
 
         private void OnDisable()
@@ -89,6 +98,10 @@ namespace HVR.Basis.Comms
         {
             if (isWearer)
             {
+                if (!_canSendNetworkData)
+                {
+                    return;
+                }
                 OnSender();
             }
             else
@@ -119,6 +132,15 @@ namespace HVR.Basis.Comms
                     }
                 }
 
+                _timeLeft = 0;
+            }
+        }
+
+        private void OnLocalPlayerConnectionStateChanged(bool isConnected)
+        {
+            _canSendNetworkData = isConnected;
+            if (!isConnected)
+            {
                 _timeLeft = 0;
             }
         }

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/HVR.Basis.Comms.asmdef
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/HVR.Basis.Comms.asmdef
@@ -9,7 +9,8 @@
         "BasisDebug",
         "HVR.Basis.Comms.HVRUtility",
         "Unity.Addressables",
-        "Unity.ResourceManager"
+        "Unity.ResourceManager",
+        "BasisNetworkClient"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
At the moment the script will continue to send to the network channel after disconnect from server, which will be null.

## Additions
* Adds a event action called OnLocalPlayerConnectionStateChanged
* LocalPlayerIsConnected invokes events

## Improvement
* Adds check if can send in face tracking.
* Adds event delegate function for state change.