### PR TITLE
feat(shim): whitelist Graphics + AsyncGPUReadback for video-driven props

### DIFF
--- a/Basis/Packages/com.basis.shim/Shims/CilboxPropBasis.cs
+++ b/Basis/Packages/com.basis.shim/Shims/CilboxPropBasis.cs
@@ -239,8 +239,11 @@ namespace Cilbox
 			"UnityEngine.LineAlignment",
 			"UnityEngine.LineRenderer",
 			"UnityEngine.LineTextureMode",
+			"UnityEngine.Graphics",
 			"UnityEngine.Renderer",
 			"UnityEngine.Rendering.AmbientMode",
+			"UnityEngine.Rendering.AsyncGPUReadback",
+			"UnityEngine.Rendering.AsyncGPUReadbackRequest",
 			"UnityEngine.Rendering.IndexFormat",
 			"UnityEngine.Rendering.LightProbeUsage",
 			"UnityEngine.Rendering.OpaqueSortMode",
@@ -271,6 +274,8 @@ namespace Cilbox
 			"UnityEngine.TextureWrapMode",
 			"UnityEngine.FilterMode",
 			"UnityEngine.TrailRenderer",
+
+			"Unity.Collections.NativeArray*",
 
 			// Unity types - lighting
 			"UnityEngine.Light",
@@ -484,6 +489,8 @@ namespace Cilbox
 				typeof(GameObject).GetProperty(nameof(GameObject.activeInHierarchy)).GetGetMethod().Name,
 				typeof(GameObject).GetProperty(nameof(GameObject.layer)).GetGetMethod().Name,
 				} },
+			{ typeof(UnityEngine.Graphics), new HashSet<string>{ "Blit" } },
+			{ typeof(UnityEngine.Rendering.AsyncGPUReadback), new HashSet<string>{ "Request" } },
 			{ typeof(Buffer), new HashSet<string>{ "BlockCopy" } },
 			{ typeof(BitConverter), new HashSet<string>{
 				"GetBytes", "ToBoolean", "ToChar", "ToDouble", "ToInt16", "ToInt32",


### PR DESCRIPTION
## Summary
Adds 4 type entries to `CilboxPropBasis.whiteListType` plus narrow method restrictions, enabling props that sample a `RenderTexture` and push the result via `Shader.SetGlobal*` — e.g. a video-driven area light reading the playing frame each tick.

## Changes
- Whitelist `UnityEngine.Graphics`, restricted to `Blit` only
- Whitelist `UnityEngine.Rendering.AsyncGPUReadback`, restricted to `Request` only
- Whitelist `UnityEngine.Rendering.AsyncGPUReadbackRequest` (struct — `done` and `hasError` getters, `GetData<T>()`)
- Whitelist `Unity.Collections.NativeArray*` (return of `GetData<T>()`, indexer + `Length`)

## Motivation
VideoAreaLight (https://github.com/towneh/VideoAreaLight) turns a `VideoPlayer`'s render texture into a rectangular area light. Its broadcaster `LateUpdate` does:

1. `Graphics.Blit` the source RT into a 4×4 averaging RT
2. `AsyncGPUReadback.Request` (polling overload — no callback delegate) to read the average back to CPU
3. `Shader.SetGlobal*` (already allowed) to push corners / colour / cookie to shared `_VAL_*` uniforms

Restricting to `Blit` / `Request` keeps the rest of `Graphics` (DrawProcedural, CopyBuffer, ClearRandomWriteTargets, …) and the rest of `AsyncGPUReadback` out of the prop sandbox.