### PR TITLE
docs(localization): fix outdated path in translate-help text

### DIFF
--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/ar.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/ar.json
@@ -279,7 +279,7 @@
     { "key": "settings.general.language.title", "value": "اللغة" },
     { "key": "settings.general.language.description", "value": "أعد فتح القائمة لتطبيق تغيير اللغة." },
     { "key": "settings.general.language.help_translate.title", "value": "الرجاء مساعدتنا في الترجمة!" },
-    { "key": "settings.general.language.help_translate.description", "value": "ملفات اللغة موجودة في StreamingAssets/Basis/Languages. انسخ en.json، وترجم القيم، وأرسل pull request." },
+    { "key": "settings.general.language.help_translate.description", "value": "ملفات اللغة موجودة في Packages/com.basis.framework/BasisUI/Localization/Languages. انسخ en.json، وترجم القيم، وأرسل pull request." },
 
     { "key": "settings.audio.mixer.title", "value": "مازج الصوت" },
     { "key": "settings.audio.mixer.description", "value": "التحكم في مستوى صوت القنوات الفردية." },

--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/bn.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/bn.json
@@ -278,7 +278,7 @@
     { "key": "settings.general.language.title", "value": "ভাষা" },
     { "key": "settings.general.language.description", "value": "ভাষা পরিবর্তন প্রয়োগ করতে মেনুটি পুনরায় খুলুন।" },
     { "key": "settings.general.language.help_translate.title", "value": "অনুগ্রহ করে আমাদের অনুবাদ করতে সাহায্য করুন!" },
-    { "key": "settings.general.language.help_translate.description", "value": "ভাষার ফাইলগুলি StreamingAssets/Basis/Languages এ অবস্থিত। en.json কপি করুন, মানগুলি অনুবাদ করুন, এবং একটি পুল রিকোয়েস্ট জমা দিন।" },
+    { "key": "settings.general.language.help_translate.description", "value": "ভাষার ফাইলগুলি Packages/com.basis.framework/BasisUI/Localization/Languages এ অবস্থিত। en.json কপি করুন, মানগুলি অনুবাদ করুন, এবং একটি পুল রিকোয়েস্ট জমা দিন।" },
 
     { "key": "settings.audio.mixer.title", "value": "ভলিউম মিক্সার" },
     { "key": "settings.audio.mixer.description", "value": "পৃথক চ্যানেল ভলিউম নিয়ন্ত্রণ করুন।" },

--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/de.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/de.json
@@ -279,7 +279,7 @@
     { "key": "settings.general.language.title", "value": "Sprache" },
     { "key": "settings.general.language.description", "value": "Schließe das Menü und öffne es erneut, um die Sprachänderung anzuwenden." },
     { "key": "settings.general.language.help_translate.title", "value": "Bitte hilf uns beim Übersetzen!" },
-    { "key": "settings.general.language.help_translate.description", "value": "Sprachdateien befinden sich in StreamingAssets/Basis/Languages. Kopiere en.json, übersetze die Werte und reiche einen Pull Request ein." },
+    { "key": "settings.general.language.help_translate.description", "value": "Sprachdateien befinden sich in Packages/com.basis.framework/BasisUI/Localization/Languages. Kopiere en.json, übersetze die Werte und reiche einen Pull Request ein." },
 
     { "key": "settings.audio.mixer.title", "value": "Lautstärke-Mixer" },
     { "key": "settings.audio.mixer.description", "value": "Steuert die Lautstärke einzelner Kanäle." },

--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/en.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/en.json
@@ -278,7 +278,7 @@
     { "key": "settings.general.language.title", "value": "Language" },
     { "key": "settings.general.language.description", "value": "Reopen the menu to apply a language change." },
     { "key": "settings.general.language.help_translate.title", "value": "Please help us translate!" },
-    { "key": "settings.general.language.help_translate.description", "value": "Language files are located in StreamingAssets/Basis/Languages. Copy en.json, translate the values, and submit a pull request." },
+    { "key": "settings.general.language.help_translate.description", "value": "Language files live in Packages/com.basis.framework/BasisUI/Localization/Languages. Copy en.json, rename the copy to your locale code (for example fr.json or ja.json), translate the values, and open a pull request at github.com/BasisVR/Basis." },
 
     { "key": "settings.audio.mixer.title", "value": "Volume Mixer" },
     { "key": "settings.audio.mixer.description", "value": "Control individual channel volumes." },

--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/es-MX.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/es-MX.json
@@ -278,7 +278,7 @@
     { "key": "settings.general.language.title", "value": "Idioma" },
     { "key": "settings.general.language.description", "value": "Vuelve a abrir el menú para aplicar el cambio de idioma." },
     { "key": "settings.general.language.help_translate.title", "value": "¡Ayúdanos a traducir!" },
-    { "key": "settings.general.language.help_translate.description", "value": "Los archivos de idioma están en StreamingAssets/Basis/Languages. Copia en.json, traduce los valores y envía un pull request." },
+    { "key": "settings.general.language.help_translate.description", "value": "Los archivos de idioma están en Packages/com.basis.framework/BasisUI/Localization/Languages. Copia en.json, traduce los valores y envía un pull request." },
 
     { "key": "settings.audio.mixer.title", "value": "Mezclador de volumen" },
     { "key": "settings.audio.mixer.description", "value": "Controla los volúmenes de los canales individuales." },

--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/es.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/es.json
@@ -279,7 +279,7 @@
     { "key": "settings.general.language.title", "value": "Idioma" },
     { "key": "settings.general.language.description", "value": "Vuelve a abrir el menú para aplicar el cambio de idioma." },
     { "key": "settings.general.language.help_translate.title", "value": "¡Ayúdanos a traducir!" },
-    { "key": "settings.general.language.help_translate.description", "value": "Los archivos de idioma están en StreamingAssets/Basis/Languages. Copia en.json, traduce los valores y envía un pull request." },
+    { "key": "settings.general.language.help_translate.description", "value": "Los archivos de idioma están en Packages/com.basis.framework/BasisUI/Localization/Languages. Copia en.json, traduce los valores y envía un pull request." },
 
     { "key": "settings.audio.mixer.title", "value": "Mezclador de volumen" },
     { "key": "settings.audio.mixer.description", "value": "Controla los volúmenes de los canales individuales." },

--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/fr.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/fr.json
@@ -279,7 +279,7 @@
     { "key": "settings.general.language.title", "value": "Langue" },
     { "key": "settings.general.language.description", "value": "Rouvrez le menu pour appliquer un changement de langue." },
     { "key": "settings.general.language.help_translate.title", "value": "Aidez-nous à traduire !" },
-    { "key": "settings.general.language.help_translate.description", "value": "Les fichiers de langue se trouvent dans StreamingAssets/Basis/Languages. Copiez en.json, traduisez les valeurs et soumettez une pull request." },
+    { "key": "settings.general.language.help_translate.description", "value": "Les fichiers de langue se trouvent dans Packages/com.basis.framework/BasisUI/Localization/Languages. Copiez en.json, traduisez les valeurs et soumettez une pull request." },
 
     { "key": "settings.audio.mixer.title", "value": "Table de mixage" },
     { "key": "settings.audio.mixer.description", "value": "Contrôle les volumes de chaque canal." },

--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/hi.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/hi.json
@@ -278,7 +278,7 @@
     { "key": "settings.general.language.title", "value": "भाषा" },
     { "key": "settings.general.language.description", "value": "भाषा परिवर्तन लागू करने के लिए मेनू को फिर से खोलें।" },
     { "key": "settings.general.language.help_translate.title", "value": "कृपया अनुवाद करने में हमारी मदद करें!" },
-    { "key": "settings.general.language.help_translate.description", "value": "भाषा फ़ाइलें StreamingAssets/Basis/Languages में स्थित हैं। en.json की कॉपी बनाएँ, मानों का अनुवाद करें, और एक pull request जमा करें।" },
+    { "key": "settings.general.language.help_translate.description", "value": "भाषा फ़ाइलें Packages/com.basis.framework/BasisUI/Localization/Languages में स्थित हैं। en.json की कॉपी बनाएँ, मानों का अनुवाद करें, और एक pull request जमा करें।" },
 
     { "key": "settings.audio.mixer.title", "value": "वॉल्यूम मिक्सर" },
     { "key": "settings.audio.mixer.description", "value": "अलग-अलग चैनलों की वॉल्यूम नियंत्रित करें।" },

--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/it.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/it.json
@@ -279,7 +279,7 @@
     { "key": "settings.general.language.title", "value": "Lingua" },
     { "key": "settings.general.language.description", "value": "Riapri il menu per applicare il cambio di lingua." },
     { "key": "settings.general.language.help_translate.title", "value": "Aiutaci a tradurre!" },
-    { "key": "settings.general.language.help_translate.description", "value": "I file di lingua si trovano in StreamingAssets/Basis/Languages. Copia en.json, traduci i valori e invia una pull request." },
+    { "key": "settings.general.language.help_translate.description", "value": "I file di lingua si trovano in Packages/com.basis.framework/BasisUI/Localization/Languages. Copia en.json, traduci i valori e invia una pull request." },
 
     { "key": "settings.audio.mixer.title", "value": "Mixer volume" },
     { "key": "settings.audio.mixer.description", "value": "Controlla il volume dei singoli canali." },

--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/ja.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/ja.json
@@ -279,7 +279,7 @@
     { "key": "settings.general.language.title", "value": "言語" },
     { "key": "settings.general.language.description", "value": "言語の変更を反映するにはメニューを開き直してください。" },
     { "key": "settings.general.language.help_translate.title", "value": "翻訳にご協力ください！" },
-    { "key": "settings.general.language.help_translate.description", "value": "言語ファイルは StreamingAssets/Basis/Languages にあります。en.json をコピーして値を翻訳し、プルリクエストを送ってください。" },
+    { "key": "settings.general.language.help_translate.description", "value": "言語ファイルは Packages/com.basis.framework/BasisUI/Localization/Languages にあります。en.json をコピーして値を翻訳し、プルリクエストを送ってください。" },
 
     { "key": "settings.audio.mixer.title", "value": "音量ミキサー" },
     { "key": "settings.audio.mixer.description", "value": "各チャンネルの音量を個別に設定。" },

--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/nl.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/nl.json
@@ -1508,7 +1508,7 @@
         },
         {
             "key": "settings.general.language.help_translate.description",
-            "value": "Taalbestanden staan in StreamingAssets/Basis/Languages. Kopieer en.json, vertaal de waarden en stuur een pull request in."
+            "value": "Taalbestanden staan in Packages/com.basis.framework/BasisUI/Localization/Languages. Kopieer en.json, vertaal de waarden en stuur een pull request in."
         },
         {
             "key": "settings.general.limitAudio",

--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/pt.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/pt.json
@@ -279,7 +279,7 @@
     { "key": "settings.general.language.title", "value": "Idioma" },
     { "key": "settings.general.language.description", "value": "Reabra o menu para aplicar uma mudança de idioma." },
     { "key": "settings.general.language.help_translate.title", "value": "Por favor, ajude-nos a traduzir!" },
-    { "key": "settings.general.language.help_translate.description", "value": "Os arquivos de idioma estão localizados em StreamingAssets/Basis/Languages. Copie o en.json, traduza os valores e envie um pull request." },
+    { "key": "settings.general.language.help_translate.description", "value": "Os arquivos de idioma estão localizados em Packages/com.basis.framework/BasisUI/Localization/Languages. Copie o en.json, traduza os valores e envie um pull request." },
 
     { "key": "settings.audio.mixer.title", "value": "Mixer de Volume" },
     { "key": "settings.audio.mixer.description", "value": "Controlar volumes individuais de cada canal." },

--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/ru.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/ru.json
@@ -279,7 +279,7 @@
     { "key": "settings.general.language.title", "value": "Язык" },
     { "key": "settings.general.language.description", "value": "Откройте меню заново, чтобы применить смену языка." },
     { "key": "settings.general.language.help_translate.title", "value": "Помогите нам с переводом!" },
-    { "key": "settings.general.language.help_translate.description", "value": "Языковые файлы находятся в StreamingAssets/Basis/Languages. Скопируйте en.json, переведите значения и отправьте pull request." },
+    { "key": "settings.general.language.help_translate.description", "value": "Языковые файлы находятся в Packages/com.basis.framework/BasisUI/Localization/Languages. Скопируйте en.json, переведите значения и отправьте pull request." },
 
     { "key": "settings.audio.mixer.title", "value": "Микшер громкости" },
     { "key": "settings.audio.mixer.description", "value": "Управление громкостью отдельных каналов." },

--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/ur.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/ur.json
@@ -279,7 +279,7 @@
     { "key": "settings.general.language.title", "value": "زبان" },
     { "key": "settings.general.language.description", "value": "زبان کی تبدیلی کو لاگو کرنے کے لیے مینیو کو دوبارہ کھولیں۔" },
     { "key": "settings.general.language.help_translate.title", "value": "براہ کرم ترجمہ میں ہماری مدد کریں!" },
-    { "key": "settings.general.language.help_translate.description", "value": "زبان کی فائلیں StreamingAssets/Basis/Languages میں موجود ہیں۔ en.json کو کاپی کریں، اقدار کا ترجمہ کریں، اور ایک pull request جمع کروائیں۔" },
+    { "key": "settings.general.language.help_translate.description", "value": "زبان کی فائلیں Packages/com.basis.framework/BasisUI/Localization/Languages میں موجود ہیں۔ en.json کو کاپی کریں، اقدار کا ترجمہ کریں، اور ایک pull request جمع کروائیں۔" },
 
     { "key": "settings.audio.mixer.title", "value": "والیوم مکسر" },
     { "key": "settings.audio.mixer.description", "value": "انفرادی چینل والیوم کنٹرول کریں۔" },

--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/zh-CN.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/zh-CN.json
@@ -279,7 +279,7 @@
     { "key": "settings.general.language.title", "value": "语言" },
     { "key": "settings.general.language.description", "value": "重新打开菜单以应用语言更改。" },
     { "key": "settings.general.language.help_translate.title", "value": "请帮助我们翻译！" },
-    { "key": "settings.general.language.help_translate.description", "value": "语言文件位于 StreamingAssets/Basis/Languages 中。复制 en.json，翻译其中的值，并提交一个 pull request。" },
+    { "key": "settings.general.language.help_translate.description", "value": "语言文件位于 Packages/com.basis.framework/BasisUI/Localization/Languages 中。复制 en.json，翻译其中的值，并提交一个 pull request。" },
 
     { "key": "settings.audio.mixer.title", "value": "音量混合器" },
     { "key": "settings.audio.mixer.description", "value": "控制各通道音量。" },

--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/zh-Hans.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/zh-Hans.json
@@ -279,7 +279,7 @@
     { "key": "settings.general.language.title", "value": "语言" },
     { "key": "settings.general.language.description", "value": "重新打开菜单以应用语言更改。" },
     { "key": "settings.general.language.help_translate.title", "value": "请帮助我们翻译！" },
-    { "key": "settings.general.language.help_translate.description", "value": "语言文件位于 StreamingAssets/Basis/Languages 中。复制 en.json，翻译其中的值，并提交一个 pull request。" },
+    { "key": "settings.general.language.help_translate.description", "value": "语言文件位于 Packages/com.basis.framework/BasisUI/Localization/Languages 中。复制 en.json，翻译其中的值，并提交一个 pull request。" },
 
     { "key": "settings.audio.mixer.title", "value": "音量混合器" },
     { "key": "settings.audio.mixer.description", "value": "控制各通道音量。" },

--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/zh-Hant.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/zh-Hant.json
@@ -279,7 +279,7 @@
     { "key": "settings.general.language.title", "value": "语言" },
     { "key": "settings.general.language.description", "value": "重新打开菜单以应用语言更改。" },
     { "key": "settings.general.language.help_translate.title", "value": "请帮助我们翻译！" },
-    { "key": "settings.general.language.help_translate.description", "value": "语言文件位于 StreamingAssets/Basis/Languages 中。复制 en.json，翻译其中的值，并提交一个 pull request。" },
+    { "key": "settings.general.language.help_translate.description", "value": "语言文件位于 Packages/com.basis.framework/BasisUI/Localization/Languages 中。复制 en.json，翻译其中的值，并提交一个 pull request。" },
 
     { "key": "settings.audio.mixer.title", "value": "音量混音器" },
     { "key": "settings.audio.mixer.description", "value": "控制各通道的音量。" },

--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/zh.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/zh.json
@@ -279,7 +279,7 @@
     { "key": "settings.general.language.title", "value": "语言" },
     { "key": "settings.general.language.description", "value": "重新打开菜单以应用语言更改。" },
     { "key": "settings.general.language.help_translate.title", "value": "请帮助我们翻译！" },
-    { "key": "settings.general.language.help_translate.description", "value": "语言文件位于 StreamingAssets/Basis/Languages 中。复制 en.json，翻译其中的值，并提交一个 pull request。" },
+    { "key": "settings.general.language.help_translate.description", "value": "语言文件位于 Packages/com.basis.framework/BasisUI/Localization/Languages 中。复制 en.json，翻译其中的值，并提交一个 pull request。" },
 
     { "key": "settings.audio.mixer.title", "value": "音量混音器" },
     { "key": "settings.audio.mixer.description", "value": "控制各通道的音量。" },


### PR DESCRIPTION
## What
The **Please help us translate!** panel in *General Settings* (rendered by `SettingsProvider.BuildLanguageSelector` in `Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProvider.cs`) was telling contributors to look in `StreamingAssets/Basis/Languages`. That folder no longer exists — the language files moved into the framework package and are now loaded via Addressables.

## Changes
- **All 18 locale JSONs** — replace the literal path `StreamingAssets/Basis/Languages` with `Packages/com.basis.framework/BasisUI/Localization/Languages`. The path was left untranslated in every locale, so swapping just the substring keeps each existing translation intact.
- **`en.json`** — additionally rewrite the description with clearer steps: rename the copy to your locale code (e.g. `fr.json` / `ja.json`) and open the PR at `github.com/BasisVR/Basis`.

## What I did NOT change
- Localization keys are unchanged, so `SettingsProvider.cs` needs no edit.
- The title (`"Please help us translate!"` / equivalents) is unchanged in every language to avoid pointless retranslation churn.

## Follow-ups for whoever merges
- The Languages addressable group probably needs a rebuild so the updated text ships in built players. Editor playmode picks it up directly from the package.
- The 17 non-English description strings are now slightly out of sync with English (they don't yet mention the locale-code rename or the GitHub URL). That's a translator-friendly nudge, not a blocker — the path is correct and the original instruction still works.