### PR TITLE
Disconnect headless admin toggle

### DIFF
--- a/Basis Server/BasisNetworkCore/BasisServerConfiguration.cs
+++ b/Basis Server/BasisNetworkCore/BasisServerConfiguration.cs
@@ -56,6 +56,7 @@ public class Configuration
     public bool DisableReadUnlessAdminPersistentFlag = false;
     public bool UseNetworkFinalCompression = false;
     public bool EnableBSRProfiling = false;
+    public bool DisallowHeadless = false;
     /// <summary>
     /// Read config from file. If no file is found create a default config file at filePath
     /// </summary>

--- a/Basis Server/BasisNetworkCore/Serializable/AdminRequest.cs
+++ b/Basis Server/BasisNetworkCore/Serializable/AdminRequest.cs
@@ -62,6 +62,8 @@ namespace BasisNetworkCore.Serializable
             GlobalGetLockState,  // server→client: current global lock state
             GlobalGetHeadlessAudioState, // server→client: current global headless audio state
             SetGlobalHeadlessAudio, // admin: explicitly set headless audio clip playback state for headless clients
+            GlobalGetHeadlessDisallowState, // server→client: current global headless disallow state
+            SetGlobalHeadlessDisallow, // admin: explicitly allow/disallow headless client connections
         }
     }
 }

--- a/Basis Server/BasisNetworkServer/BasisServerHandleEvents.cs
+++ b/Basis Server/BasisNetworkServer/BasisServerHandleEvents.cs
@@ -136,8 +136,10 @@ namespace BasisServerHandle
             writer.Put(reason ?? string.Empty);
             byte[] reasonBytes = writer.CopyData();
             NetworkServer.ReturnWriter(writer);
-            NetworkServer.AuthenticatedPeers.TryRemove(id, out _);
-            NetworkServer.RebuildPeerSnapshot();
+            if (NetworkServer.AuthenticatedPeers.TryRemove(id, out _))
+            {
+                NetworkServer.RebuildPeerSnapshot();
+            }
             request.Disconnect(reasonBytes);
             BNL.LogError($"Rejected after accept with reason: {reason}");
         }

--- a/Basis Server/BasisNetworkServer/BasisServerHandleEvents.cs
+++ b/Basis Server/BasisNetworkServer/BasisServerHandleEvents.cs
@@ -144,15 +144,16 @@ namespace BasisServerHandle
             BNL.LogError($"Rejected after accept with reason: {reason}");
         }
 
-        public static bool RejectIfHeadlessDisallowed(NetPeer peer, ClientMetaDataMessage metaData)
+        public static bool IsHeadlessDisallowed(ClientMetaDataMessage metaData, out string reason)
         {
             if (!BasisHeadlessConnectionPolicyManager.HeadlessDisallowed ||
                 !BasisHeadlessConnectionPolicyManager.IsHeadlessClient(metaData))
             {
+                reason = null;
                 return false;
             }
 
-            RejectWithReason(peer, BasisHeadlessConnectionPolicyManager.DisallowedReason);
+            reason = BasisHeadlessConnectionPolicyManager.DisallowedReason;
             return true;
         }
         #endregion
@@ -207,10 +208,9 @@ namespace BasisServerHandle
                     BytesMessage authMessage = new BytesMessage();
                     authMessage.Deserialize(ConReq.Data, out byte[] UnusedBytes);
                 }
-                NetPeer newPeer = ConReq.Accept();//can do both way Communication from here on
-
                 if (NetworkServer.Configuration.UseAuthIdentity)
                 {
+                    NetPeer newPeer = ConReq.Accept();//can do both way Communication from here on
                     NetworkServer.AuthIdentity.ProcessConnection(NetworkServer.Configuration, ConReq, newPeer);
                 }
                 else
@@ -220,11 +220,17 @@ namespace BasisServerHandle
 
                     if (readyMessage.WasDeserializedCorrectly())
                     {
-                        if (RejectIfHeadlessDisallowed(newPeer, readyMessage.playerMetaDataMessage))
+                        if (IsHeadlessDisallowed(readyMessage.playerMetaDataMessage, out string reason))
                         {
+                            RejectWithReason(ConReq, reason);
                             return;
                         }
+                    }
 
+                    NetPeer newPeer = ConReq.Accept();//can do both way Communication from here on
+
+                    if (readyMessage.WasDeserializedCorrectly())
+                    {
                         OnNetworkAccepted(newPeer, readyMessage, readyMessage.playerMetaDataMessage.playerUUID);
                     }
                 }

--- a/Basis Server/BasisNetworkServer/BasisServerHandleEvents.cs
+++ b/Basis Server/BasisNetworkServer/BasisServerHandleEvents.cs
@@ -131,13 +131,24 @@ namespace BasisServerHandle
         }
         public static void RejectWithReason(NetPeer request, string reason)
         {
-            ushort Id =(ushort)request.Id;
-            NetDataWriter writer = NetworkServer.RentWriter();
-            writer.Put(reason);
-            NetworkServer.AuthenticatedPeers.TryRemove(Id, out _);
-            request.Disconnect();
-            NetworkServer.ReturnWriter(writer);
+            ushort id = (ushort)request.Id;
+            byte[] reasonBytes = System.Text.Encoding.UTF8.GetBytes(reason ?? string.Empty);
+            NetworkServer.AuthenticatedPeers.TryRemove(id, out _);
+            NetworkServer.RebuildPeerSnapshot();
+            request.Disconnect(reasonBytes);
             BNL.LogError($"Rejected after accept with reason: {reason}");
+        }
+
+        public static bool RejectIfHeadlessDisallowed(NetPeer peer, ClientMetaDataMessage metaData)
+        {
+            if (!BasisHeadlessConnectionPolicyManager.HeadlessDisallowed ||
+                !BasisHeadlessConnectionPolicyManager.IsHeadlessClient(metaData))
+            {
+                return false;
+            }
+
+            RejectWithReason(peer, BasisHeadlessConnectionPolicyManager.DisallowedReason);
+            return true;
         }
         #endregion
 
@@ -204,6 +215,11 @@ namespace BasisServerHandle
 
                     if (readyMessage.WasDeserializedCorrectly())
                     {
+                        if (RejectIfHeadlessDisallowed(newPeer, readyMessage.playerMetaDataMessage))
+                        {
+                            return;
+                        }
+
                         OnNetworkAccepted(newPeer, readyMessage, readyMessage.playerMetaDataMessage.playerUUID);
                     }
                 }
@@ -273,6 +289,7 @@ namespace BasisServerHandle
                 BasisNetworkContentShare.SendAllSpheresToPeer(newPeer);
                 BasisNetworkServer.Security.BasisGlobalLockManager.SendLockStateToPeer(newPeer);
                 BasisNetworkServer.Security.BasisHeadlessAudioStateManager.SendStateToPeer(newPeer);
+                BasisNetworkServer.Security.BasisHeadlessConnectionPolicyManager.SendStateToPeer(newPeer);
                 SendShoutStateToPeer(newPeer);
             }
             else

--- a/Basis Server/BasisNetworkServer/BasisServerHandleEvents.cs
+++ b/Basis Server/BasisNetworkServer/BasisServerHandleEvents.cs
@@ -132,7 +132,10 @@ namespace BasisServerHandle
         public static void RejectWithReason(NetPeer request, string reason)
         {
             ushort id = (ushort)request.Id;
-            byte[] reasonBytes = System.Text.Encoding.UTF8.GetBytes(reason ?? string.Empty);
+            NetDataWriter writer = NetworkServer.RentWriter();
+            writer.Put(reason ?? string.Empty);
+            byte[] reasonBytes = writer.CopyData();
+            NetworkServer.ReturnWriter(writer);
             NetworkServer.AuthenticatedPeers.TryRemove(id, out _);
             NetworkServer.RebuildPeerSnapshot();
             request.Disconnect(reasonBytes);

--- a/Basis Server/BasisNetworkServer/NetworkServer.cs
+++ b/Basis Server/BasisNetworkServer/NetworkServer.cs
@@ -62,6 +62,7 @@ public static class NetworkServer
         HighQualityLength = BasisAvatarBitPacking.ConvertToSize(BitQuality.High);
         InitializePulseSettings();
         InitializeAuth();
+        BasisHeadlessConnectionPolicyManager.InitializeFromConfig(configuration.DisallowHeadless);
         SetupServer(configuration);
         SubscribeEvents(Configuration);
 

--- a/Basis Server/BasisNetworkServer/Security/BasisDIDAuthIdentity.cs
+++ b/Basis Server/BasisNetworkServer/Security/BasisDIDAuthIdentity.cs
@@ -85,8 +85,9 @@ namespace BasisDidLink
 
                 if (readyMessage.WasDeserializedCorrectly())
                 {
-                    if (BasisServerHandleEvents.RejectIfHeadlessDisallowed(newPeer, readyMessage.playerMetaDataMessage))
+                    if (BasisServerHandleEvents.IsHeadlessDisallowed(readyMessage.playerMetaDataMessage, out string reason))
                     {
+                        BasisServerHandleEvents.RejectWithReason(newPeer, reason);
                         return;
                     }
 

--- a/Basis Server/BasisNetworkServer/Security/BasisDIDAuthIdentity.cs
+++ b/Basis Server/BasisNetworkServer/Security/BasisDIDAuthIdentity.cs
@@ -85,6 +85,11 @@ namespace BasisDidLink
 
                 if (readyMessage.WasDeserializedCorrectly())
                 {
+                    if (BasisServerHandleEvents.RejectIfHeadlessDisallowed(newPeer, readyMessage.playerMetaDataMessage))
+                    {
+                        return;
+                    }
+
                     string UUID = readyMessage.playerMetaDataMessage.playerUUID;
                     Did playerDid = new Did(UUID);
                     if (BasisPlayerModeration.IsBanned(UUID))

--- a/Basis Server/BasisNetworkServer/Security/BasisHeadlessConnectionPolicyManager.cs
+++ b/Basis Server/BasisNetworkServer/Security/BasisHeadlessConnectionPolicyManager.cs
@@ -1,0 +1,98 @@
+using Basis.Network.Core;
+using Basis.Network.Server.Generic;
+using System;
+using System.Threading;
+using static BasisNetworkCore.Serializable.SerializableBasis;
+namespace BasisNetworkServer.Security
+{
+    /// <summary>
+    /// Runtime-only server policy controlling whether headless clients may stay connected.
+    /// </summary>
+    public static class BasisHeadlessConnectionPolicyManager
+    {
+        public const string DisallowedReason = "Headless client disallowed by server.";
+
+        private static int _headlessDisallowed;
+
+        public static bool HeadlessDisallowed => Interlocked.CompareExchange(ref _headlessDisallowed, 0, 0) == 1;
+
+        public static void InitializeFromConfig(bool disallowHeadless)
+        {
+            Interlocked.Exchange(ref _headlessDisallowed, disallowHeadless ? 1 : 0);
+        }
+
+        public static bool SetDisallowHeadless(bool disallowHeadless)
+        {
+            int requestedValue = disallowHeadless ? 1 : 0;
+            int previousValue = Interlocked.Exchange(ref _headlessDisallowed, requestedValue);
+            return previousValue != requestedValue;
+        }
+
+        public static bool IsHeadlessClient(SerializableBasis.ClientMetaDataMessage metaData)
+        {
+            return IsHeadlessPlatform(metaData.playerPlatform);
+        }
+
+        public static bool IsHeadlessPlatform(string playerPlatform)
+        {
+            if (string.IsNullOrWhiteSpace(playerPlatform))
+            {
+                return false;
+            }
+
+            return string.Equals(playerPlatform, "Headless", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(playerPlatform, "WindowsServer", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(playerPlatform, "LinuxServer", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(playerPlatform, "OSXServer", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static void DisconnectConnectedHeadlessPeers()
+        {
+            NetPeer[] peers = NetworkServer.PeerSnapshot;
+            foreach (NetPeer peer in peers)
+            {
+                if (!BasisSavedState.GetLastPlayerMetaData(peer, out SerializableBasis.ClientMetaDataMessage metaData) ||
+                    !IsHeadlessClient(metaData))
+                {
+                    continue;
+                }
+
+                BasisServerHandle.BasisServerHandleEvents.RejectWithReason(peer, DisallowedReason);
+            }
+        }
+
+        public static void SendStateToPeer(NetPeer peer)
+        {
+            NetDataWriter writer = NetworkServer.RentWriter();
+            try
+            {
+                new AdminRequest().Serialize(writer, AdminRequestMode.GlobalGetHeadlessDisallowState);
+                writer.Put(HeadlessDisallowed);
+                NetworkServer.TrySend(peer, writer, BasisNetworkCommons.AdminChannel, DeliveryMethod.ReliableOrdered);
+            }
+            finally
+            {
+                NetworkServer.ReturnWriter(writer);
+            }
+        }
+
+        public static void BroadcastState()
+        {
+            NetDataWriter writer = NetworkServer.RentWriter();
+            try
+            {
+                new AdminRequest().Serialize(writer, AdminRequestMode.GlobalGetHeadlessDisallowState);
+                writer.Put(HeadlessDisallowed);
+                NetworkServer.BroadcastMessageToClients(
+                    writer,
+                    BasisNetworkCommons.AdminChannel,
+                    NetworkServer.PeerSnapshot,
+                    DeliveryMethod.ReliableOrdered);
+            }
+            finally
+            {
+                NetworkServer.ReturnWriter(writer);
+            }
+        }
+    }
+}

--- a/Basis Server/BasisNetworkServer/Security/BasisPlayerModeration.cs
+++ b/Basis Server/BasisNetworkServer/Security/BasisPlayerModeration.cs
@@ -322,6 +322,11 @@ namespace BasisNetworkServer.Security
                         HandleHeadlessAudioSet(peer, reader));
                     break;
 
+                case AdminRequestMode.SetGlobalHeadlessDisallow:
+                    Require(peer, PermNodes.ModerationKick, () =>
+                        HandleHeadlessDisallowSet(peer, reader));
+                    break;
+
                 // ===== PERMISSION EDIT =====
                 case AdminRequestMode.SetUserGroup:
                 case AdminRequestMode.SetUserNode:
@@ -474,6 +479,32 @@ namespace BasisNetworkServer.Security
             BNL.Log(notification);
             SendBackMessage(peer, notification);
             BasisHeadlessAudioStateManager.BroadcastState();
+        }
+
+        private static void HandleHeadlessDisallowSet(NetPeer peer, NetPacketReader reader)
+        {
+            if (reader.AvailableBytes < 1)
+            {
+                SendBackMessage(peer, "Failed to set headless connection policy: missing state value.");
+                return;
+            }
+
+            bool disallowHeadless = reader.GetBool();
+            bool changed = BasisHeadlessConnectionPolicyManager.SetDisallowHeadless(disallowHeadless);
+            string state = disallowHeadless ? "DISALLOWED" : "ALLOWED";
+            string notification = changed
+                ? $"Headless clients are now {state}."
+                : $"Headless clients were already {state}.";
+
+            BNL.Log(notification);
+            SendBackMessage(peer, notification);
+
+            if (disallowHeadless)
+            {
+                BasisHeadlessConnectionPolicyManager.DisconnectConnectedHeadlessPeers();
+            }
+
+            BasisHeadlessConnectionPolicyManager.BroadcastState();
         }
 
         public static void SendBackMessage(NetPeer peer, string msg)

--- a/Basis Server/BasisNetworkServer/Security/BasisPlayerModeration.cs
+++ b/Basis Server/BasisNetworkServer/Security/BasisPlayerModeration.cs
@@ -323,7 +323,7 @@ namespace BasisNetworkServer.Security
                     break;
 
                 case AdminRequestMode.SetGlobalHeadlessDisallow:
-                    Require(peer, PermNodes.ModerationKick, () =>
+                    Require(peer, PermNodes.ModerationGlobalLock, () =>
                         HandleHeadlessDisallowSet(peer, reader));
                     break;
 

--- a/Basis Server/Docker/README.md
+++ b/Basis Server/Docker/README.md
@@ -51,6 +51,7 @@ Example snippet from a `config/config.xml` (values here might be defaults before
   <PeerLimit>1024</PeerLimit>
   <SetPort>4296</SetPort>
   <EnableConsole>true</EnableConsole>
+  <DisallowHeadless>false</DisallowHeadless>
   <!-- ... other settings ... -->
 </Configuration>
 ```
@@ -70,6 +71,7 @@ Commonly used environment variables:
 | `Password`           | `default_password`              | Connection password for clients. **Change this!** |
 | `EnableStatistics`   | `true`                          | Enables the statistics module.                    |
 | `EnableConsole`      | `false`                         | Enables the interactive server console (CLI).     |
+| `DisallowHeadless`   | `false`                         | Disconnects connected headless clients and blocks new ones. |
 
 A more comprehensive list of configurable settings can typically be found by inspecting the generated `config/config.xml` after an initial run, or by checking the server's internal documentation if available.
 

--- a/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/NetworkStatsPanelUpdater.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/NetworkStatsPanelUpdater.cs
@@ -83,10 +83,11 @@ namespace Basis.BasisUI
             if (PlayersField != null)
             {
                 int receiverCount = BasisNetworkPlayers.ReceiverCount;
-                int totalPlayers = BasisNetworkPlayers.Players.Count;
+                int totalPlayers = 0;
                 int headlessPlayers = 0;
                 foreach (var entry in BasisNetworkPlayers.Players)
                 {
+                    totalPlayers++; // We could have players leave during the count so better to just count them all the same time.
                     switch (entry.Value?.Player?.PlayerPlatform)
                     {
                         case "Headless":

--- a/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/NetworkStatsPanelUpdater.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/NetworkStatsPanelUpdater.cs
@@ -93,18 +93,34 @@ namespace Basis.BasisUI
                     totalPlayers++; // We could have players leave during the count so better to just count them all the same time.
                     string playerPlatform = entry.Value?.Player?.PlayerPlatform;
                     string aggregatePlatform = NormalizePlatformAggregate(playerPlatform);
-
-                    platformCounts[aggregatePlatform] = platformCounts.GetValueOrDefault(aggregatePlatform) + 1;
-
+                    bool isHeadless = false;
                     switch (playerPlatform)
                     {
                         case "Headless":
+                            headlessPlayers++;
+                            isHeadless = true;
+                            platformCounts["Headless"] = platformCounts.GetValueOrDefault("Headless") + 1;
+                            break;
                         case "WindowsServer":
+                            headlessPlayers++;
+                            isHeadless = true;
+                            platformCounts["WindowsServer"] = platformCounts.GetValueOrDefault("WindowsServer") + 1;
+                            break;
                         case "LinuxServer":
+                            headlessPlayers++;
+                            isHeadless = true;
+                            platformCounts["LinuxServer"] = platformCounts.GetValueOrDefault("LinuxServer") + 1;
+                            break;
                         case "OSXServer":
                             headlessPlayers++;
+                            isHeadless = true;
+                            platformCounts["macOSServer"] = platformCounts.GetValueOrDefault("macOSServer") + 1;
                             break;
                     }
+                    if (!isHeadless)
+                        platformCounts[aggregatePlatform] = platformCounts.GetValueOrDefault(aggregatePlatform) + 1;
+
+                    
                 }
                 int realPlayers = totalPlayers - headlessPlayers;
                 ServerMetaDataMessage meta = BasisNetworkManagement.ServerMetaDataMessage;
@@ -125,6 +141,9 @@ namespace Basis.BasisUI
                     AppendPlatformCount(description, platformCounts, "Linux", ref hasAppendedPlatform);
                     AppendPlatformCount(description, platformCounts, "Android", ref hasAppendedPlatform);
                     AppendPlatformCount(description, platformCounts, "iOS", ref hasAppendedPlatform);
+                    AppendPlatformCount(description, platformCounts, "Windows Server", ref hasAppendedPlatform);
+                    AppendPlatformCount(description, platformCounts, "Linux Server", ref hasAppendedPlatform);
+                    AppendPlatformCount(description, platformCounts, "macOS Server", ref hasAppendedPlatform);
                     AppendPlatformCount(description, platformCounts, "Headless", ref hasAppendedPlatform);
                     AppendPlatformCount(description, platformCounts, "Unknown", ref hasAppendedPlatform);
 
@@ -242,6 +261,18 @@ namespace Basis.BasisUI
                 return "Unknown";
             }
 
+            switch (platform)
+            {
+                case "WindowsServer":
+                    return "Windows Server";
+                case "LinuxServer":
+                    return "Linux Server";
+                case "OSXServer":
+                    return "macOS Server";
+                case "Headless":
+                    return "Headless";
+            }
+
             return BasisIOManagement.NormalizeCachePlatformName(platform) switch
             {
                 "StandaloneWindows64" => "Windows",
@@ -249,7 +280,6 @@ namespace Basis.BasisUI
                 "StandaloneOSX" => "macOS",
                 "Android" => "Android",
                 "iOS" => "iOS",
-                "Headless" => "Headless",
                 _ => UserListProvider.GetPlatformLabel(platform)
             };
         }

--- a/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/NetworkStatsPanelUpdater.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/NetworkStatsPanelUpdater.cs
@@ -93,32 +93,8 @@ namespace Basis.BasisUI
                     totalPlayers++; // We could have players leave during the count so better to just count them all the same time.
                     string playerPlatform = entry.Value?.Player?.PlayerPlatform;
                     string aggregatePlatform = NormalizePlatformAggregate(playerPlatform);
-                    bool isHeadless = false;
-                    switch (playerPlatform)
-                    {
-                        case "Headless":
-                            headlessPlayers++;
-                            isHeadless = true;
-                            platformCounts["Headless"] = platformCounts.GetValueOrDefault("Headless") + 1;
-                            break;
-                        case "WindowsServer":
-                            headlessPlayers++;
-                            isHeadless = true;
-                            platformCounts["WindowsServer"] = platformCounts.GetValueOrDefault("WindowsServer") + 1;
-                            break;
-                        case "LinuxServer":
-                            headlessPlayers++;
-                            isHeadless = true;
-                            platformCounts["LinuxServer"] = platformCounts.GetValueOrDefault("LinuxServer") + 1;
-                            break;
-                        case "OSXServer":
-                            headlessPlayers++;
-                            isHeadless = true;
-                            platformCounts["macOSServer"] = platformCounts.GetValueOrDefault("macOSServer") + 1;
-                            break;
-                    }
-                    if (!isHeadless)
-                        platformCounts[aggregatePlatform] = platformCounts.GetValueOrDefault(aggregatePlatform) + 1;
+
+                    platformCounts[aggregatePlatform] = platformCounts.GetValueOrDefault(aggregatePlatform) + 1;
 
                     
                 }
@@ -155,7 +131,7 @@ namespace Basis.BasisUI
                         }
 
                         description.Append(platformCount.Key);
-                        description.Append(':');
+                        description.Append(":");
                         description.Append(platformCount.Value);
                         hasAppendedPlatform = true;
                     }
@@ -297,7 +273,7 @@ namespace Basis.BasisUI
             }
 
             description.Append(platform);
-            description.Append(':');
+            description.Append(": ");
             description.Append(count);
             hasAppendedPlatform = true;
             platformCounts.Remove(platform);

--- a/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/NetworkStatsPanelUpdater.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/NetworkStatsPanelUpdater.cs
@@ -84,10 +84,25 @@ namespace Basis.BasisUI
             {
                 int receiverCount = BasisNetworkPlayers.ReceiverCount;
                 int totalPlayers = BasisNetworkPlayers.Players.Count;
+                int headlessPlayers = 0;
+                foreach (var entry in BasisNetworkPlayers.Players)
+                {
+                    switch (entry.Value?.Player?.PlayerPlatform)
+                    {
+                        case "Headless":
+                        case "WindowsServer":
+                        case "LinuxServer":
+                        case "OSXServer":
+                            headlessPlayers++;
+                            break;
+                    }
+                }
+                int realPlayers = totalPlayers - headlessPlayers;
                 ServerMetaDataMessage meta = BasisNetworkManagement.ServerMetaDataMessage;
                 int capacity = meta.PeerLimit;
                 PlayersField.SetDescription(
                     $"Total: {totalPlayers} | Remote: {receiverCount}\n" +
+                    $"Real: {realPlayers} | Headless: {headlessPlayers}\n" +
                     $"Server Capacity: {capacity}");
             }
 

--- a/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/NetworkStatsPanelUpdater.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/NetworkStatsPanelUpdater.cs
@@ -1,5 +1,7 @@
 using Basis.Scripts.Networking;
 using Basis.Network.Core;
+using System.Collections.Generic;
+using System.Text;
 using UnityEngine;
 using static SerializableBasis;
 
@@ -85,10 +87,16 @@ namespace Basis.BasisUI
                 int receiverCount = BasisNetworkPlayers.ReceiverCount;
                 int totalPlayers = 0;
                 int headlessPlayers = 0;
+                Dictionary<string, int> platformCounts = new Dictionary<string, int>();
                 foreach (var entry in BasisNetworkPlayers.Players)
                 {
                     totalPlayers++; // We could have players leave during the count so better to just count them all the same time.
-                    switch (entry.Value?.Player?.PlayerPlatform)
+                    string playerPlatform = entry.Value?.Player?.PlayerPlatform;
+                    string aggregatePlatform = NormalizePlatformAggregate(playerPlatform);
+
+                    platformCounts[aggregatePlatform] = platformCounts.GetValueOrDefault(aggregatePlatform) + 1;
+
+                    switch (playerPlatform)
                     {
                         case "Headless":
                         case "WindowsServer":
@@ -101,10 +109,40 @@ namespace Basis.BasisUI
                 int realPlayers = totalPlayers - headlessPlayers;
                 ServerMetaDataMessage meta = BasisNetworkManagement.ServerMetaDataMessage;
                 int capacity = meta.PeerLimit;
-                PlayersField.SetDescription(
+                StringBuilder description = new StringBuilder(160);
+                description.Append(
                     $"Total: {totalPlayers} | Remote: {receiverCount}\n" +
                     $"Real: {realPlayers} | Headless: {headlessPlayers}\n" +
                     $"Server Capacity: {capacity}");
+
+                if (platformCounts.Count > 0)
+                {
+                    description.Append("\nPlatforms: ");
+                    bool hasAppendedPlatform = false;
+
+                    AppendPlatformCount(description, platformCounts, "Windows", ref hasAppendedPlatform);
+                    AppendPlatformCount(description, platformCounts, "macOS", ref hasAppendedPlatform);
+                    AppendPlatformCount(description, platformCounts, "Linux", ref hasAppendedPlatform);
+                    AppendPlatformCount(description, platformCounts, "Android", ref hasAppendedPlatform);
+                    AppendPlatformCount(description, platformCounts, "iOS", ref hasAppendedPlatform);
+                    AppendPlatformCount(description, platformCounts, "Headless", ref hasAppendedPlatform);
+                    AppendPlatformCount(description, platformCounts, "Unknown", ref hasAppendedPlatform);
+
+                    foreach (KeyValuePair<string, int> platformCount in platformCounts)
+                    {
+                        if (hasAppendedPlatform)
+                        {
+                            description.Append(" | ");
+                        }
+
+                        description.Append(platformCount.Key);
+                        description.Append(':');
+                        description.Append(platformCount.Value);
+                        hasAppendedPlatform = true;
+                    }
+                }
+
+                PlayersField.SetDescription(description.ToString());
             }
 
             // Transmission
@@ -195,6 +233,44 @@ namespace Basis.BasisUI
             if (bytesPerSec < 1024) return $"{bytesPerSec:F0} B/s";
             if (bytesPerSec < 1024 * 1024) return $"{bytesPerSec / 1024.0:F1} KB/s";
             return $"{bytesPerSec / (1024.0 * 1024.0):F2} MB/s";
+        }
+
+        private static string NormalizePlatformAggregate(string platform)
+        {
+            if (string.IsNullOrWhiteSpace(platform))
+            {
+                return "Unknown";
+            }
+
+            return BasisIOManagement.NormalizeCachePlatformName(platform) switch
+            {
+                "StandaloneWindows64" => "Windows",
+                "StandaloneLinux64" => "Linux",
+                "StandaloneOSX" => "macOS",
+                "Android" => "Android",
+                "iOS" => "iOS",
+                "Headless" => "Headless",
+                _ => UserListProvider.GetPlatformLabel(platform)
+            };
+        }
+
+        private static void AppendPlatformCount(StringBuilder description, Dictionary<string, int> platformCounts, string platform, ref bool hasAppendedPlatform)
+        {
+            if (!platformCounts.TryGetValue(platform, out int count))
+            {
+                return;
+            }
+
+            if (hasAppendedPlatform)
+            {
+                description.Append(" | ");
+            }
+
+            description.Append(platform);
+            description.Append(':');
+            description.Append(count);
+            hasAppendedPlatform = true;
+            platformCounts.Remove(platform);
         }
     }
 }

--- a/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/SettingsProviderAdminTab.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/SettingsProviderAdminTab.cs
@@ -335,10 +335,17 @@ namespace Basis.BasisUI
             headlessAudioToggle.SetValueWithoutNotify(BasisNetworkModeration.GlobalHeadlessAudioOff);
             headlessAudioToggle.OnValueChanged += value => BasisNetworkModeration.SetGlobalHeadlessAudio(value);
 
+            PanelToggle disallowHeadlessToggle = PanelToggle.CreateNewEntry(lockGroup.ContentParent);
+            disallowHeadlessToggle.Descriptor.SetTitle("Disallow headless");
+            disallowHeadlessToggle.Descriptor.SetDescription("Disconnects connected headless clients and blocks new headless clients while enabled.");
+            disallowHeadlessToggle.SetValueWithoutNotify(BasisNetworkModeration.GlobalHeadlessDisallowed);
+            disallowHeadlessToggle.OnValueChanged += value => BasisNetworkModeration.SetGlobalHeadlessDisallow(value);
+
             controller.AvatarLockToggle = avatarLock;
             controller.PropLockToggle = propLock;
             controller.WorldLockToggle = worldLock;
             controller.HeadlessAudioToggle = headlessAudioToggle;
+            controller.HeadlessDisallowToggle = disallowHeadlessToggle;
 
             // Permissions section
             SettingsProviderPermissionsTab.BuildPermissionsUI(container, tab.gameObject);
@@ -403,6 +410,7 @@ namespace Basis.BasisUI
             public PanelToggle PropLockToggle;
             public PanelToggle WorldLockToggle;
             public PanelToggle HeadlessAudioToggle;
+            public PanelToggle HeadlessDisallowToggle;
 
             public BasisNetworkPlayer SelectedPlayer;
             private string _searchQuery = string.Empty;
@@ -422,6 +430,7 @@ namespace Basis.BasisUI
                 BasisNetworkPlayer.OnRemotePlayerLeft += OnRemotePlayersChanged;
                 BasisNetworkModeration.OnGlobalLockStateChanged += OnGlobalLockStateChanged;
                 BasisNetworkModeration.OnGlobalHeadlessAudioStateChanged += OnGlobalHeadlessAudioStateChanged;
+                BasisNetworkModeration.OnGlobalHeadlessDisallowStateChanged += OnGlobalHeadlessDisallowStateChanged;
                 RebuildPlayerList();
             }
 
@@ -431,7 +440,7 @@ namespace Basis.BasisUI
                 BasisNetworkPlayer.OnRemotePlayerLeft -= OnRemotePlayersChanged;
                 BasisNetworkModeration.OnGlobalLockStateChanged -= OnGlobalLockStateChanged;
                 BasisNetworkModeration.OnGlobalHeadlessAudioStateChanged -= OnGlobalHeadlessAudioStateChanged;
-                BasisNetworkModeration.OnGlobalHeadlessAudioStateChanged -= OnGlobalHeadlessAudioStateChanged;
+                BasisNetworkModeration.OnGlobalHeadlessDisallowStateChanged -= OnGlobalHeadlessDisallowStateChanged;
 
                 ClearPlayerButtons();
             }
@@ -446,6 +455,11 @@ namespace Basis.BasisUI
             private void OnGlobalHeadlessAudioStateChanged(bool headlessAudioOff)
             {
                 if (HeadlessAudioToggle != null) HeadlessAudioToggle.SetValueWithoutNotify(headlessAudioOff);
+            }
+
+            private void OnGlobalHeadlessDisallowStateChanged(bool headlessDisallowed)
+            {
+                if (HeadlessDisallowToggle != null) HeadlessDisallowToggle.SetValueWithoutNotify(headlessDisallowed);
             }
 
             private void OnRemotePlayersChanged(BasisNetworkPlayer _p1, BasisRemotePlayer _p2)

--- a/Basis/Packages/com.basis.framework/Device Management/Devices/Headless/BasisHeadlessManagement.cs
+++ b/Basis/Packages/com.basis.framework/Device Management/Devices/Headless/BasisHeadlessManagement.cs
@@ -893,6 +893,19 @@ public class BasisHeadlessManagement : BasisBaseTypeManagement
         BasisHeadlessRuntimeStatus.MarkDisconnected(disconnectInfo, message);
         ResetServerHeadlessAudioPolicy();
 
+        if (IsServerHeadlessDisallowMessage(message))
+        {
+            BasisNetworkConnection.HeadlessReconnectSuppressed = true;
+            BasisDebug.LogWarning("Headless client disconnected because headless connections are disallowed by server.", BasisDebug.LogTag.Networking);
+
+            if (!HealthCheckEnabled)
+            {
+                QuitHeadlessApplication();
+            }
+
+            return;
+        }
+
         if (!ShouldRetry(disconnectInfo))
         {
             return;
@@ -1007,10 +1020,26 @@ public class BasisHeadlessManagement : BasisBaseTypeManagement
         }
 
         return message.IndexOf("reject", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               message.IndexOf("disallow", StringComparison.OrdinalIgnoreCase) >= 0 ||
                message.IndexOf("denied", StringComparison.OrdinalIgnoreCase) >= 0 ||
                message.IndexOf("auth", StringComparison.OrdinalIgnoreCase) >= 0 ||
                message.IndexOf("password", StringComparison.OrdinalIgnoreCase) >= 0 ||
                message.IndexOf("protocol", StringComparison.OrdinalIgnoreCase) >= 0;
+    }
+
+    private static bool IsServerHeadlessDisallowMessage(string message)
+    {
+        return !string.IsNullOrWhiteSpace(message) &&
+               message.IndexOf("disallowed by server", StringComparison.OrdinalIgnoreCase) >= 0;
+    }
+
+    private static void QuitHeadlessApplication()
+    {
+#if UNITY_EDITOR
+        UnityEditor.EditorApplication.isPlaying = false;
+#else
+        Application.Quit();
+#endif
     }
 
     private static string TryReadDisconnectMessage(DisconnectInfo disconnectInfo)

--- a/Basis/Packages/com.basis.framework/Device Management/Devices/Headless/BasisHeadlessManagement.cs
+++ b/Basis/Packages/com.basis.framework/Device Management/Devices/Headless/BasisHeadlessManagement.cs
@@ -1046,10 +1046,9 @@ public class BasisHeadlessManagement : BasisBaseTypeManagement
     {
         try
         {
-            if (disconnectInfo.AdditionalData != null &&
-                disconnectInfo.AdditionalData.TryGetString(out string message))
+            if (disconnectInfo.AdditionalData != null)
             {
-                return message;
+                return disconnectInfo.AdditionalData.PeekString();
             }
         }
         catch

--- a/Basis/Packages/com.basis.framework/Networking/BasisNetworkEvents.cs
+++ b/Basis/Packages/com.basis.framework/Networking/BasisNetworkEvents.cs
@@ -486,9 +486,9 @@ public static class BasisNetworkEvents
 #if UNITY_SERVER
             string reason = null;
             if (disconnectInfo.AdditionalData != null &&
-                disconnectInfo.AdditionalData.TryGetString(out string parsedReason))
+                !string.IsNullOrEmpty(disconnectInfo.AdditionalData.PeekString()))
             {
-                reason = parsedReason;
+                reason = disconnectInfo.AdditionalData.PeekString();
             }
 
             if (!string.IsNullOrEmpty(reason))
@@ -510,8 +510,9 @@ public static class BasisNetworkEvents
                 BasisDebug.Log($"Unexpected Failure Of Reason {disconnectInfo.Reason}");
             }
 #else
-            if (disconnectInfo.AdditionalData != null && disconnectInfo.AdditionalData.TryGetString(out string Reason))
+            if (disconnectInfo.AdditionalData != null && !string.IsNullOrEmpty(disconnectInfo.AdditionalData.PeekString()))
             {
+                string Reason = disconnectInfo.AdditionalData.PeekString();
                 BasisMainMenu.Open();
                 if (BasisMainMenu.Instance != null)
                 {

--- a/Basis/Packages/com.basis.framework/Networking/BasisNetworkModeration.cs
+++ b/Basis/Packages/com.basis.framework/Networking/BasisNetworkModeration.cs
@@ -191,6 +191,10 @@ public static class BasisNetworkModeration
                 HandleGlobalHeadlessAudioState(reader);
                 break;
 
+            case AdminRequestMode.GlobalGetHeadlessDisallowState:
+                HandleGlobalHeadlessDisallowState(reader);
+                break;
+
             default:
                 BasisDebug.LogError($"Unhandled admin command: {mode}", BasisDebug.LogTag.Networking);
                 break;
@@ -462,6 +466,18 @@ public static class BasisNetworkModeration
     /// </summary>
     public static event Action<bool> OnGlobalHeadlessAudioStateChanged;
 
+    /// <summary>
+    /// Current headless connection policy received from the server.
+    /// True means headless clients are not allowed to remain connected.
+    /// </summary>
+    public static bool GlobalHeadlessDisallowed { get; private set; }
+
+    /// <summary>
+    /// Fired when the global headless disallow state changes.
+    /// Parameter: headlessDisallowed.
+    /// </summary>
+    public static event Action<bool> OnGlobalHeadlessDisallowStateChanged;
+
     private static void HandleGlobalLockState(NetDataReader reader)
     {
         GlobalAvatarsLocked = reader.GetBool();
@@ -502,6 +518,13 @@ public static class BasisNetworkModeration
         OnGlobalHeadlessAudioStateChanged?.Invoke(GlobalHeadlessAudioOff);
     }
 
+    private static void HandleGlobalHeadlessDisallowState(NetDataReader reader)
+    {
+        GlobalHeadlessDisallowed = reader.GetBool();
+        BasisDebug.Log($"Global headless connection policy updated - Headless disallowed: {GlobalHeadlessDisallowed}", BasisDebug.LogTag.Networking);
+        OnGlobalHeadlessDisallowStateChanged?.Invoke(GlobalHeadlessDisallowed);
+    }
+
     /// <summary>
     /// Admin: Set headless audio clip playback state for headless clients.
     /// </summary>
@@ -510,6 +533,16 @@ public static class BasisNetworkModeration
         SendAdminRequest(
             AdminRequestMode.SetGlobalHeadlessAudio,
             w => w.Put(headlessAudioOff));
+    }
+
+    /// <summary>
+    /// Admin: Allow or disallow headless clients from remaining connected.
+    /// </summary>
+    public static void SetGlobalHeadlessDisallow(bool headlessDisallowed)
+    {
+        SendAdminRequest(
+            AdminRequestMode.SetGlobalHeadlessDisallow,
+            w => w.Put(headlessDisallowed));
     }
 
     #endregion

--- a/Basis/Packages/com.basis.framework/Players/Local/BasisLocalPlayer.cs
+++ b/Basis/Packages/com.basis.framework/Players/Local/BasisLocalPlayer.cs
@@ -189,11 +189,7 @@ namespace Basis.Scripts.BasisSdk.Players
             {
                 Instance = this;
             }
-#if UNITY_SERVER
-            PlayerPlatform = BasisConstants.Headless;
-#else
             PlayerPlatform = Application.platform.ToString();
-#endif
 
 #if !BASIS_DISABLE_MICROPHONE
             BasisLocalMicrophoneDriver.OnPausedAction += LocalVisemeDriver.OnPausedEvent;

--- a/Basis/Packages/com.basis.framework/Players/Local/BasisLocalPlayer.cs
+++ b/Basis/Packages/com.basis.framework/Players/Local/BasisLocalPlayer.cs
@@ -189,7 +189,11 @@ namespace Basis.Scripts.BasisSdk.Players
             {
                 Instance = this;
             }
+#if UNITY_SERVER
+            PlayerPlatform = BasisConstants.Headless;
+#else
             PlayerPlatform = Application.platform.ToString();
+#endif
 
 #if !BASIS_DISABLE_MICROPHONE
             BasisLocalMicrophoneDriver.OnPausedAction += LocalVisemeDriver.OnPausedEvent;

--- a/Basis/Packages/com.basis.framework/UI/BasisFrameRateVisualization.cs
+++ b/Basis/Packages/com.basis.framework/UI/BasisFrameRateVisualization.cs
@@ -12,7 +12,7 @@ public class BasisFrameRateVisualization : MonoBehaviour
     private float nextTimeUpdate;
 
     // Reusable character buffer — adjust size if needed
-    private char[] buffer = new char[192];
+    private char[] buffer = new char[160];
 
     void Update()
     {
@@ -61,13 +61,6 @@ public class BasisFrameRateVisualization : MonoBehaviour
                 buffer[idx++] = '/';
                 idx = AppendInt(peerLimit, idx);
             }
-
-            int headlessCount = CountHeadlessUsers();
-            if (headlessCount > 0)
-            {
-                idx = Append(buffer, " Headless:", idx);
-                idx = AppendInt(headlessCount, idx);
-            }
         }
 
         idx = Append(buffer, " FPS:", idx);
@@ -76,25 +69,6 @@ public class BasisFrameRateVisualization : MonoBehaviour
         // We don't convert to string → no GC
         fpsText.SetCharArray(buffer, 0, idx);
     }
-
-    private static int CountHeadlessUsers()
-    {
-        int headlessCount = 0;
-        foreach (var entry in BasisNetworkPlayers.Players)
-        {
-            switch (entry.Value?.Player?.PlayerPlatform)
-            {
-                case "Headless":
-                case "WindowsServer":
-                case "LinuxServer":
-                case "OSXServer":
-                    headlessCount++;
-                    break;
-            }
-        }
-        return headlessCount;
-    }
-
 
     // -------- Helpers (no GC) --------
 

--- a/Basis/Packages/com.basis.framework/UI/BasisFrameRateVisualization.cs
+++ b/Basis/Packages/com.basis.framework/UI/BasisFrameRateVisualization.cs
@@ -1,6 +1,7 @@
 using TMPro;
 using UnityEngine;
 using Basis.Scripts.Networking;
+using System;
 public class BasisFrameRateVisualization : MonoBehaviour
 {
     public TextMeshProUGUI fpsText;

--- a/Basis/Packages/com.basis.framework/UI/BasisFrameRateVisualization.cs
+++ b/Basis/Packages/com.basis.framework/UI/BasisFrameRateVisualization.cs
@@ -1,8 +1,6 @@
 using TMPro;
 using UnityEngine;
 using Basis.Scripts.Networking;
-using System;
-
 public class BasisFrameRateVisualization : MonoBehaviour
 {
     public TextMeshProUGUI fpsText;
@@ -13,7 +11,7 @@ public class BasisFrameRateVisualization : MonoBehaviour
     private float nextTimeUpdate;
 
     // Reusable character buffer — adjust size if needed
-    private char[] buffer = new char[160];
+    private char[] buffer = new char[192];
 
     void Update()
     {
@@ -62,6 +60,13 @@ public class BasisFrameRateVisualization : MonoBehaviour
                 buffer[idx++] = '/';
                 idx = AppendInt(peerLimit, idx);
             }
+
+            int headlessCount = CountHeadlessUsers();
+            if (headlessCount > 0)
+            {
+                idx = Append(buffer, " Headless:", idx);
+                idx = AppendInt(headlessCount, idx);
+            }
         }
 
         idx = Append(buffer, " FPS:", idx);
@@ -69,6 +74,24 @@ public class BasisFrameRateVisualization : MonoBehaviour
 
         // We don't convert to string → no GC
         fpsText.SetCharArray(buffer, 0, idx);
+    }
+
+    private static int CountHeadlessUsers()
+    {
+        int headlessCount = 0;
+        foreach (var entry in BasisNetworkPlayers.Players)
+        {
+            switch (entry.Value?.Player?.PlayerPlatform)
+            {
+                case "Headless":
+                case "WindowsServer":
+                case "LinuxServer":
+                case "OSXServer":
+                    headlessCount++;
+                    break;
+            }
+        }
+        return headlessCount;
     }
 
 

--- a/Basis/Packages/com.basis.server/BasisNetworkCore/BasisServerConfiguration.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkCore/BasisServerConfiguration.cs
@@ -56,6 +56,7 @@ public class Configuration
     public bool DisableReadUnlessAdminPersistentFlag = false;
     public bool UseNetworkFinalCompression = false;
     public bool EnableBSRProfiling = false;
+    public bool DisallowHeadless = false;
     /// <summary>
     /// Read config from file. If no file is found create a default config file at filePath
     /// </summary>

--- a/Basis/Packages/com.basis.server/BasisNetworkCore/Serializable/AdminRequest.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkCore/Serializable/AdminRequest.cs
@@ -62,6 +62,8 @@ namespace BasisNetworkCore.Serializable
             GlobalGetLockState,  // server→client: current global lock state
             GlobalGetHeadlessAudioState, // server→client: current global headless audio state
             SetGlobalHeadlessAudio, // admin: explicitly set headless audio clip playback state for headless clients
+            GlobalGetHeadlessDisallowState, // server→client: current global headless disallow state
+            SetGlobalHeadlessDisallow, // admin: explicitly allow/disallow headless client connections
         }
     }
 }

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/BasisServerHandleEvents.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/BasisServerHandleEvents.cs
@@ -133,7 +133,10 @@ namespace BasisServerHandle
         public static void RejectWithReason(NetPeer request, string reason)
         {
             ushort id = (ushort)request.Id;
-            byte[] reasonBytes = System.Text.Encoding.UTF8.GetBytes(reason ?? string.Empty);
+            NetDataWriter writer = NetworkServer.RentWriter();
+            writer.Put(reason ?? string.Empty);
+            byte[] reasonBytes = writer.CopyData();
+            NetworkServer.ReturnWriter(writer);
             NetworkServer.AuthenticatedPeers.TryRemove(id, out _);
             NetworkServer.RebuildPeerSnapshot();
             request.Disconnect(reasonBytes);

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/BasisServerHandleEvents.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/BasisServerHandleEvents.cs
@@ -132,13 +132,24 @@ namespace BasisServerHandle
         }
         public static void RejectWithReason(NetPeer request, string reason)
         {
-            ushort Id =(ushort)request.Id;
-            NetDataWriter writer = NetworkServer.RentWriter();
-            writer.Put(reason);
-            NetworkServer.AuthenticatedPeers.TryRemove(Id, out _);
-            request.Disconnect();
-            NetworkServer.ReturnWriter(writer);
+            ushort id = (ushort)request.Id;
+            byte[] reasonBytes = System.Text.Encoding.UTF8.GetBytes(reason ?? string.Empty);
+            NetworkServer.AuthenticatedPeers.TryRemove(id, out _);
+            NetworkServer.RebuildPeerSnapshot();
+            request.Disconnect(reasonBytes);
             BNL.LogError($"Rejected after accept with reason: {reason}");
+        }
+
+        public static bool RejectIfHeadlessDisallowed(NetPeer peer, ClientMetaDataMessage metaData)
+        {
+            if (!BasisHeadlessConnectionPolicyManager.HeadlessDisallowed ||
+                !BasisHeadlessConnectionPolicyManager.IsHeadlessClient(metaData))
+            {
+                return false;
+            }
+
+            RejectWithReason(peer, BasisHeadlessConnectionPolicyManager.DisallowedReason);
+            return true;
         }
         #endregion
 
@@ -201,6 +212,11 @@ namespace BasisServerHandle
 
                     if (readyMessage.WasDeserializedCorrectly())
                     {
+                        if (RejectIfHeadlessDisallowed(newPeer, readyMessage.playerMetaDataMessage))
+                        {
+                            return;
+                        }
+
                         OnNetworkAccepted(newPeer, readyMessage, readyMessage.playerMetaDataMessage.playerUUID);
                     }
                 }
@@ -270,6 +286,7 @@ namespace BasisServerHandle
                 BasisNetworkContentShare.SendAllSpheresToPeer(newPeer);
                 BasisNetworkServer.Security.BasisGlobalLockManager.SendLockStateToPeer(newPeer);
                 BasisNetworkServer.Security.BasisHeadlessAudioStateManager.SendStateToPeer(newPeer);
+                BasisNetworkServer.Security.BasisHeadlessConnectionPolicyManager.SendStateToPeer(newPeer);
                 SendShoutStateToPeer(newPeer);
             }
             else

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/BasisServerHandleEvents.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/BasisServerHandleEvents.cs
@@ -137,8 +137,10 @@ namespace BasisServerHandle
             writer.Put(reason ?? string.Empty);
             byte[] reasonBytes = writer.CopyData();
             NetworkServer.ReturnWriter(writer);
-            NetworkServer.AuthenticatedPeers.TryRemove(id, out _);
-            NetworkServer.RebuildPeerSnapshot();
+            if (NetworkServer.AuthenticatedPeers.TryRemove(id, out _))
+            {
+                NetworkServer.RebuildPeerSnapshot();
+            }
             request.Disconnect(reasonBytes);
             BNL.LogError($"Rejected after accept with reason: {reason}");
         }

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/BasisServerHandleEvents.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/BasisServerHandleEvents.cs
@@ -145,15 +145,16 @@ namespace BasisServerHandle
             BNL.LogError($"Rejected after accept with reason: {reason}");
         }
 
-        public static bool RejectIfHeadlessDisallowed(NetPeer peer, ClientMetaDataMessage metaData)
+        public static bool IsHeadlessDisallowed(ClientMetaDataMessage metaData, out string reason)
         {
             if (!BasisHeadlessConnectionPolicyManager.HeadlessDisallowed ||
                 !BasisHeadlessConnectionPolicyManager.IsHeadlessClient(metaData))
             {
+                reason = null;
                 return false;
             }
 
-            RejectWithReason(peer, BasisHeadlessConnectionPolicyManager.DisallowedReason);
+            reason = BasisHeadlessConnectionPolicyManager.DisallowedReason;
             return true;
         }
         #endregion
@@ -204,10 +205,9 @@ namespace BasisServerHandle
                     BytesMessage authMessage = new BytesMessage();
                     authMessage.Deserialize(ConReq.Data, out byte[] UnusedBytes);
                 }
-                NetPeer newPeer = ConReq.Accept();//can do both way Communication from here on
-
                 if (NetworkServer.Configuration.UseAuthIdentity)
                 {
+                    NetPeer newPeer = ConReq.Accept();//can do both way Communication from here on
                     NetworkServer.AuthIdentity.ProcessConnection(NetworkServer.Configuration, ConReq, newPeer);
                 }
                 else
@@ -217,11 +217,17 @@ namespace BasisServerHandle
 
                     if (readyMessage.WasDeserializedCorrectly())
                     {
-                        if (RejectIfHeadlessDisallowed(newPeer, readyMessage.playerMetaDataMessage))
+                        if (IsHeadlessDisallowed(readyMessage.playerMetaDataMessage, out string reason))
                         {
+                            RejectWithReason(ConReq, reason);
                             return;
                         }
+                    }
 
+                    NetPeer newPeer = ConReq.Accept();//can do both way Communication from here on
+
+                    if (readyMessage.WasDeserializedCorrectly())
+                    {
                         OnNetworkAccepted(newPeer, readyMessage, readyMessage.playerMetaDataMessage.playerUUID);
                     }
                 }

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/NetworkServer.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/NetworkServer.cs
@@ -62,6 +62,7 @@ public static class NetworkServer
         HighQualityLength = BasisAvatarBitPacking.ConvertToSize(BitQuality.High);
         InitializePulseSettings();
         InitializeAuth();
+        BasisHeadlessConnectionPolicyManager.InitializeFromConfig(configuration.DisallowHeadless);
         SetupServer(configuration);
         SubscribeEvents(Configuration);
 

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/Security/BasisDIDAuthIdentity.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/Security/BasisDIDAuthIdentity.cs
@@ -85,8 +85,9 @@ namespace BasisDidLink
 
                 if (readyMessage.WasDeserializedCorrectly())
                 {
-                    if (BasisServerHandleEvents.RejectIfHeadlessDisallowed(newPeer, readyMessage.playerMetaDataMessage))
+                    if (BasisServerHandleEvents.IsHeadlessDisallowed(readyMessage.playerMetaDataMessage, out string reason))
                     {
+                        BasisServerHandleEvents.RejectWithReason(newPeer, reason);
                         return;
                     }
 

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/Security/BasisDIDAuthIdentity.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/Security/BasisDIDAuthIdentity.cs
@@ -85,6 +85,11 @@ namespace BasisDidLink
 
                 if (readyMessage.WasDeserializedCorrectly())
                 {
+                    if (BasisServerHandleEvents.RejectIfHeadlessDisallowed(newPeer, readyMessage.playerMetaDataMessage))
+                    {
+                        return;
+                    }
+
                     string UUID = readyMessage.playerMetaDataMessage.playerUUID;
                     Did playerDid = new Did(UUID);
                     if (BasisPlayerModeration.IsBanned(UUID))

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/Security/BasisHeadlessConnectionPolicyManager.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/Security/BasisHeadlessConnectionPolicyManager.cs
@@ -1,0 +1,98 @@
+using Basis.Network.Core;
+using Basis.Network.Server.Generic;
+using System;
+using System.Threading;
+using static BasisNetworkCore.Serializable.SerializableBasis;
+namespace BasisNetworkServer.Security
+{
+    /// <summary>
+    /// Runtime-only server policy controlling whether headless clients may stay connected.
+    /// </summary>
+    public static class BasisHeadlessConnectionPolicyManager
+    {
+        public const string DisallowedReason = "Headless client disallowed by server.";
+
+        private static int _headlessDisallowed;
+
+        public static bool HeadlessDisallowed => Interlocked.CompareExchange(ref _headlessDisallowed, 0, 0) == 1;
+
+        public static void InitializeFromConfig(bool disallowHeadless)
+        {
+            Interlocked.Exchange(ref _headlessDisallowed, disallowHeadless ? 1 : 0);
+        }
+
+        public static bool SetDisallowHeadless(bool disallowHeadless)
+        {
+            int requestedValue = disallowHeadless ? 1 : 0;
+            int previousValue = Interlocked.Exchange(ref _headlessDisallowed, requestedValue);
+            return previousValue != requestedValue;
+        }
+
+        public static bool IsHeadlessClient(SerializableBasis.ClientMetaDataMessage metaData)
+        {
+            return IsHeadlessPlatform(metaData.playerPlatform);
+        }
+
+        public static bool IsHeadlessPlatform(string playerPlatform)
+        {
+            if (string.IsNullOrWhiteSpace(playerPlatform))
+            {
+                return false;
+            }
+
+            return string.Equals(playerPlatform, "Headless", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(playerPlatform, "WindowsServer", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(playerPlatform, "LinuxServer", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(playerPlatform, "OSXServer", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static void DisconnectConnectedHeadlessPeers()
+        {
+            NetPeer[] peers = NetworkServer.PeerSnapshot;
+            foreach (NetPeer peer in peers)
+            {
+                if (!BasisSavedState.GetLastPlayerMetaData(peer, out SerializableBasis.ClientMetaDataMessage metaData) ||
+                    !IsHeadlessClient(metaData))
+                {
+                    continue;
+                }
+
+                BasisServerHandle.BasisServerHandleEvents.RejectWithReason(peer, DisallowedReason);
+            }
+        }
+
+        public static void SendStateToPeer(NetPeer peer)
+        {
+            NetDataWriter writer = NetworkServer.RentWriter();
+            try
+            {
+                new AdminRequest().Serialize(writer, AdminRequestMode.GlobalGetHeadlessDisallowState);
+                writer.Put(HeadlessDisallowed);
+                NetworkServer.TrySend(peer, writer, BasisNetworkCommons.AdminChannel, DeliveryMethod.ReliableOrdered);
+            }
+            finally
+            {
+                NetworkServer.ReturnWriter(writer);
+            }
+        }
+
+        public static void BroadcastState()
+        {
+            NetDataWriter writer = NetworkServer.RentWriter();
+            try
+            {
+                new AdminRequest().Serialize(writer, AdminRequestMode.GlobalGetHeadlessDisallowState);
+                writer.Put(HeadlessDisallowed);
+                NetworkServer.BroadcastMessageToClients(
+                    writer,
+                    BasisNetworkCommons.AdminChannel,
+                    NetworkServer.PeerSnapshot,
+                    DeliveryMethod.ReliableOrdered);
+            }
+            finally
+            {
+                NetworkServer.ReturnWriter(writer);
+            }
+        }
+    }
+}

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/Security/BasisPlayerModeration.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/Security/BasisPlayerModeration.cs
@@ -323,7 +323,7 @@ namespace BasisNetworkServer.Security
                     break;
 
                 case AdminRequestMode.SetGlobalHeadlessDisallow:
-                    Require(peer, PermNodes.ModerationKick, () =>
+                    Require(peer, PermNodes.ModerationGlobalLock, () =>
                         HandleHeadlessDisallowSet(peer, reader));
                     break;
 

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/Security/BasisPlayerModeration.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/Security/BasisPlayerModeration.cs
@@ -322,6 +322,11 @@ namespace BasisNetworkServer.Security
                         HandleHeadlessAudioSet(peer, reader));
                     break;
 
+                case AdminRequestMode.SetGlobalHeadlessDisallow:
+                    Require(peer, PermNodes.ModerationKick, () =>
+                        HandleHeadlessDisallowSet(peer, reader));
+                    break;
+
                 // ===== PERMISSION EDIT =====
                 case AdminRequestMode.SetUserGroup:
                 case AdminRequestMode.SetUserNode:
@@ -467,6 +472,32 @@ namespace BasisNetworkServer.Security
             BNL.Log(notification);
             SendBackMessage(peer, notification);
             BasisHeadlessAudioStateManager.BroadcastState();
+        }
+
+        private static void HandleHeadlessDisallowSet(NetPeer peer, NetPacketReader reader)
+        {
+            if (reader.AvailableBytes < 1)
+            {
+                SendBackMessage(peer, "Failed to set headless connection policy: missing state value.");
+                return;
+            }
+
+            bool disallowHeadless = reader.GetBool();
+            bool changed = BasisHeadlessConnectionPolicyManager.SetDisallowHeadless(disallowHeadless);
+            string state = disallowHeadless ? "DISALLOWED" : "ALLOWED";
+            string notification = changed
+                ? $"Headless clients are now {state}."
+                : $"Headless clients were already {state}.";
+
+            BNL.Log(notification);
+            SendBackMessage(peer, notification);
+
+            if (disallowHeadless)
+            {
+                BasisHeadlessConnectionPolicyManager.DisconnectConnectedHeadlessPeers();
+            }
+
+            BasisHeadlessConnectionPolicyManager.BroadcastState();
         }
 
         private static void HandleShoutMode(NetPeer peer, NetPacketReader reader, bool enable)

--- a/Basis/Packages/com.basis.server/Docker/README.md
+++ b/Basis/Packages/com.basis.server/Docker/README.md
@@ -51,6 +51,7 @@ Example snippet from a `config/config.xml` (values here might be defaults before
   <PeerLimit>1024</PeerLimit>
   <SetPort>4296</SetPort>
   <EnableConsole>true</EnableConsole>
+  <DisallowHeadless>false</DisallowHeadless>
   <!-- ... other settings ... -->
 </Configuration>
 ```
@@ -70,6 +71,7 @@ Commonly used environment variables:
 | `Password`           | `default_password`              | Connection password for clients. **Change this!** |
 | `EnableStatistics`   | `true`                          | Enables the statistics module.                    |
 | `EnableConsole`      | `false`                         | Enables the interactive server console (CLI).     |
+| `DisallowHeadless`   | `false`                         | Disconnects connected headless clients and blocks new ones. |
 
 A more comprehensive list of configurable settings can typically be found by inspecting the generated `config/config.xml` after an initial run, or by checking the server's internal documentation if available.
 


### PR DESCRIPTION
## New Features
  * Server option plus Admin UI and admin commands to query/set a global "Disallow headless" policy and broadcast its state.

## Bug Fixes
  * Stronger headless detection and enforcement: rejected headless connections include reason payloads; server can disconnect existing headless peers; headless clients suppress/restart appropriately when disallowed.
  * Improved native audio bindings and adjusted platform plugin metadata for better cross-platform compatibility.