### PR TITLE
fix(plugins): add PluginImporter config to macOS opus.dylib meta files

### DIFF
--- a/Basis/Packages/com.avionblock.opussharp/Plugins/osx-arm64/native/opus.dylib.meta
+++ b/Basis/Packages/com.avionblock.opussharp/Plugins/osx-arm64/native/opus.dylib.meta
@@ -1,2 +1,47 @@
 fileFormatVersion: 2
 guid: 2222def68db777747a28b458c4551234
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 0
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 0
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude Android: 1
+        Exclude iOS: 1
+  - first:
+      Any:
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 1
+      settings:
+        CPU: ARM64
+        DefaultValueInitialized: true
+        OS: OSX
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 1
+      settings:
+        CPU: ARM64
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Basis/Packages/com.avionblock.opussharp/Plugins/osx-x64/native/opus.dylib.meta
+++ b/Basis/Packages/com.avionblock.opussharp/Plugins/osx-x64/native/opus.dylib.meta
@@ -1,2 +1,47 @@
 fileFormatVersion: 2
 guid: 62ca4b7f075ca3243a8c1a314ce4c548
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 0
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 0
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude Android: 1
+        Exclude iOS: 1
+  - first:
+      Any:
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+        DefaultValueInitialized: true
+        OS: OSX
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 1
+      settings:
+        CPU: x86_64
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary

Fixes macOS IL2CPP standalone builds failing with undefined symbol errors for all `opus_*` functions (`opus_encode`, `opus_decode`, `opus_encoder_create`, `opus_decoder_destroy`, etc.).

## Problem

The `.meta` files for `osx-x64/native/opus.dylib` and `osx-arm64/native/opus.dylib` in `com.avionblock.opussharp` only contained a `fileFormatVersion` and `guid` — no `PluginImporter` section. Without this section, Unity treats the `.dylib` files as generic assets rather than native plugins. They are completely excluded from the IL2CPP linker step, which causes every P/Invoke call into the Opus library to fail with `Undefined symbols for architecture x86_64` at build time.

Other platform plugins (Windows `.dll`, Linux `.so`, Android `.so`) may have the same issue in their meta files but were not tested as part of this change.

## Fix

Added full `PluginImporter` metadata to both macOS dylib meta files:

- **`osx-x64/opus.dylib.meta`** — enabled for Editor (x86_64, OSX) and Standalone OSXUniversal (x86_64), excluded from all other platforms
- **`osx-arm64/opus.dylib.meta`** — enabled for Editor (ARM64, OSX) and Standalone OSXUniversal (ARM64), excluded from all other platforms

This ensures Unity recognizes the dylibs as native plugins and links them correctly during IL2CPP builds.