### PR TITLE
Fix headless client loading and audio decoding.

### DIFF
--- a/Basis/Packages/com.basis.framework/Drivers/Local/BasisAudioClipPlayer.cs
+++ b/Basis/Packages/com.basis.framework/Drivers/Local/BasisAudioClipPlayer.cs
@@ -426,9 +426,9 @@ public static class BasisAudioClipPlayer
             int remainingPreSkip = preSkipSamples;
 #if UNITY_IOS && !UNITY_EDITOR
             // iOS requires statically linked Opus library
-            decoder = new OpusSharp.Core.Static.OpusDecoder(RemoteOpusSettings.NetworkSampleRate, RemoteOpusSettings.Channels);
+            decoder = new OpusSharp.Core.Static.OpusDecoder(SampleRate, channels);
 #else
-            decoder = new OpusSharp.Core.Dynamic.OpusDecoder(RemoteOpusSettings.NetworkSampleRate, RemoteOpusSettings.Channels);
+            decoder = new OpusSharp.Core.Dynamic.OpusDecoder(SampleRate, channels);
 #endif
             for (int packetIndex = audioPacketStart; packetIndex < packets.Count; packetIndex++)
             {

--- a/Basis/Packages/com.basis.framework/Drivers/Local/BasisAudioClipPlayer.cs
+++ b/Basis/Packages/com.basis.framework/Drivers/Local/BasisAudioClipPlayer.cs
@@ -44,9 +44,9 @@ public static class BasisAudioClipPlayer
     /// </summary>
     public static string ClipDirectory;
 
-#if !UNITY_SERVER
+
     public static OpusSharp.Core.Interfaces.IOpusDecoder decoder;
-#endif
+
     /// <summary>
     /// Attempts to initialize the clip player. If the AudioClips directory exists and
     /// contains supported audio files, a random clip is loaded and streamed as voice audio.

--- a/Basis/Packages/com.basis.framework/Drivers/Local/BasisAudioClipPlayer.cs
+++ b/Basis/Packages/com.basis.framework/Drivers/Local/BasisAudioClipPlayer.cs
@@ -45,7 +45,7 @@ public static class BasisAudioClipPlayer
     public static string ClipDirectory;
 
 
-    public static OpusSharp.Core.Interfaces.IOpusDecoder decoder;
+    private static OpusSharp.Core.Interfaces.IOpusDecoder decoder;
 
     /// <summary>
     /// Attempts to initialize the clip player. If the AudioClips directory exists and
@@ -152,6 +152,8 @@ public static class BasisAudioClipPlayer
         clipSamples = null;
         clipPosition = 0;
 
+        decoder?.Dispose();
+        decoder = null;
         encoder?.Dispose();
         encoder = null;
     }

--- a/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalAvatarDriver.cs
+++ b/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalAvatarDriver.cs
@@ -292,19 +292,13 @@ namespace Basis.Scripts.Drivers
         /// <returns>Eye height value.</returns>
         public float ActiveAvatarEyeHeight()
         {
-            if (BasisLocalPlayer.Instance.BasisAvatar != null)
+            var localPlayer = BasisLocalPlayer.Instance;
+            if (localPlayer?.BasisAvatar != null)
             {
-                // Prefer the actual eye bone height from T-pose calibration data.
-                // The authored AvatarEyePosition.x (e.g. from NDMF/VRChat viewpoint)
-                // does NOT include Animator.humanScale, but bone world positions do.
-                // When humanScale != 1 this mismatch causes the avatar to be scaled
-                // to the wrong size, floating 10-20 cm above the floor.
-                var eye = BasisLocalBoneDriver.EyeControl;
-                if (eye != null && eye.TposeLocal.position.y > 0.1f)
-                {
-                    return eye.TposeLocal.position.y;
-                }
-                return BasisLocalPlayer.Instance.BasisAvatar.AvatarEyePosition.x;
+                // Use the authored/avatar-configured eye height here.
+                // This value is user-editable and survives avatar swap ordering,
+                // while rig/control data can be stale during recalibration.
+                return localPlayer.BasisAvatar.AvatarEyePosition.x;
             }
             else
             {


### PR DESCRIPTION
## Direct change
  * Audio decoder is now included across build configurations.

## Bug Fix
  * Improved shutdown cleanup to reliably dispose the audio decoder and free resources.
  * Opus decoding now uses the correct sample rate and channel settings, improving audio compatibility and playback stability.
  * Avatar eye height is now sourced from the active avatar data for more consistent camera/eye positioning.