### PR TITLE
fix: update docs.basisvr.org links to correct paths

### DIFF
--- a/Basis/Packages/com.basis.framework.editor/Editor/Project Window/BasisProjectSetup.cs
+++ b/Basis/Packages/com.basis.framework.editor/Editor/Project Window/BasisProjectSetup.cs
@@ -47,9 +47,9 @@ public partial class BasisProjectSetup : EditorWindow
 
     // Links
     private const string BASIS_SITE = "https://basisvr.org/";
-    private const string BASIS_GETTING_STARTED = "https://docs.basisvr.org/docs";
-    private const string BASIS_AVATARS = "https://docs.basisvr.org/docs/avatar";
-    private const string BASIS_WORLDS = "https://docs.basisvr.org/docs/world";
+    private const string BASIS_GETTING_STARTED = "https://docs.basisvr.org";
+    private const string BASIS_AVATARS = "https://docs.basisvr.org/en/docs/avatar";
+    private const string BASIS_WORLDS = "https://docs.basisvr.org/en/docs/world";
     private const string BASIS_DONATE = "https://opencollective.com/basis";
     private const string UNITY_HUB_ADD_MODULES = "https://docs.unity3d.com/hub/manual/AddModules.html";
 

--- a/Basis/Packages/com.basis.sdk/Scripts/Editor/Constants/BasisSDKConstants.cs
+++ b/Basis/Packages/com.basis.sdk/Scripts/Editor/Constants/BasisSDKConstants.cs
@@ -28,7 +28,7 @@ public class BasisSDKConstants
     public static readonly string AvatarDescription = "avatardescriptioninput";
     public static readonly string AvatarIcon = "avataricon";
     public static readonly string Avatarpassword = "avatarpassword";
-    public static readonly string AvatarDocumentationURL = "https://docs.basisvr.org/docs/avatar";
+    public static readonly string AvatarDocumentationURL = "https://docs.basisvr.org/en/docs/avatar";
     public static readonly string AvatarTestInEditor = "TestInEditor";
     public static readonly string AvatarAnimatorControllerPath = "Packages/com.basis.sdk/Animator/BasisLocomotion.controller";
 
@@ -44,7 +44,7 @@ public class BasisSDKConstants
     public static readonly string PropIcon = "propicon";
     public static readonly string PropName = "propnameinput";
     public static readonly string PropDescription = "propdescriptioninput";
-    public static readonly string PropDocumentationURL = "https://docs.basisvr.org/docs/prop";
+    public static readonly string PropDocumentationURL = "https://docs.basisvr.org/en/docs/prop";
     #endregion
 
     #region Scene
@@ -52,7 +52,7 @@ public class BasisSDKConstants
     public static readonly string SceneIcon = "sceneicon";
     public static readonly string SceneName = "scenenameinput";
     public static readonly string SceneDescription = "scenedescriptioninput";
-    public static readonly string SceneDocumentationURL = "https://docs.basisvr.org/docs/scene";
+    public static readonly string SceneDocumentationURL = "https://docs.basisvr.org/en/docs/world";
     public static readonly string SpawnPointField = "spawnpointfield";
     public static readonly string MainCameraField = "maincamerafield";
     public static readonly string AudioMixerGroupField = "audiomixergroupfield";


### PR DESCRIPTION
## Summary
                                                                                                                                                                              
  - Added `/en` prefix to avatar, world, prop, and scene doc URLs                                                                                                             
  - Simplified the getting-started URL to the docs root                                                                                                                       
                                                                                                                                                                              
  ## Test plan                                                                                                                                                                
                                                                                                                                                                              
  - [x] Verify each link opens the correct documentation page in a browser