### PR TITLE
Fix bounds calculation for skinned meshes

### DIFF
--- a/Basis/Packages/com.basis.sdk/Scripts/Editor/SDKInspector/BasisBundleBuild.cs
+++ b/Basis/Packages/com.basis.sdk/Scripts/Editor/SDKInspector/BasisBundleBuild.cs
@@ -66,12 +66,12 @@ public static class BasisBundleBuild
         {
             if (r == null) continue;
 
-            Bounds srcLocal;
+            Bounds transformed;
 
             if (r is SkinnedMeshRenderer smr)
             {
-                // In smr local space
-                srcLocal = smr.localBounds;
+                // Transform bounds center and extents to new AABB in parent local space
+                transformed = TransformBoundsAABB(smr.bounds, parentWorldToLocal);
             }
             else if (r is MeshRenderer mr)
             {
@@ -79,18 +79,16 @@ public static class BasisBundleBuild
                 if (mf == null || mf.sharedMesh == null) continue;
 
                 // In mesh local space (same as MeshFilter transform local space)
-                srcLocal = mf.sharedMesh.bounds;
+                var srcLocal = mf.sharedMesh.bounds;
+                // Map from renderer local -> world -> parent local
+                Matrix4x4 toParentLocal = parentWorldToLocal * r.transform.localToWorldMatrix;
+                // Transform bounds center and extents to new AABB in parent local space
+                transformed = TransformBoundsAABB(srcLocal, toParentLocal);
             }
             else
             {
                 continue; // ignore other renderer types for now
             }
-
-            // Map from renderer local -> world -> parent local
-            Matrix4x4 toParentLocal = parentWorldToLocal * r.transform.localToWorldMatrix;
-
-            // Transform bounds center and extents to new AABB in parent local space
-            Bounds transformed = TransformBoundsAABB(srcLocal, toParentLocal);
 
             if (!hasAny)
             {


### PR DESCRIPTION
resolves #774

basically the old approach assumes that `smr.localBounds` is local to the transform that the smr is attached to, but in reality it's local to `smr.rootBone`. anyway in this PR I decided to just transform the global bounds directly into parent space, this way it's harder to make such mistake, since unity gives you the correct global bounds.