### PR TITLE
chore(deps): bump com.llealloo.audiolink 3.0.0 → 3.1.2

### DIFF
--- a/Basis/Packages/manifest.json
+++ b/Basis/Packages/manifest.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "com.llealloo.audiolink": "https://github.com/llealloo/audiolink.git?path=Packages/com.llealloo.audiolink#3.0.0",
+    "com.llealloo.audiolink": "https://github.com/llealloo/audiolink.git?path=Packages/com.llealloo.audiolink#3.1.2",
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.addressables": "2.9.1",
     "com.unity.animation.rigging": "1.4.1",


### PR DESCRIPTION
Bumps `com.llealloo.audiolink` from `3.0.0` (2025-11-24, commit `d0beb87`) to `3.1.2` (2026-02-15, commit `5bd23af`). Rolls up `3.1.0` + `3.1.1` + `3.1.2` (no `3.0.x` patches exist).

Currently pulls directly from https://github.com/llealloo/audiolink/tree/3.0.0

## Highlights

- **3.1.0** — first-class URP support, ffmpeg transcoding for ytdlpPlayer, theme-color support on `AudioReactiveLight`, custom AudioSource curves, AudioReactive editor GUI, new C# / shader helpers.
- **3.1.1** — fixes the long project-load times introduced in 3.1.0; OpenGL core fixes (`AudioLinkIsAvailable()`, controller Z-fighting).
- **3.1.2** — `AudioLinkEnabled` toggle on the `AudioLink` script; silent Amplify pipeline-conversion; Custom YTDL / ffmpeg location config now respected.

## ⚠️ Breaking change in 3.1.0

Field renames + type changes across `AudioReactiveLight`, `AudioReactiveObject`, `AudioReactiveSurface`, `AudioReactiveSurfaceArray`, `AudioReactiveBlendShape`. Bundled Basis content doesn't use these scripts; downstream avatars/worlds that do will need to re-bind serialized fields.