### PR TITLE
fix: re-add cilbox build hook

### DIFF
--- a/Basis/Packages/com.basis.shim/Shims/BasisCilboxBuildHook.cs
+++ b/Basis/Packages/com.basis.shim/Shims/BasisCilboxBuildHook.cs
@@ -1,0 +1,359 @@
+#if UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Basis.Scripts.BasisSdk;
+using Cilbox;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+public class BasisCilboxBuildHook
+{
+    [InitializeOnLoadMethod]
+    private static void Initialize()
+    {
+        //Debug.Log("BasisCilboxBuildHook initialized.");
+        BasisAssetBundlePipeline.OnBeforeBuildPrefab -= HandleBeforeBuildPrefab;
+        BasisAssetBundlePipeline.OnBeforeBuildPrefab += HandleBeforeBuildPrefab;
+        BasisAvatarSDKInspector.OnBeforeTestInEditor -= HandleBeforeTestInEditor;
+        BasisAvatarSDKInspector.OnBeforeTestInEditor += HandleBeforeTestInEditor;
+    }
+
+    private static void HandleBeforeTestInEditor(GameObject prefabRoot)
+    {
+        HandleBeforeBuildPrefab(prefabRoot, null);
+    }
+
+    private static void HandleBeforeBuildPrefab(GameObject prefabRoot, BasisAssetBundleObject settings)
+    {
+        if (prefabRoot == null || !HasCilboxableComponents(prefabRoot))
+        {
+            return;
+        }
+
+        Debug.Log("Basis build prehook: generating Cilbox assembly data on the isolated build clone.");
+        Scene originalScene = prefabRoot.scene;
+        Transform originalParent = prefabRoot.transform.parent;
+        int originalSiblingIndex = originalParent != null ? prefabRoot.transform.GetSiblingIndex() : -1;
+        Dictionary<EntityId, string> cilboxAssemblySnapshot = CaptureCilboxAssemblySnapshot();
+        List<GameObject> temporarilyDisabledRoots = new List<GameObject>();
+        Scene temporaryScene = default;
+        Cilbox.Cilbox temporarySceneCilbox = null;
+        GameObject temporaryCilboxHost = null;
+        bool detachedFromParent = false;
+        try
+        {
+            temporaryScene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Additive);
+            if (originalParent != null)
+            {
+                prefabRoot.transform.SetParent(null, true);
+                detachedFromParent = true;
+            }
+
+            SceneManager.MoveGameObjectToScene(prefabRoot, temporaryScene);
+            SceneManager.SetActiveScene(temporaryScene);
+
+            DeactivateOtherSceneRoots(temporaryScene, temporarilyDisabledRoots);
+
+            temporarySceneCilbox = FindCilboxInScene(temporaryScene);
+            if (temporarySceneCilbox == null)
+            {
+                Type fallbackCilboxType = GetFirstLoadedCilboxType();
+                if (fallbackCilboxType != null)
+                {
+                    temporaryCilboxHost = new GameObject("BasisCilboxTempHost");
+                    SceneManager.MoveGameObjectToScene(temporaryCilboxHost, temporaryScene);
+                    temporarySceneCilbox = temporaryCilboxHost.AddComponent(fallbackCilboxType) as Cilbox.Cilbox;
+                    if (temporarySceneCilbox != null)
+                    {
+                        temporarySceneCilbox.exportDebuggingData = false;
+                    }
+                }
+            }
+
+            if (temporarySceneCilbox == null)
+            {
+                Debug.LogWarning("Basis build detected Cilboxable scripts, but no Cilbox component was found. Skipping Cilbox prebuild assembly.");
+                return;
+            }
+
+            CilboxScenePostprocessor.OnPostprocessScene(temporaryScene);
+            EnsureTemporarySceneHasAssemblyData(temporarySceneCilbox, cilboxAssemblySnapshot);
+            RebindProxiesToTemporarySceneCilbox(prefabRoot, temporarySceneCilbox);
+            RestoreExternalCilboxAssemblyData(cilboxAssemblySnapshot, temporaryScene);
+        }
+        finally
+        {
+            RestoreDisabledRoots(temporarilyDisabledRoots);
+
+            if (originalScene.IsValid() && originalScene.isLoaded && prefabRoot != null && prefabRoot.scene.IsValid() && prefabRoot.scene == temporaryScene)
+            {
+                SceneManager.MoveGameObjectToScene(prefabRoot, originalScene);
+            }
+
+            if (detachedFromParent && prefabRoot != null && originalParent != null && prefabRoot.scene.IsValid() && prefabRoot.scene == originalScene)
+            {
+                prefabRoot.transform.SetParent(originalParent, true);
+                int siblingIndex = Mathf.Clamp(originalSiblingIndex, 0, originalParent.childCount - 1);
+                prefabRoot.transform.SetSiblingIndex(siblingIndex);
+            }
+
+            if (temporaryCilboxHost != null)
+            {
+                UnityEngine.Object.DestroyImmediate(temporaryCilboxHost);
+            }
+
+            if (temporaryScene.IsValid() && temporaryScene.isLoaded && (prefabRoot == null || prefabRoot.scene != temporaryScene))
+            {
+                EditorSceneManager.CloseScene(temporaryScene, true);
+            }
+
+            if (originalScene.IsValid() && originalScene.isLoaded)
+            {
+                SceneManager.SetActiveScene(originalScene);
+            }
+        }
+    }
+
+    private static void CleanupStaleCilboxHelpers()
+    {
+        GameObject[] allObjects = Resources.FindObjectsOfTypeAll<GameObject>();
+        int length = allObjects.Length;
+        for (int i = 0; i < length; i++)
+        {
+            GameObject go = allObjects[i];
+            if (go == null)
+            {
+                continue;
+            }
+
+            if (!go.scene.IsValid() || !go.scene.isLoaded)
+            {
+                continue;
+            }
+
+            if (go.name == "CilboxDirtier" || go.name.StartsWith("CilboxAsm "))
+            {
+                UnityEngine.Object.DestroyImmediate(go);
+            }
+        }
+    }
+
+    private static bool HasCilboxableComponents(GameObject root)
+    {
+        if (root == null)
+        {
+            return false;
+        }
+
+        MonoBehaviour[] components = root.GetComponentsInChildren<MonoBehaviour>(true);
+        int length = components.Length;
+        for (int i = 0; i < length; i++)
+        {
+            MonoBehaviour component = components[i];
+            if (component == null)
+            {
+                continue;
+            }
+
+            object[] attributes = component.GetType().GetCustomAttributes(typeof(CilboxableAttribute), true);
+            if (attributes != null && attributes.Length > 0)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Dictionary<EntityId, string> CaptureCilboxAssemblySnapshot()
+    {
+        Dictionary<EntityId, string> snapshot = new Dictionary<EntityId, string>();
+        Cilbox.Cilbox[] allCilboxes = Resources.FindObjectsOfTypeAll<Cilbox.Cilbox>();
+        int length = allCilboxes.Length;
+        for (int i = 0; i < length; i++)
+        {
+            Cilbox.Cilbox cilbox = allCilboxes[i];
+            if (cilbox == null)
+            {
+                continue;
+            }
+
+            snapshot[cilbox.GetEntityId()] = cilbox.assemblyData;
+        }
+
+        return snapshot;
+    }
+
+    private static void DeactivateOtherSceneRoots(Scene keepScene, List<GameObject> disabledRoots)
+    {
+        int sceneCount = SceneManager.sceneCount;
+        for (int sceneIndex = 0; sceneIndex < sceneCount; sceneIndex++)
+        {
+            Scene scene = SceneManager.GetSceneAt(sceneIndex);
+            if (!scene.IsValid() || !scene.isLoaded || scene == keepScene)
+            {
+                continue;
+            }
+
+            GameObject[] roots = scene.GetRootGameObjects();
+            int rootLength = roots.Length;
+            for (int rootIndex = 0; rootIndex < rootLength; rootIndex++)
+            {
+                GameObject root = roots[rootIndex];
+                if (root == null || !root.activeSelf)
+                {
+                    continue;
+                }
+
+                root.SetActive(false);
+                disabledRoots.Add(root);
+            }
+        }
+    }
+
+    private static void RestoreDisabledRoots(List<GameObject> disabledRoots)
+    {
+        int length = disabledRoots.Count;
+        for (int i = 0; i < length; i++)
+        {
+            GameObject root = disabledRoots[i];
+            if (root != null)
+            {
+                root.SetActive(true);
+            }
+        }
+    }
+
+    private static Cilbox.Cilbox FindCilboxInScene(Scene scene)
+    {
+        if (!scene.IsValid() || !scene.isLoaded)
+        {
+            return null;
+        }
+
+        GameObject[] roots = scene.GetRootGameObjects();
+        int length = roots.Length;
+        for (int i = 0; i < length; i++)
+        {
+            GameObject root = roots[i];
+            if (root == null)
+            {
+                continue;
+            }
+
+            Cilbox.Cilbox cilbox = root.GetComponentInChildren<Cilbox.Cilbox>(true);
+            if (cilbox != null)
+            {
+                return cilbox;
+            }
+        }
+
+        return null;
+    }
+
+    private static Type GetFirstLoadedCilboxType()
+    {
+        Cilbox.Cilbox[] allCilboxes = Resources.FindObjectsOfTypeAll<Cilbox.Cilbox>();
+        int length = allCilboxes.Length;
+        for (int i = 0; i < length; i++)
+        {
+            Cilbox.Cilbox cilbox = allCilboxes[i];
+            if (cilbox != null)
+            {
+                return cilbox.GetType();
+            }
+        }
+
+        return null;
+    }
+
+    private static void EnsureTemporarySceneHasAssemblyData(Cilbox.Cilbox temporarySceneCilbox, Dictionary<EntityId, string> snapshot)
+    {
+        if (temporarySceneCilbox == null)
+        {
+            return;
+        }
+
+        if (!string.IsNullOrEmpty(temporarySceneCilbox.assemblyData))
+        {
+            return;
+        }
+
+        Cilbox.Cilbox[] allCilboxes = Resources.FindObjectsOfTypeAll<Cilbox.Cilbox>();
+        int length = allCilboxes.Length;
+        for (int i = 0; i < length; i++)
+        {
+            Cilbox.Cilbox cilbox = allCilboxes[i];
+            if (cilbox == null || cilbox == temporarySceneCilbox || string.IsNullOrEmpty(cilbox.assemblyData))
+            {
+                continue;
+            }
+
+            EntityId id = cilbox.GetEntityId();
+            if (snapshot.TryGetValue(id, out string original) && original == cilbox.assemblyData)
+            {
+                continue;
+            }
+
+            temporarySceneCilbox.assemblyData = cilbox.assemblyData;
+            temporarySceneCilbox.ForceReinit();
+            EditorUtility.SetDirty(temporarySceneCilbox);
+            return;
+        }
+    }
+
+    private static void RebindProxiesToTemporarySceneCilbox(GameObject contentRoot, Cilbox.Cilbox temporarySceneCilbox)
+    {
+        if (contentRoot == null || temporarySceneCilbox == null)
+        {
+            return;
+        }
+
+        CilboxProxy[] proxies = contentRoot.GetComponentsInChildren<CilboxProxy>(true);
+        int length = proxies.Length;
+        for (int i = 0; i < length; i++)
+        {
+            CilboxProxy proxy = proxies[i];
+            if (proxy == null || proxy.box == temporarySceneCilbox)
+            {
+                continue;
+            }
+
+            proxy.box = temporarySceneCilbox;
+            EditorUtility.SetDirty(proxy);
+        }
+    }
+
+    private static void RestoreExternalCilboxAssemblyData(Dictionary<EntityId, string> snapshot, Scene keepScene)
+    {
+        Cilbox.Cilbox[] allCilboxes = Resources.FindObjectsOfTypeAll<Cilbox.Cilbox>();
+        int length = allCilboxes.Length;
+        for (int i = 0; i < length; i++)
+        {
+            Cilbox.Cilbox cilbox = allCilboxes[i];
+            if (cilbox == null || !cilbox.gameObject.scene.IsValid() || cilbox.gameObject.scene == keepScene)
+            {
+                continue;
+            }
+
+            EntityId id = cilbox.GetEntityId();
+            if (!snapshot.TryGetValue(id, out string originalAssemblyData))
+            {
+                continue;
+            }
+
+            if (cilbox.assemblyData == originalAssemblyData)
+            {
+                continue;
+            }
+
+            cilbox.assemblyData = originalAssemblyData;
+            cilbox.ForceReinit();
+            EditorUtility.SetDirty(cilbox);
+        }
+    }
+
+}
+#endif


### PR DESCRIPTION
## Summary
re add cilbox buildhook that was removed from #795

## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
- [x] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [x] Windows
- [ ] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [ ] Tested in VR (note headset under **Notes**)
- [ ] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [x] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [x] N/A — change does not touch any of the above

## Notes
N/A
