### PR TITLE
feat: prepare ability to bundle additional assets in avatar

### DIFF
--- a/Basis/Packages/com.basis.bundlemanagement/BasisLoadhandler.cs
+++ b/Basis/Packages/com.basis.bundlemanagement/BasisLoadhandler.cs
@@ -90,6 +90,59 @@ public static class BasisLoadHandler
             }
         }
     }
+
+    public static async Task<UnityEngine.Object> LoadAdditionalAssetInAlreadyLoadedBundle(
+        BasisLoadableBundle loadableBundle,
+        string assetPath,
+        bool includeSubAssets)
+    {
+        BasisDebug.Log($"Loading additional asset {assetPath} in already loaded bundle {loadableBundle.BasisRemoteBundleEncrypted.RemoteBeeFileLocation}", BasisDebug.LogTag.Networking);
+
+        if (LoadedBundles.TryGetValue(loadableBundle.BasisRemoteBundleEncrypted.RemoteBeeFileLocation, out BasisTrackedBundleWrapper wrapper))
+        {
+            if (wrapper.AssetBundle == null)
+            {
+                BasisDebug.LogError($"{nameof(LoadAdditionalAssetInAlreadyLoadedBundle)} was called, but the wrapper was not already loaded. It is expected that calls to this method are only made while a bundle is still being used.");
+                return null;
+            }
+
+            AssetBundleRequest Request = includeSubAssets
+                ? wrapper.AssetBundle.LoadAssetWithSubAssetsAsync<UnityEngine.Object>(assetPath)
+                : wrapper.AssetBundle.LoadAssetAsync<UnityEngine.Object>(assetPath);
+            await Request;
+
+            UnityEngine.Object result = Request.asset;
+            if (result == null)
+            {
+                BasisDebug.LogError("The additional asset returned null.");
+                return null;
+            }
+            if (result is GameObject or Transform or Component)
+            {
+                BasisDebug.LogError($"{nameof(LoadAdditionalAssetInAlreadyLoadedBundle)} was called, but an object of type {result.GetType().Name} was present instead. This is not allowed.");
+                return null;
+            }
+
+            if (result is BasisObjectReferenceContainer container)
+            {
+                if (container.references == null || container.references.Length == 0)
+                {
+                    BasisDebug.LogError($"{nameof(LoadAdditionalAssetInAlreadyLoadedBundle)} was called, but the object returned by the bundle was a container with no references.");
+                    return null;
+                }
+
+                return container.references[0];
+            }
+
+            return result;
+        }
+        else
+        {
+            BasisDebug.LogError($"{nameof(LoadAdditionalAssetInAlreadyLoadedBundle)} was called, but the bundle was not already loaded. It is expected that calls to this method are only made while a bundle is still being used.");
+            return null;
+        }
+    }
+
     public static async Task<GameObject> LoadGameObjectBundle(GameObject DisabledGameobject,BasisLoadableBundle loadableBundle, bool useContentRemoval, BasisProgressReport report, CancellationToken cancellationToken, Vector3 Position, Quaternion Rotation, Vector3 Scale, bool ModifyScale, Selector Selector, Transform Parent = null, bool DestroyColliders = false,bool ChangeColidersToCorrectLayer = false, long MaxDownloadSizeInMB = 4L * 1024 * 1024 * 1024, List<BasisHeadChop.HeadChopTarget> HarvestedHeadChop = null)
     {
         await EnsureInitializationComplete();

--- a/Basis/Packages/com.basis.sdk/Scripts/Basis Components/BasisAvatar.cs
+++ b/Basis/Packages/com.basis.sdk/Scripts/Basis Components/BasisAvatar.cs
@@ -184,6 +184,12 @@ namespace Basis.Scripts.BasisSdk
         public BasisProcessingAvatarOptions ProcessingAvatarOptions;
 
         /// <summary>
+        /// Contains information used by the bundle build process. The information contained inside this is processed
+        /// and then altered right when the bundle is built.
+        /// </summary>
+        public BasisBundleAdditionalAssets BundleAdditionalAssets;
+
+        /// <summary>
         /// the animators humanScale, Cached here to stop requesting it from the animator per frame.
         /// </summary>
 

--- a/Basis/Packages/com.basis.sdk/Scripts/BasisObjectReferenceContainer.cs
+++ b/Basis/Packages/com.basis.sdk/Scripts/BasisObjectReferenceContainer.cs
@@ -1,0 +1,10 @@
+﻿using UnityEngine;
+
+namespace Basis.Scripts.BasisSdk
+{
+    [System.Serializable]
+    public class BasisObjectReferenceContainer : ScriptableObject
+    {
+        public Object[] references;
+    }
+}

--- a/Basis/Packages/com.basis.sdk/Scripts/BasisObjectReferenceContainer.cs.meta
+++ b/Basis/Packages/com.basis.sdk/Scripts/BasisObjectReferenceContainer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 67c81cb92a2242049a3672e673cd5c60
+timeCreated: 1777901993

--- a/Basis/Packages/com.basis.sdk/Scripts/BasisProcessingAvatarOptions.cs
+++ b/Basis/Packages/com.basis.sdk/Scripts/BasisProcessingAvatarOptions.cs
@@ -1,3 +1,5 @@
+using UnityEngine;
+
 namespace Basis.Scripts.BasisSdk
 {
     [System.Serializable]
@@ -15,5 +17,23 @@ namespace Basis.Scripts.BasisSdk
         /// when on the blendshape indexes break and need reconstruction from callback.
         /// </summary>
       // disabled does work just not for all avatars  public bool RemoveUnusedBlendshapes = false;
+    }
+
+    [System.Serializable]
+    public class BasisBundleAdditionalAssets
+    {
+        public BasisBundleAdditionalAsset[] deferredAssets;
+    }
+
+    [System.Serializable]
+    public class BasisBundleAdditionalAsset
+    {
+        // Defined by user scripts, during the build.
+        public string key;
+        public Object asset;
+
+        // Defined by Basis, in the bundle builder.
+        public int indexInBundle;
+        public string assetPath;
     }
 }

--- a/Basis/Packages/com.basis.sdk/Scripts/Editor/AssetBundleBuilder/BasisAssetBundlePipeline.cs
+++ b/Basis/Packages/com.basis.sdk/Scripts/Editor/AssetBundleBuilder/BasisAssetBundlePipeline.cs
@@ -64,6 +64,7 @@ public static class BasisAssetBundlePipeline
 
         try
         {
+            List<string> additionalAssetPaths = new List<string>();
             if (isScene)
             {
                 if (settings.RebakeOcclusionCulling)
@@ -88,6 +89,30 @@ public static class BasisAssetBundlePipeline
                 OnBeforeBuildPrefab?.Invoke(prefab, settings);
                 PostProcessAvatar(prefab);
 
+                // This is not part of post-processing, because we don't want this running during Test In Editor.
+                if (prefab.TryGetComponent<BasisAvatar>(out BasisAvatar avatar))
+                {
+                    // Not null, PostProcessAvatar ensures that.
+                    for (var indexInArray = 0; indexInArray < avatar.BundleAdditionalAssets.deferredAssets.Length; indexInArray++)
+                    {
+                        var indexInBundle = 1 + indexInArray;
+
+                        var forAvatar = avatar.BundleAdditionalAssets.deferredAssets[indexInArray];
+                        if (forAvatar.asset == null) throw new InvalidOperationException("Cannot bundle null additional assets.");
+                        if (forAvatar.asset is GameObject or Transform or Component) throw new InvalidOperationException("Cannot bundle GameObjects, Transforms, or Components as additional assets.");
+
+                        // We cannot just use AssetDatabase.AddObjectToAsset because the asset path of a Mesh is very often the path of the .fbx, which is a GameObject.
+                        // We're using SaveAssetToTemporaryStorage to create a container that references the asset.
+                        var additionalAssetPath = TemporaryStorageHandler.SaveAssetToTemporaryStorage(forAvatar.asset, settings, out _);
+                        additionalAssetPaths.Add(additionalAssetPath);
+
+                        // Dereference it so that it doesn't get bundled into main.
+                        forAvatar.asset = null;
+                        forAvatar.indexInBundle = indexInBundle;
+                        forAvatar.assetPath = additionalAssetPath;
+                    }
+                }
+
                 assetPath = TemporaryStorageHandler.SavePrefabToTemporaryStorage(prefab, settings, ref wasModified, out uniqueID);
 
                 if (prefab != null)
@@ -99,7 +124,7 @@ public static class BasisAssetBundlePipeline
             AssetBundleBuild Build = new AssetBundleBuild()
             {
                 assetBundleName = uniqueID,
-                assetNames = new string[] { assetPath }
+                assetNames = new[] { assetPath }.Concat(additionalAssetPaths).ToArray()
             };
 
             AssetBundleBuild[] Builds = new AssetBundleBuild[] { Build };
@@ -174,6 +199,18 @@ public static class BasisAssetBundlePipeline
 
             // We do not want to keep this data at runtime.
             avatar.ProcessingAvatarOptions = null;
+
+            if (avatar.BundleAdditionalAssets == null)
+            {
+                avatar.BundleAdditionalAssets = new BasisBundleAdditionalAssets
+                {
+                    deferredAssets = Array.Empty<BasisBundleAdditionalAsset>()
+                };
+            }
+            else if (avatar.BundleAdditionalAssets.deferredAssets == null)
+            {
+                avatar.BundleAdditionalAssets.deferredAssets = Array.Empty<BasisBundleAdditionalAsset>();
+            }
         }
     }
 

--- a/Basis/Packages/com.basis.sdk/Scripts/Editor/AssetBundleBuilder/BasisTemporaryStorageHandler.cs
+++ b/Basis/Packages/com.basis.sdk/Scripts/Editor/AssetBundleBuilder/BasisTemporaryStorageHandler.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using Basis.Scripts.BasisSdk;
 using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine;
@@ -13,6 +14,20 @@ public static class TemporaryStorageHandler
         prefab = PrefabUtility.SaveAsPrefabAsset(prefab, prefabPath);
         wasModified = true;
         return prefabPath;
+    }
+    public static string SaveAssetToTemporaryStorage(Object asset, BasisAssetBundleObject settings, out string uniqueID)
+    {
+        if (asset is GameObject or Transform or Component) throw new InvalidDataException("Cannot save asset of type GameObject, Transform or Component.");
+
+        EnsureDirectoryExists(settings.TemporaryStorage);
+        uniqueID = BasisGenerateUniqueID.GenerateUniqueID();
+        string assetPath = Path.Combine(settings.TemporaryStorage, $"{uniqueID}.asset");
+        BasisObjectReferenceContainer referenceContainer = ScriptableObject.CreateInstance<BasisObjectReferenceContainer>();
+        referenceContainer.references = new[] { asset };
+
+        AssetDatabase.CreateAsset(referenceContainer, assetPath);
+
+        return assetPath;
     }
     public static string SaveScene(Scene sceneToCopy, BasisAssetBundleObject settings, out string uniqueID)
     {


### PR DESCRIPTION
## Summary

Some users often create avatars that have GameObjects or Components turned OFF by default, only to be turned ON later during a session using a toggle; some days it may not even become ON. This raises the question, should assets contained inside those GameObjects or Components be loaded later, rather than loaded at the same time as the avatar?

This PR lays some preliminary work to figure out if this question is worth pursuing. This adds the ability to append additional assets to BasisAvatar bundles, and exposes a method for consumers to load them.

A new field in BasisAvatar can now define additional assets to be added to the avatar during the build:
- When an avatar is being processed to be built or tested, the BundleAdditionalAssets field may contain a list of (key + asset) pairs. This list is meant to be filled by external avatar processing scripts during the build process, and is otherwise empty or undefined otherwise. The asset is not a GameObject, Transform, or Component; they are probably going to be Mesh, Material, or Texture2D assets.
- When that avatar is done processing and a bundle build is about to start, we create as many ScriptableObject containing a reference to each asset, and persist them in a temporary directory.
  - We are using a ScriptableObject to store a reference to the asset, because Mesh assets located inside .FBX files have the .FBX as the asset path, which is the GameObject of the FBX prefab, so AssetDatabase.GetAssetPath cannot be used directly.
- The asset reference is removed from the BundleAdditionalAssets field, and the asset path to that ScriptableObject is put in its place instead.
- The list of asset paths to those ScriptableObject is appended to the list of assets inside the bundle, and then the bundle is built.

A method is also provided to load it. No consumer of that method is provided in this PR, but it has been tested using the following code:

```csharp
if (!TryFindKey(avatar.BundleAdditionalAssets, meshAssetKey, out var deferredMesh))
{
    BasisDebug.LogError($"Deferred asset for mesh {meshAssetKey} not found, late loading will not continue.");
    return;
}

var assetMesh = deferredMesh.asset != null
    ? deferredMesh.asset // For use in "Test in Editor"
    : (await BasisLoadHandler.LoadAdditionalAssetInAlreadyLoadedBundle(player.AvatarMetaData, deferredMesh.assetPath, false));
if (assetMesh is not Mesh mesh)
{
    BasisDebug.LogError("Deferred asset is not a mesh, late loading will not continue.");
    return;
}
```

Demonstration on an uploaded .BEE file (the *HVR Late Loading* component is for demonstration purposes, and is not part of this PR):

https://github.com/user-attachments/assets/7e66e783-3602-4d10-85ae-b4f160944041


## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
- [x] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [x] Windows
- [ ] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [ ] Tested in VR (note headset under **Notes**)
- [ ] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [X] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [x] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [ ] N/A — change does not touch any of the above

## Notes
<!-- Optional context for reviewers. Headset model, why a required box is N/A, anything else worth knowing. -->
