### PR TITLE
fix: possible race condition in StreamedAvatarFeature preventing data from being sent

### DIFF
--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/Components/Networking/StreamedAvatarFeature.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/Components/Networking/StreamedAvatarFeature.cs
@@ -35,7 +35,6 @@ namespace HVR.Basis.Comms
         private float _timeLeft;
         private bool _isOutOfTape;
         private bool _writtenThisFrame;
-        private bool _canSendNetworkData;
 
         public event InterpolatedDataChanged OnInterpolatedDataChanged;
         public delegate void InterpolatedDataChanged(float[] current);
@@ -43,14 +42,6 @@ namespace HVR.Basis.Comms
         private void Awake()
         {
             EnsureBuffers();
-            BasisNetworkConnection.NetworkClient.listener.PeerConnectedEvent += OnLocalPlayerPeerConnected;
-            BasisNetworkConnection.NetworkClient.listener.PeerDisconnectedEvent += OnLocalPlayerPeerDisconnected;
-        }
-
-        private void OnDestroy()
-        {
-            BasisNetworkConnection.NetworkClient.listener.PeerConnectedEvent -= OnLocalPlayerPeerConnected;
-            BasisNetworkConnection.NetworkClient.listener.PeerDisconnectedEvent -= OnLocalPlayerPeerDisconnected;
         }
 
         private void OnDisable()
@@ -99,8 +90,9 @@ namespace HVR.Basis.Comms
         {
             if (isWearer)
             {
-                if (!_canSendNetworkData)
+                if (BasisNetworkConnection.LocalPlayerPeer == null)
                 {
+                    _timeLeft = 0;
                     return;
                 }
                 OnSender();
@@ -135,26 +127,6 @@ namespace HVR.Basis.Comms
 
                 _timeLeft = 0;
             }
-        }
-
-        private void OnLocalPlayerConnectionStateChanged(bool isConnected)
-        {
-            _canSendNetworkData = isConnected;
-            if (!isConnected)
-            {
-                _timeLeft = 0;
-            }
-        }
-
-        private void OnLocalPlayerPeerConnected(NetPeer peer)
-        {
-            _canSendNetworkData = true;
-        }
-
-        private void OnLocalPlayerPeerDisconnected(NetPeer peer,DisconnectInfo disconnectInfo)
-        {
-            _canSendNetworkData = false;
-            _timeLeft = 0;
         }
 
         private void OnReceiver()


### PR DESCRIPTION
StreamedAvatarFeature subscribed to PeerConnectedEvent in `Awake()` to set `_canSendNetworkData`, but Nethack guarantees this component is only created AFTER both avatar + network are ready so the event had likely already fired before the subscription existed (resulting in the flag being perma-false)

Replaced with a direct `if (BasisNetworkConnection.LocalPlayerPeer == null)` in `Update()`

Hoping this fixes the issue reported in disc server re: eye movements not being sent
(couldn't / didn't repro, but this stuck out to me when I looked into it to make sure it wasn't caused by my previous PR 😅 )