### PR TITLE
Basisosc with vixxy support

### DIFF
--- a/Basis/Packages/com.basis.eventdriver/BasisEventDriver.asmdef
+++ b/Basis/Packages/com.basis.eventdriver/BasisEventDriver.asmdef
@@ -8,7 +8,8 @@
         "com.gator-dragon-games.jigglephysics",
         "SteamAudioUnity",
         "Basis.OpenLipSync.Runtime",
-        "BasisProfiler"
+        "BasisProfiler",
+        "HVR.Basis.Comms"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Basis/Packages/com.basis.eventdriver/BasisEventDriver.cs
+++ b/Basis/Packages/com.basis.eventdriver/BasisEventDriver.cs
@@ -12,6 +12,7 @@ using Basis.Scripts.UI;
 using Basis.Scripts.UI.NamePlate;
 using Basis.Scripts.Profiler;
 using GatorDragonGames.JigglePhysics;
+using HVR.Basis.Comms;
 using SteamAudio;
 using System;
 using UnityEngine;
@@ -194,6 +195,7 @@ public partial class BasisEventDriver : MonoBehaviour
         BasisObjectSyncDriver.ScheduleRemoteLerp(DeltaTime);
         if (!IsHeadlessClient)
             InputSystem.Update();
+        OSCAcquisitionServer.Simulate();
         timeSinceLastUpdate += DeltaTime;
     }
 

--- a/Basis/Packages/com.basis.sdk/Settings/AvatarContentPoliceSelector.asset
+++ b/Basis/Packages/com.basis.sdk/Settings/AvatarContentPoliceSelector.asset
@@ -176,6 +176,7 @@ MonoBehaviour:
   - Basis.Shims.BasisAvatarShim
   - Basis.Shims.BasisNetworkShim
   - Cilbox.CilboxProxy
+  - Basis.Shims.BasisOsc
   - Basis.Scripts.BasisSdk.BasisHeadChop
   - HVR.Vixxy.HVRVixxyControl
   - HVR.Vixxy.HVRVixxyMenuItem

--- a/Basis/Packages/com.basis.sdk/Settings/PropContentPoliceSelector.asset
+++ b/Basis/Packages/com.basis.sdk/Settings/PropContentPoliceSelector.asset
@@ -340,3 +340,4 @@ MonoBehaviour:
   - UnityEngine.Rendering.Universal.UniversalAdditionalLightData
   - Basis.Scripts.BasisSdk.Interactions.BasisInteractableButton
   - GatorDragonGames.JigglePhysics.JiggleRig
+  - Basis.Shims.BasisOsc

--- a/Basis/Packages/com.basis.sdk/Settings/SceneContentPoliceSelector.asset
+++ b/Basis/Packages/com.basis.sdk/Settings/SceneContentPoliceSelector.asset
@@ -378,3 +378,4 @@ MonoBehaviour:
   - Basis.Shims.VideoPlayerShim
   - Basis.Shims.BasisNetworkShim
   - Basis.Shims.BasisInteractableShim
+  - Basis.Shims.BasisOsc

--- a/Basis/Packages/com.basis.sdk/Settings/SystemContentPoliceSelector.asset
+++ b/Basis/Packages/com.basis.sdk/Settings/SystemContentPoliceSelector.asset
@@ -161,3 +161,4 @@ MonoBehaviour:
   - Basis.Network.Vehicles.BasisNetworkedVehicle
   - Basis.Scripts.Vehicles.Parts.BasisVehicleEngineAudio
   - Basis.Scripts.BasisSdk.Interactions.BasisInteractableButton
+  - Basis.Shims.BasisOsc

--- a/Basis/Packages/com.basis.shim/Samples.meta
+++ b/Basis/Packages/com.basis.shim/Samples.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6b04e60978174f3bba9650a5f41bdc8e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Basis/Packages/com.basis.shim/Samples/OSC Subscription Example.meta
+++ b/Basis/Packages/com.basis.shim/Samples/OSC Subscription Example.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2685b6ec89434aafad9c9ebd9eeb9615
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Basis/Packages/com.basis.shim/Samples/OSC Subscription Example/Basis.Shims.Samples.asmdef
+++ b/Basis/Packages/com.basis.shim/Samples/OSC Subscription Example/Basis.Shims.Samples.asmdef
@@ -1,0 +1,21 @@
+{
+    "name": "Basis.Shims.Samples",
+    "rootNamespace": "Basis.Shims.Samples",
+    "references": [
+        "BasisShims",
+        "Basis Framework",
+        "BasisSDK",
+        "BasisNetworkCore",
+        "Cilbox",
+        "HVR.Basis.Comms"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Basis/Packages/com.basis.shim/Samples/OSC Subscription Example/Basis.Shims.Samples.asmdef.meta
+++ b/Basis/Packages/com.basis.shim/Samples/OSC Subscription Example/Basis.Shims.Samples.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5d92ec8340c744f48bdfe851519f15c2
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Basis/Packages/com.basis.shim/Samples/OSC Subscription Example/BasisOscCilboxSubscriptionExample.cs
+++ b/Basis/Packages/com.basis.shim/Samples/OSC Subscription Example/BasisOscCilboxSubscriptionExample.cs
@@ -125,7 +125,8 @@ namespace Basis.Shims.Samples
                 return report;
             }
 
-            for (int index = 0; index < arguments.Length; index++)
+            int argumentCount = arguments.Length;
+            for (int index = 0; index < argumentCount; index++)
             {
                 report += " | arg[" + index + "]=" + DescribeOscData(arguments[index]);
             }
@@ -185,7 +186,8 @@ namespace Basis.Shims.Samples
             }
 
             string description = string.Empty;
-            for (int index = 0; index < values.Length; index++)
+            int valueCount = values.Length;
+            for (int index = 0; index < valueCount; index++)
             {
                 if (index > 0)
                 {

--- a/Basis/Packages/com.basis.shim/Samples/OSC Subscription Example/BasisOscCilboxSubscriptionExample.cs
+++ b/Basis/Packages/com.basis.shim/Samples/OSC Subscription Example/BasisOscCilboxSubscriptionExample.cs
@@ -1,0 +1,226 @@
+using Cilbox;
+using Basis.Network.Core;
+using Basis.Scripts.BasisSdk;
+using HVR.Basis.Comms.OSC;
+using System.Text;
+using UnityEngine;
+
+namespace Basis.Shims.Samples
+{
+    [Cilboxable]
+    public class BasisOscCilboxSubscriptionExample : MonoBehaviour
+    {
+        private const string ExplicitTestAddress = "/avatar/parameters/test";
+        private const string ImplicitTestAddress = "test";
+
+        private Basis.Shims.BasisOsc osc;
+        private BasisAvatar avatar;
+        private Basis.Shims.BasisNetworkShim networkShim;
+        private bool isNetworkReady;
+
+        private void Start()
+        {
+            if (osc == null)
+            {
+                osc = GetComponent<Basis.Shims.BasisOsc>();
+                if (osc == null)
+                {
+                    Debug.LogError("BasisOscCilboxSubscriptionExample requires a BasisOsc component.");
+                    return;
+                }
+            }
+
+            avatar = BasisAvatar.GetGameObject(this).GetComponent<BasisAvatar>();
+            if (avatar == null)
+            {
+                Debug.Log("BasisOscCilboxSubscriptionExample did not find a BasisAvatar in the parent hierarchy.");
+            }
+
+            networkShim = this.gameObject.GetComponent<Basis.Shims.BasisNetworkShim>();
+
+            networkShim.NetworkReady += OnNetworkReady;
+            networkShim.NetworkMessageReceived += OnNetworkMessageReceived;
+
+            osc.Subscribe(ExplicitTestAddress, OnExplicitTestTriggered, out string ExplicitAddress);
+            osc.Subscribe(ImplicitTestAddress, OnImplicitTestTriggered, out string ImplicitAddress);
+
+            Debug.Log("Subscribed to " + ExplicitAddress + " and implicit \"" + ImplicitAddress + "\" on avatar local=" + avatar?.IsOwnedLocally + ".");
+        }
+
+        private void OnDestroy()
+        {
+            if (osc != null)
+            {
+                osc.Unsubscribe(ExplicitTestAddress, OnExplicitTestTriggered);
+                osc.Unsubscribe(ImplicitTestAddress, OnImplicitTestTriggered);
+            }
+
+            if (networkShim != null)
+            {
+                networkShim.NetworkReady -= OnNetworkReady;
+                networkShim.NetworkMessageReceived -= OnNetworkMessageReceived;
+            }
+            Debug.Log("BasisOscCilboxSubscriptionExample destroyed and unsubscribed from OSC and network events.");
+        }
+
+        private void OnExplicitTestTriggered(OscMessage message, OscData[] arguments)
+        {
+            HandleOscMessage("Explicit", message, arguments);
+        }
+
+        private void OnImplicitTestTriggered(OscMessage message, OscData[] arguments)
+        {
+            HandleOscMessage("Implicit", message, arguments);
+        }
+
+        private void OnNetworkReady()
+        {
+            isNetworkReady = true;
+            Debug.Log("BasisOscCilboxSubscriptionExample network ready for avatar local=" + avatar.IsOwnedLocally + ".");
+        }
+
+        private void OnNetworkMessageReceived(ushort playerId, byte[] buffer, DeliveryMethod deliveryMethod)
+        {
+            string payload = buffer == null || buffer.Length == 0 ? string.Empty : Encoding.UTF8.GetString(buffer);
+            Debug.Log("Received network relay from player " + playerId + " via " + deliveryMethod + ": " + payload);
+        }
+
+        private void HandleOscMessage(string label, OscMessage message, OscData[] arguments)
+        {
+            string decoded = BuildDecodedOscReport(message, arguments);
+            Debug.Log(label + " OSC subscription fired: " + decoded);
+            ForwardDecodedMessageToAvatarOwner(label, decoded);
+        }
+
+        private void ForwardDecodedMessageToAvatarOwner(string label, string decoded)
+        {
+            if (avatar == null || avatar.IsOwnedLocally)
+            {
+                return;
+            }
+
+            if (networkShim == null || !isNetworkReady)
+            {
+                Debug.LogWarning("Skipping network relay for remote avatar because BasisNetworkShim is not ready yet.");
+                return;
+            }
+
+            if (!avatar.TryGetLinkedPlayer(out ushort linkedPlayerId))
+            {
+                Debug.LogWarning("Skipping network relay for remote avatar because no linked player ID was available.");
+                return;
+            }
+
+            string payload = label + " OSC relay to linked player " + linkedPlayerId + ": " + MessageOrDefault(decoded);
+            Debug.Log("Relaying OSC message to avatar owner: " + payload);
+            networkShim.SendCustomNetworkEvent(Encoding.UTF8.GetBytes(payload), DeliveryMethod.ReliableUnordered, new ushort[] { linkedPlayerId });
+        }
+
+        private static string BuildDecodedOscReport(OscMessage message, OscData[] arguments)
+        {
+            string report = message.Path + " with " + GetArgumentCount(arguments) + " argument(s)";
+
+            if (arguments == null || arguments.Length == 0)
+            {
+                return report;
+            }
+
+            for (int index = 0; index < arguments.Length; index++)
+            {
+                report += " | arg[" + index + "]=" + DescribeOscData(arguments[index]);
+            }
+
+            return report;
+        }
+
+        private static string DescribeOscData(OscData value)
+        {
+            if (value == null)
+            {
+                return "null";
+            }
+
+            switch (value.Kind)
+            {
+                case OscDataKind.Boolean:
+                    return "bool(" + value.BoolValue + ")";
+                case OscDataKind.Nil:
+                    return "nil";
+                case OscDataKind.Impulse:
+                    return "impulse";
+                case OscDataKind.Int32:
+                    return "int(" + value.IntValue + ")";
+                case OscDataKind.Float32:
+                    return "float(" + value.FloatValue + ")";
+                case OscDataKind.TimeTag:
+                    return "timeTag(" + value.TimeTagSeconds + "s," + value.TimeTagNanoseconds + "ns)";
+                case OscDataKind.String:
+                    return "string(\"" + value.StringValue + "\")";
+                case OscDataKind.Symbol:
+                    return "symbol(\"" + value.StringValue + "\")";
+                case OscDataKind.Blob:
+                    return "blob[" + GetBlobLength(value.BlobValue) + "]";
+                case OscDataKind.Color:
+                    return "color(r:" + value.ColorR + ",g:" + value.ColorG + ",b:" + value.ColorB + ",a:" + value.ColorA + ")";
+                case OscDataKind.Int64:
+                    return "long(" + value.LongValue + ")";
+                case OscDataKind.Float64:
+                    return "double(" + value.DoubleValue + ")";
+                case OscDataKind.Char:
+                    return "char(" + DescribeCharacter(value.UIntValue) + ")";
+                case OscDataKind.Midi:
+                    return "midi(port:" + value.MidiPort + ",status:" + value.MidiStatus + ",data1:" + value.MidiData1 + ",data2:" + value.MidiData2 + ")";
+                case OscDataKind.Array:
+                    return "array(" + DescribeArray(value.Elements) + ")";
+                default:
+                    return "unknown(" + value.Kind + ")";
+            }
+        }
+
+        private static string DescribeArray(OscData[] values)
+        {
+            if (values == null || values.Length == 0)
+            {
+                return "empty";
+            }
+
+            string description = string.Empty;
+            for (int index = 0; index < values.Length; index++)
+            {
+                if (index > 0)
+                {
+                    description += ", ";
+                }
+
+                description += DescribeOscData(values[index]);
+            }
+
+            return description;
+        }
+
+        private static string DescribeCharacter(uint codePoint)
+        {
+            if (codePoint > 0x10FFFF || (codePoint >= 0xD800 && codePoint <= 0xDFFF))
+            {
+                return "invalid/" + codePoint;
+            }
+
+            return "\"" + char.ConvertFromUtf32((int)codePoint) + "\"/" + codePoint;
+        }
+
+        private static int GetBlobLength(byte[] blob)
+        {
+            return blob == null ? 0 : blob.Length;
+        }
+
+        private static int GetArgumentCount(OscData[] arguments)
+        {
+            return arguments == null ? 0 : arguments.Length;
+        }
+
+        private static string MessageOrDefault(string decoded)
+        {
+            return string.IsNullOrEmpty(decoded) ? "empty OSC message" : decoded;
+        }
+    }
+}

--- a/Basis/Packages/com.basis.shim/Samples/OSC Subscription Example/BasisOscCilboxSubscriptionExample.cs
+++ b/Basis/Packages/com.basis.shim/Samples/OSC Subscription Example/BasisOscCilboxSubscriptionExample.cs
@@ -35,7 +35,7 @@ namespace Basis.Shims.Samples
             {
                 Debug.Log("BasisOscCilboxSubscriptionExample did not find a BasisAvatar in the parent hierarchy.");
             }
-
+            // Cilbox will add the Shim when using GetComponent.
             networkShim = this.gameObject.GetComponent<Basis.Shims.BasisNetworkShim>();
 
             networkShim.NetworkReady += OnNetworkReady;

--- a/Basis/Packages/com.basis.shim/Samples/OSC Subscription Example/BasisOscCilboxSubscriptionExample.cs.meta
+++ b/Basis/Packages/com.basis.shim/Samples/OSC Subscription Example/BasisOscCilboxSubscriptionExample.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ee946065331c4ad88b76c8a6c2e57071
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Basis/Packages/com.basis.shim/Shims/BasisOsc.cs
+++ b/Basis/Packages/com.basis.shim/Shims/BasisOsc.cs
@@ -49,14 +49,18 @@ namespace Basis.Shims
             public string[] PrefixRegistrationLines { get; internal set; } = Array.Empty<string>();
         }
 
-        private readonly Dictionary<string, OscMessageEvent> exactCallbacks = new Dictionary<string, OscMessageEvent>(StringComparer.Ordinal);
-        private readonly Dictionary<string, OscMessageEvent> prefixCallbacks = new Dictionary<string, OscMessageEvent>(StringComparer.Ordinal);
-        private readonly Dictionary<string, OscValueEvent> exactValueCallbacks = new Dictionary<string, OscValueEvent>(StringComparer.Ordinal);
-        private readonly Dictionary<string, OscValueEvent> prefixValueCallbacks = new Dictionary<string, OscValueEvent>(StringComparer.Ordinal);
-        private readonly Dictionary<string, HashSet<string>> exactCallbackInputs = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
-        private readonly Dictionary<string, HashSet<string>> prefixCallbackInputs = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
-        private readonly Dictionary<string, HashSet<string>> exactValueCallbackInputs = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
-        private readonly Dictionary<string, HashSet<string>> prefixValueCallbackInputs = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+        private sealed class OscSubscription
+        {
+            public OscMessageEvent MessageCallbacks;
+            public OscValueEvent ValueCallbacks;
+            public readonly HashSet<string> MessageInputs = new HashSet<string>(StringComparer.Ordinal);
+            public readonly HashSet<string> ValueInputs = new HashSet<string>(StringComparer.Ordinal);
+
+            public bool IsEmpty => MessageCallbacks == null && ValueCallbacks == null;
+        }
+
+        private readonly Dictionary<string, OscSubscription> exactSubscriptions = new Dictionary<string, OscSubscription>(StringComparer.Ordinal);
+        private readonly Dictionary<string, OscSubscription> prefixSubscriptions = new Dictionary<string, OscSubscription>(StringComparer.Ordinal);
         private int inspectorStateVersion;
         private bool hasCachedScope;
         private bool cachedScopeFound;
@@ -137,10 +141,11 @@ namespace Basis.Shims
             resolvedAddress = NormalizeSubscriptionAddress(address, localOnly);
             if (resolvedAddress != null)
             {
-                AddCallback(exactCallbacks, resolvedAddress, callback);
-                TrackInput(exactCallbackInputs, resolvedAddress, address);
-                MarkInspectorStateDirty();
-                SyncQuerySubscriptions();
+                if (AddMessageCallback(exactSubscriptions, resolvedAddress, callback, address))
+                {
+                    MarkInspectorStateDirty();
+                    SyncQuerySubscriptions();
+                }
             }
         }
 
@@ -164,10 +169,11 @@ namespace Basis.Shims
             resolvedAddress = NormalizeSubscriptionAddress(address, localOnly);
             if (resolvedAddress != null)
             {
-                AddCallback(exactValueCallbacks, resolvedAddress, callback);
-                TrackInput(exactValueCallbackInputs, resolvedAddress, address);
-                MarkInspectorStateDirty();
-                SyncQuerySubscriptions();
+                if (AddValueCallback(exactSubscriptions, resolvedAddress, callback, address))
+                {
+                    MarkInspectorStateDirty();
+                    SyncQuerySubscriptions();
+                }
             }
         }
 
@@ -181,10 +187,11 @@ namespace Basis.Shims
             resolvedAddress = NormalizeSubscriptionAddress(prefix);
             if (resolvedAddress != null)
             {
-                AddCallback(prefixCallbacks, resolvedAddress, callback);
-                TrackInput(prefixCallbackInputs, resolvedAddress, prefix);
-                MarkInspectorStateDirty();
-                SyncQuerySubscriptions();
+                if (AddMessageCallback(prefixSubscriptions, resolvedAddress, callback, prefix))
+                {
+                    MarkInspectorStateDirty();
+                    SyncQuerySubscriptions();
+                }
             }
         }
 
@@ -198,30 +205,28 @@ namespace Basis.Shims
             resolvedAddress = NormalizeSubscriptionAddress(prefix);
             if (resolvedAddress != null)
             {
-                AddCallback(prefixValueCallbacks, resolvedAddress, callback);
-                TrackInput(prefixValueCallbackInputs, resolvedAddress, prefix);
-                MarkInspectorStateDirty();
-                SyncQuerySubscriptions();
+                if (AddValueCallback(prefixSubscriptions, resolvedAddress, callback, prefix))
+                {
+                    MarkInspectorStateDirty();
+                    SyncQuerySubscriptions();
+                }
             }
         }
 
         /// <summary>
         /// Removes all subscriptions and handlers for the normalized address. This is the "remove everything for this address"
         /// variant: unlike <see cref="Unsubscribe(string, OscMessageEvent)"/>, which removes a single handler through
-        /// <see cref="RemoveCallback{TDelegate}(Dictionary{string, TDelegate}, string, TDelegate)"/>, this overload clears the
-        /// full address entry and all delegates that were previously added through <see cref="AddCallback{TDelegate}(Dictionary{string, TDelegate}, string, TDelegate)"/>.
-        /// When <see cref="RemoveCallback{TDelegate}(Dictionary{string, TDelegate}, string, TDelegate)"/> receives a null callback it
-        /// also removes the whole key, which is the same "remove all" behavior exposed intentionally by <see cref="Unsubscribe(string)"/>.
+        /// <see cref="RemoveCallback{TDelegate}(TDelegate, TDelegate)"/>, this overload clears the full address entry and all delegates
+        /// that were previously added through <see cref="AddCallback{TDelegate}(TDelegate, TDelegate)"/>.
+        /// When <see cref="RemoveCallback{TDelegate}(TDelegate, TDelegate)"/> receives a null callback it also removes that callback type,
+        /// which is the same "remove all" behavior exposed intentionally by <see cref="Unsubscribe(string)"/>.
         /// </summary>
         public void Unsubscribe(string address)
         {
             string normalizedAddress = NormalizeSubscriptionAddress(address);
             if (normalizedAddress != null)
             {
-                exactCallbacks.Remove(normalizedAddress);
-                exactValueCallbacks.Remove(normalizedAddress);
-                exactCallbackInputs.Remove(normalizedAddress);
-                exactValueCallbackInputs.Remove(normalizedAddress);
+                exactSubscriptions.Remove(normalizedAddress);
                 MarkInspectorStateDirty();
                 SyncQuerySubscriptions();
             }
@@ -232,10 +237,11 @@ namespace Basis.Shims
             string normalizedAddress = NormalizeSubscriptionAddress(address);
             if (normalizedAddress != null)
             {
-                RemoveCallback(exactCallbacks, normalizedAddress, callback);
-                RemoveTrackedInputsWhenEmpty(exactCallbacks, exactCallbackInputs, normalizedAddress);
-                MarkInspectorStateDirty();
-                SyncQuerySubscriptions();
+                if (RemoveMessageCallback(exactSubscriptions, normalizedAddress, callback))
+                {
+                    MarkInspectorStateDirty();
+                    SyncQuerySubscriptions();
+                }
             }
         }
 
@@ -244,10 +250,11 @@ namespace Basis.Shims
             string normalizedAddress = NormalizeSubscriptionAddress(address);
             if (normalizedAddress != null)
             {
-                RemoveCallback(exactValueCallbacks, normalizedAddress, callback);
-                RemoveTrackedInputsWhenEmpty(exactValueCallbacks, exactValueCallbackInputs, normalizedAddress);
-                MarkInspectorStateDirty();
-                SyncQuerySubscriptions();
+                if (RemoveValueCallback(exactSubscriptions, normalizedAddress, callback))
+                {
+                    MarkInspectorStateDirty();
+                    SyncQuerySubscriptions();
+                }
             }
         }
 
@@ -256,10 +263,7 @@ namespace Basis.Shims
             string normalizedPrefix = NormalizeSubscriptionAddress(prefix);
             if (normalizedPrefix != null)
             {
-                prefixCallbacks.Remove(normalizedPrefix);
-                prefixValueCallbacks.Remove(normalizedPrefix);
-                prefixCallbackInputs.Remove(normalizedPrefix);
-                prefixValueCallbackInputs.Remove(normalizedPrefix);
+                prefixSubscriptions.Remove(normalizedPrefix);
                 MarkInspectorStateDirty();
                 SyncQuerySubscriptions();
             }
@@ -270,10 +274,11 @@ namespace Basis.Shims
             string normalizedPrefix = NormalizeSubscriptionAddress(prefix);
             if (normalizedPrefix != null)
             {
-                RemoveCallback(prefixCallbacks, normalizedPrefix, callback);
-                RemoveTrackedInputsWhenEmpty(prefixCallbacks, prefixCallbackInputs, normalizedPrefix);
-                MarkInspectorStateDirty();
-                SyncQuerySubscriptions();
+                if (RemoveMessageCallback(prefixSubscriptions, normalizedPrefix, callback))
+                {
+                    MarkInspectorStateDirty();
+                    SyncQuerySubscriptions();
+                }
             }
         }
 
@@ -282,23 +287,18 @@ namespace Basis.Shims
             string normalizedPrefix = NormalizeSubscriptionAddress(prefix);
             if (normalizedPrefix != null)
             {
-                RemoveCallback(prefixValueCallbacks, normalizedPrefix, callback);
-                RemoveTrackedInputsWhenEmpty(prefixValueCallbacks, prefixValueCallbackInputs, normalizedPrefix);
-                MarkInspectorStateDirty();
-                SyncQuerySubscriptions();
+                if (RemoveValueCallback(prefixSubscriptions, normalizedPrefix, callback))
+                {
+                    MarkInspectorStateDirty();
+                    SyncQuerySubscriptions();
+                }
             }
         }
 
         public void ClearSubscriptions()
         {
-            exactCallbacks.Clear();
-            prefixCallbacks.Clear();
-            exactValueCallbacks.Clear();
-            prefixValueCallbacks.Clear();
-            exactCallbackInputs.Clear();
-            prefixCallbackInputs.Clear();
-            exactValueCallbackInputs.Clear();
-            prefixValueCallbackInputs.Clear();
+            exactSubscriptions.Clear();
+            prefixSubscriptions.Clear();
             MarkInspectorStateDirty();
             SyncQuerySubscriptions();
         }
@@ -317,18 +317,14 @@ namespace Basis.Shims
                 ReceiveAll = ReceiveAll,
                 CanPublish = scope != OscScope.None && scope != OscScope.AvatarRemote,
                 OnMessageListenerCount = GetInvocationCount(OnMessage),
-                ExactCallbackCount = exactCallbacks.Count,
-                ExactValueCallbackCount = exactValueCallbacks.Count,
-                PrefixCallbackCount = prefixCallbacks.Count,
-                PrefixValueCallbackCount = prefixValueCallbacks.Count,
-                ExactSubscriptions = BuildSortedUnion(exactCallbacks.Keys, exactValueCallbacks.Keys),
-                PrefixSubscriptions = BuildSortedUnion(prefixCallbacks.Keys, prefixValueCallbacks.Keys),
-                ExactRegistrationLines = BuildRegistrationLines(
-                    exactCallbacks, exactCallbackInputs, "Message Callback",
-                    exactValueCallbacks, exactValueCallbackInputs, "Value Callback"),
-                PrefixRegistrationLines = BuildRegistrationLines(
-                    prefixCallbacks, prefixCallbackInputs, "Message Callback",
-                    prefixValueCallbacks, prefixValueCallbackInputs, "Value Callback"),
+                ExactCallbackCount = CountMessageSubscriptions(exactSubscriptions),
+                ExactValueCallbackCount = CountValueSubscriptions(exactSubscriptions),
+                PrefixCallbackCount = CountMessageSubscriptions(prefixSubscriptions),
+                PrefixValueCallbackCount = CountValueSubscriptions(prefixSubscriptions),
+                ExactSubscriptions = BuildSortedKeys(exactSubscriptions),
+                PrefixSubscriptions = BuildSortedKeys(prefixSubscriptions),
+                ExactRegistrationLines = BuildRegistrationLines(exactSubscriptions),
+                PrefixRegistrationLines = BuildRegistrationLines(prefixSubscriptions),
             };
         }
 
@@ -349,16 +345,14 @@ namespace Basis.Shims
         {
             string normalizedAddress = NormalizeSubscriptionAddress(address);
             return normalizedAddress != null &&
-                   (exactCallbacks.ContainsKey(normalizedAddress) ||
-                    exactValueCallbacks.ContainsKey(normalizedAddress));
+                   exactSubscriptions.ContainsKey(normalizedAddress);
         }
 
         public bool IsPrefixSubscribed(string prefix)
         {
             string normalizedPrefix = NormalizeSubscriptionAddress(prefix);
             return normalizedPrefix != null &&
-                   (prefixCallbacks.ContainsKey(normalizedPrefix) ||
-                    prefixValueCallbacks.ContainsKey(normalizedPrefix));
+                   prefixSubscriptions.ContainsKey(normalizedPrefix);
         }
 
         public void PublishValue(string address, OscData value)
@@ -408,35 +402,21 @@ namespace Basis.Shims
             OscMessageEvent callback = null;
             OscValueEvent valueCallback = null;
 
-            if (exactCallbacks.TryGetValue(path, out OscMessageEvent exactCallback))
+            if (exactSubscriptions.TryGetValue(path, out OscSubscription exactSubscription))
             {
-                callback += exactCallback;
-                matched = true;
-            }
-
-            if (exactValueCallbacks.TryGetValue(path, out OscValueEvent exactValueCallback))
-            {
-                valueCallback += exactValueCallback;
+                callback += exactSubscription.MessageCallbacks;
+                valueCallback += exactSubscription.ValueCallbacks;
                 matched = true;
             }
 
             #region CollectPrefixCallbacks
-            var prefixCallbacksSnapshot = new List<KeyValuePair<string, OscMessageEvent>>(prefixCallbacks);
-            foreach (KeyValuePair<string, OscMessageEvent> entry in prefixCallbacksSnapshot)
+            var prefixSubscriptionsSnapshot = new List<KeyValuePair<string, OscSubscription>>(prefixSubscriptions);
+            foreach (KeyValuePair<string, OscSubscription> entry in prefixSubscriptionsSnapshot)
             {
                 if (IsPathWithinPrefix(path, entry.Key))
                 {
-                    callback += entry.Value;
-                    matched = true;
-                }
-            }
-
-            var prefixValueCallbacksSnapshot = new List<KeyValuePair<string, OscValueEvent>>(prefixValueCallbacks);
-            foreach (KeyValuePair<string, OscValueEvent> entry in prefixValueCallbacksSnapshot)
-            {
-                if (IsPathWithinPrefix(path, entry.Key))
-                {
-                    valueCallback += entry.Value;
+                    callback += entry.Value.MessageCallbacks;
+                    valueCallback += entry.Value.ValueCallbacks;
                     matched = true;
                 }
             }
@@ -472,13 +452,7 @@ namespace Basis.Shims
                 return;
             }
 
-            HashSet<string> exactAddresses = new HashSet<string>(exactCallbacks.Keys, StringComparer.Ordinal);
-            exactAddresses.UnionWith(exactValueCallbacks.Keys);
-
-            HashSet<string> prefixAddresses = new HashSet<string>(prefixCallbacks.Keys, StringComparer.Ordinal);
-            prefixAddresses.UnionWith(prefixValueCallbacks.Keys);
-
-            BasisOscService.UpdateSubscriptions(GetEntityId(), ReceiveAll, exactAddresses, prefixAddresses);
+            BasisOscService.UpdateSubscriptions(GetEntityId(), ReceiveAll, exactSubscriptions.Keys, prefixSubscriptions.Keys);
         }
 
         private static string GetScopeName(OscScope scope)
@@ -534,104 +508,184 @@ namespace Basis.Shims
             }
         }
 
-        private static void TrackInput(Dictionary<string, HashSet<string>> inputs, string normalizedAddress, string rawAddress)
+        private static bool AddMessageCallback(
+            Dictionary<string, OscSubscription> subscriptions,
+            string normalizedAddress,
+            OscMessageEvent callback,
+            string rawAddress)
         {
-            if (string.IsNullOrEmpty(normalizedAddress))
+            if (callback == null || string.IsNullOrEmpty(normalizedAddress))
             {
-                return;
+                return false;
             }
 
-            if (!inputs.TryGetValue(normalizedAddress, out HashSet<string> rawInputs))
+            OscSubscription subscription = GetOrCreateSubscription(subscriptions, normalizedAddress);
+            OscMessageEvent updated = AddCallback(subscription.MessageCallbacks, callback);
+            bool changed = !Equals(updated, subscription.MessageCallbacks);
+            subscription.MessageCallbacks = updated;
+            return TrackInput(subscription.MessageInputs, normalizedAddress, rawAddress) || changed;
+        }
+
+        private static bool AddValueCallback(
+            Dictionary<string, OscSubscription> subscriptions,
+            string normalizedAddress,
+            OscValueEvent callback,
+            string rawAddress)
+        {
+            if (callback == null || string.IsNullOrEmpty(normalizedAddress))
             {
-                rawInputs = new HashSet<string>(StringComparer.Ordinal);
-                inputs[normalizedAddress] = rawInputs;
+                return false;
+            }
+
+            OscSubscription subscription = GetOrCreateSubscription(subscriptions, normalizedAddress);
+            OscValueEvent updated = AddCallback(subscription.ValueCallbacks, callback);
+            bool changed = !Equals(updated, subscription.ValueCallbacks);
+            subscription.ValueCallbacks = updated;
+            return TrackInput(subscription.ValueInputs, normalizedAddress, rawAddress) || changed;
+        }
+
+        private static bool RemoveMessageCallback(
+            Dictionary<string, OscSubscription> subscriptions,
+            string normalizedAddress,
+            OscMessageEvent callback)
+        {
+            if (string.IsNullOrEmpty(normalizedAddress) ||
+                !subscriptions.TryGetValue(normalizedAddress, out OscSubscription subscription))
+            {
+                return false;
+            }
+
+            OscMessageEvent updated = RemoveCallback(subscription.MessageCallbacks, callback);
+            if (Equals(updated, subscription.MessageCallbacks))
+            {
+                return false;
+            }
+
+            subscription.MessageCallbacks = updated;
+            if (subscription.MessageCallbacks == null)
+            {
+                subscription.MessageInputs.Clear();
+            }
+
+            RemoveSubscriptionIfEmpty(subscriptions, normalizedAddress, subscription);
+            return true;
+        }
+
+        private static bool RemoveValueCallback(
+            Dictionary<string, OscSubscription> subscriptions,
+            string normalizedAddress,
+            OscValueEvent callback)
+        {
+            if (string.IsNullOrEmpty(normalizedAddress) ||
+                !subscriptions.TryGetValue(normalizedAddress, out OscSubscription subscription))
+            {
+                return false;
+            }
+
+            OscValueEvent updated = RemoveCallback(subscription.ValueCallbacks, callback);
+            if (Equals(updated, subscription.ValueCallbacks))
+            {
+                return false;
+            }
+
+            subscription.ValueCallbacks = updated;
+            if (subscription.ValueCallbacks == null)
+            {
+                subscription.ValueInputs.Clear();
+            }
+
+            RemoveSubscriptionIfEmpty(subscriptions, normalizedAddress, subscription);
+            return true;
+        }
+
+        private static OscSubscription GetOrCreateSubscription(Dictionary<string, OscSubscription> subscriptions, string normalizedAddress)
+        {
+            if (!subscriptions.TryGetValue(normalizedAddress, out OscSubscription subscription))
+            {
+                subscription = new OscSubscription();
+                subscriptions[normalizedAddress] = subscription;
+            }
+
+            return subscription;
+        }
+
+        private static void RemoveSubscriptionIfEmpty(
+            Dictionary<string, OscSubscription> subscriptions,
+            string normalizedAddress,
+            OscSubscription subscription)
+        {
+            if (subscription.IsEmpty)
+            {
+                subscriptions.Remove(normalizedAddress);
+            }
+        }
+
+        private static bool TrackInput(HashSet<string> inputs, string normalizedAddress, string rawAddress)
+        {
+            if (inputs == null || string.IsNullOrEmpty(normalizedAddress))
+            {
+                return false;
             }
 
             string raw = string.IsNullOrWhiteSpace(rawAddress) ? normalizedAddress : rawAddress.Trim();
-            rawInputs.Add(raw);
+            return inputs.Add(raw);
         }
 
-        private static void RemoveTrackedInputsWhenEmpty<TDelegate>(
-            Dictionary<string, TDelegate> callbacks,
-            Dictionary<string, HashSet<string>> trackedInputs,
-            string normalizedAddress)
-            where TDelegate : Delegate
+        private static int CountMessageSubscriptions(Dictionary<string, OscSubscription> subscriptions)
         {
-            if (string.IsNullOrEmpty(normalizedAddress))
+            int count = 0;
+            foreach (OscSubscription subscription in subscriptions.Values)
             {
-                return;
-            }
-
-            if (!callbacks.ContainsKey(normalizedAddress))
-            {
-                trackedInputs.Remove(normalizedAddress);
-            }
-        }
-
-        private static string[] BuildSortedUnion(params IEnumerable<string>[] sources)
-        {
-            HashSet<string> merged = new HashSet<string>(StringComparer.Ordinal);
-            if (sources != null)
-            {
-                int sourceCount = sources.Length;
-                for (int sourceIndex = 0; sourceIndex < sourceCount; sourceIndex++)
+                if (subscription.MessageCallbacks != null)
                 {
-                    IEnumerable<string> source = sources[sourceIndex];
-                    if (source == null)
-                    {
-                        continue;
-                    }
-
-                    foreach (string entry in source)
-                    {
-                        if (!string.IsNullOrEmpty(entry))
-                        {
-                            merged.Add(entry);
-                        }
-                    }
+                    count++;
                 }
             }
 
-            string[] result = new string[merged.Count];
-            merged.CopyTo(result);
+            return count;
+        }
+
+        private static int CountValueSubscriptions(Dictionary<string, OscSubscription> subscriptions)
+        {
+            int count = 0;
+            foreach (OscSubscription subscription in subscriptions.Values)
+            {
+                if (subscription.ValueCallbacks != null)
+                {
+                    count++;
+                }
+            }
+
+            return count;
+        }
+
+        private static string[] BuildSortedKeys(Dictionary<string, OscSubscription> subscriptions)
+        {
+            string[] result = new string[subscriptions.Count];
+            subscriptions.Keys.CopyTo(result, 0);
             Array.Sort(result, StringComparer.Ordinal);
             return result;
         }
 
-        private static string[] BuildRegistrationLines(
-            Dictionary<string, OscMessageEvent> messageCallbacks,
-            Dictionary<string, HashSet<string>> messageInputs,
-            string messageLabel,
-            Dictionary<string, OscValueEvent> valueCallbacks,
-            Dictionary<string, HashSet<string>> valueInputs,
-            string valueLabel)
+        private static string[] BuildRegistrationLines(Dictionary<string, OscSubscription> subscriptions)
         {
             List<string> lines = new List<string>();
-            AddRegistrationLines(lines, messageCallbacks, messageInputs, messageLabel);
-            AddRegistrationLines(lines, valueCallbacks, valueInputs, valueLabel);
-            lines.Sort(StringComparer.Ordinal);
-            return lines.ToArray();
-        }
-
-        private static void AddRegistrationLines<TDelegate>(
-            List<string> lines,
-            Dictionary<string, TDelegate> callbacks,
-            Dictionary<string, HashSet<string>> inputs,
-            string label)
-            where TDelegate : Delegate
-        {
-            if (callbacks == null || inputs == null)
+            foreach (KeyValuePair<string, OscSubscription> entry in subscriptions)
             {
-                return;
-            }
-
-            foreach (KeyValuePair<string, TDelegate> entry in callbacks)
-            {
-                if (inputs.TryGetValue(entry.Key, out HashSet<string> rawInputs))
+                OscSubscription subscription = entry.Value;
+                if (subscription.MessageCallbacks != null)
                 {
-                    AddInputLines(lines, label, entry.Key, rawInputs);
+                    AddInputLines(lines, "Message Callback", entry.Key, subscription.MessageInputs);
+                }
+
+                if (subscription.ValueCallbacks != null)
+                {
+                    AddInputLines(lines, "Value Callback", entry.Key, subscription.ValueInputs);
                 }
             }
+
+            lines.Sort(StringComparer.Ordinal);
+            return lines.ToArray();
         }
 
         private static void AddInputLines(List<string> lines, string label, string normalizedAddress, HashSet<string> rawInputs)
@@ -1013,54 +1067,45 @@ namespace Basis.Shims
             return "local-" + fallbackId.ToString("x16");
         }
 
-        private static void AddCallback<TDelegate>(Dictionary<string, TDelegate> callbacks, string key, TDelegate callback)
+        private static TDelegate AddCallback<TDelegate>(TDelegate existing, TDelegate callback)
             where TDelegate : Delegate
         {
             if (callback == null)
             {
-                return;
+                return existing;
             }
 
-            if (callbacks.TryGetValue(key, out TDelegate existing))
+            if (existing != null)
             {
                 foreach (Delegate handler in existing.GetInvocationList())
                 {
                     if (Equals(handler, callback))
                     {
-                        return;
+                        return existing;
                     }
                 }
 
-                callbacks[key] = (TDelegate)Delegate.Combine(existing, callback);
-                return;
+                return (TDelegate)Delegate.Combine(existing, callback);
             }
 
-            callbacks[key] = callback;
+            return callback;
         }
 
-        private static void RemoveCallback<TDelegate>(Dictionary<string, TDelegate> callbacks, string key, TDelegate callback)
+        private static TDelegate RemoveCallback<TDelegate>(TDelegate existing, TDelegate callback)
             where TDelegate : Delegate
         {
-            if (callback == null)
+            if (existing == null)
             {
-                callbacks.Remove(key);
-                return;
+                return null;
             }
 
-            if (!callbacks.TryGetValue(key, out TDelegate existing))
+            if (callback == null)
             {
-                return;
+                return null;
             }
 
             Delegate updated = Delegate.Remove(existing, callback);
-            if (updated == null)
-            {
-                callbacks.Remove(key);
-            }
-            else
-            {
-                callbacks[key] = (TDelegate)updated;
-            }
+            return (TDelegate)updated;
         }
     }
 }

--- a/Basis/Packages/com.basis.shim/Shims/BasisOsc.cs
+++ b/Basis/Packages/com.basis.shim/Shims/BasisOsc.cs
@@ -573,7 +573,8 @@ namespace Basis.Shims
             HashSet<string> merged = new HashSet<string>(StringComparer.Ordinal);
             if (sources != null)
             {
-                for (int sourceIndex = 0; sourceIndex < sources.Length; sourceIndex++)
+                int sourceCount = sources.Length;
+                for (int sourceIndex = 0; sourceIndex < sourceCount; sourceIndex++)
                 {
                     IEnumerable<string> source = sources[sourceIndex];
                     if (source == null)
@@ -650,7 +651,8 @@ namespace Basis.Shims
             rawInputs.CopyTo(sortedInputs);
             Array.Sort(sortedInputs, StringComparer.Ordinal);
 
-            for (int i = 0; i < sortedInputs.Length; i++)
+            int sortedInputCount = sortedInputs.Length;
+            for (int i = 0; i < sortedInputCount; i++)
             {
                 string rawInput = sortedInputs[i];
                 lines.Add(rawInput == normalizedAddress
@@ -987,8 +989,9 @@ namespace Basis.Shims
             if (content != null && content.TryGetNetworkGUIDIdentifier(out string identifier) && !string.IsNullOrWhiteSpace(identifier))
             {
                 #region SanitizePathSegment
-                StringBuilder builder = new StringBuilder(identifier.Length);
-                for (int i = 0; i < identifier.Length; i++)
+                int identifierLength = identifier.Length;
+                StringBuilder builder = new StringBuilder(identifierLength);
+                for (int i = 0; i < identifierLength; i++)
                 {
                     char c = identifier[i];
                     if (char.IsLetterOrDigit(c) || c == '-' || c == '_')

--- a/Basis/Packages/com.basis.shim/Shims/BasisOsc.cs
+++ b/Basis/Packages/com.basis.shim/Shims/BasisOsc.cs
@@ -58,6 +58,12 @@ namespace Basis.Shims
         private readonly Dictionary<string, HashSet<string>> exactValueCallbackInputs = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
         private readonly Dictionary<string, HashSet<string>> prefixValueCallbackInputs = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
         private int inspectorStateVersion;
+        private bool hasCachedScope;
+        private bool cachedScopeFound;
+        private OscScope cachedScope;
+        private string cachedScopePrefix;
+        private BasisAvatar cachedScopeAvatar;
+        private bool cachedScopeAvatarIsOwnedLocally;
 
         public OscMessageEvent OnMessage { get; set; }
 
@@ -78,23 +84,37 @@ namespace Basis.Shims
             }
         }
 
+        private bool isRegistered;
         private void OnEnable()
         {
+            InvalidateScopeCache();
             BasisOscService.EnsureInitialized();
             BasisOscService.RegisterReceiver(GetEntityId(), HandleMessage);
+            isRegistered = true;
             SyncQuerySubscriptions();
         }
 
         private void OnDisable()
         {
+            if(!isRegistered) return;
             BasisOscService.UnregisterReceiver(GetEntityId());
             BasisOscService.ClearSubscriptions(GetEntityId());
+            isRegistered = false;
+        }
+
+        private void OnTransformParentChanged()
+        {
+            InvalidateScopeCache();
+            MarkInspectorStateDirty();
+            SyncQuerySubscriptions();
         }
 
         private void OnDestroy()
         {
+            if(!isRegistered) return;
             BasisOscService.UnregisterReceiver(GetEntityId());
             BasisOscService.ClearSubscriptions(GetEntityId());
+            isRegistered = false;
         }
 
         public void Subscribe(string address, OscMessageEvent callback)
@@ -401,7 +421,8 @@ namespace Basis.Shims
             }
 
             #region CollectPrefixCallbacks
-            foreach (KeyValuePair<string, OscMessageEvent> entry in prefixCallbacks)
+            var prefixCallbacksSnapshot = new List<KeyValuePair<string, OscMessageEvent>>(prefixCallbacks);
+            foreach (KeyValuePair<string, OscMessageEvent> entry in prefixCallbacksSnapshot)
             {
                 if (IsPathWithinPrefix(path, entry.Key))
                 {
@@ -410,7 +431,8 @@ namespace Basis.Shims
                 }
             }
 
-            foreach (KeyValuePair<string, OscValueEvent> entry in prefixValueCallbacks)
+            var prefixValueCallbacksSnapshot = new List<KeyValuePair<string, OscValueEvent>>(prefixValueCallbacks);
+            foreach (KeyValuePair<string, OscValueEvent> entry in prefixValueCallbacksSnapshot)
             {
                 if (IsPathWithinPrefix(path, entry.Key))
                 {
@@ -419,7 +441,6 @@ namespace Basis.Shims
                 }
             }
             #endregion
-
             if (!matched)
             {
                 return;
@@ -744,7 +765,7 @@ namespace Basis.Shims
             return trimmed.Length == 0 ? prefix : prefix + "/" + trimmed;
         }
 
-        private void SubmitPublishedValuesToVixxy(string resolvedAddress, OscData[] values) => SubmitPublishedValueToVixxy(resolvedAddress, values[0]);
+        private void SubmitPublishedValuesToVixxy(string resolvedAddress, OscData[] values) => SubmitPublishedValueToVixxy(resolvedAddress, values?.Length > 0 ? values[0] : null);
 
 
         private void SubmitPublishedValueToVixxy(string resolvedAddress, OscData value)
@@ -781,7 +802,7 @@ namespace Basis.Shims
                 return avatarComms.VariableStore;
             }
 
-            return AcquisitionService.SceneInstance.VariableStore;
+            return AcquisitionService.SceneInstance?.VariableStore;
         }
 
         private static bool TryReadVixxyFloat(OscData value, out float floatValue)
@@ -854,48 +875,89 @@ namespace Basis.Shims
 
         private static bool IsPathWithinPrefix(string path, string prefix)
         {
+            if (string.IsNullOrEmpty(path) || string.IsNullOrEmpty(prefix))
+            {
+                return false;
+            }
             return path.StartsWith(prefix, StringComparison.Ordinal) &&
                    (path.Length == prefix.Length || prefix[prefix.Length - 1] == '/' || path[prefix.Length] == '/');
         }
 
         private bool TryGetOscScope(out OscScope scope, out string prefix)
         {
-            return TryGetOscScope(this, out scope, out prefix);
+            if (hasCachedScope && IsScopeCacheValid())
+            {
+                scope = cachedScope;
+                prefix = cachedScopePrefix;
+                return cachedScopeFound;
+            }
+
+            cachedScopeFound = TryGetOscScopeUncached(out cachedScope, out cachedScopePrefix, out cachedScopeAvatar);
+            cachedScopeAvatarIsOwnedLocally = cachedScopeAvatar != null && cachedScopeAvatar.IsOwnedLocally;
+            hasCachedScope = true;
+
+            scope = cachedScope;
+            prefix = cachedScopePrefix;
+            return cachedScopeFound;
         }
 
-        private static bool TryGetOscScope(BasisOsc shim, out OscScope scope, out string prefix)
+        private bool IsScopeCacheValid()
+        {
+            if (ReferenceEquals(cachedScopeAvatar, null))
+            {
+                // Never had an avatar cached - scope is still valid (Prop/Scene/None)
+                return true;
+            }
+            // If avatar was destroyed, cache is invalid
+            if (cachedScopeAvatar == null)
+            {
+                return false;
+            }
+            return cachedScopeAvatar.IsOwnedLocally == cachedScopeAvatarIsOwnedLocally;
+        }
+
+        private void InvalidateScopeCache()
+        {
+            hasCachedScope = false;
+            cachedScopeFound = false;
+            cachedScope = OscScope.None;
+            cachedScopePrefix = null;
+            cachedScopeAvatar = null;
+            cachedScopeAvatarIsOwnedLocally = false;
+        }
+
+        private bool TryGetOscScopeUncached(out OscScope scope, out string prefix, out BasisAvatar scopeAvatar)
         {
             scope = OscScope.None;
             prefix = null;
+            scopeAvatar = null;
 
-            for (Transform current = shim.transform; current != null; current = current.parent)
+            for (Transform current = transform; current != null; current = current.parent)
             {
-                BasisProp prop = current.GetComponent<BasisProp>();
-                if (prop != null)
+                if (current.TryGetComponent(out BasisProp prop))
                 {
                     scope = OscScope.Prop;
                     prefix = PropPublishPrefix + "/" + GetScopedContentIdentifier(prop) + "/parameters";
                     return true;
                 }
 
-                BasisScene sceneOnTransform = current.GetComponent<BasisScene>();
-                if (sceneOnTransform != null)
+                if (current.TryGetComponent(out BasisScene sceneOnTransform))
                 {
                     scope = OscScope.Scene;
                     prefix = ScenePublishPrefix + "/" + GetScopedContentIdentifier(sceneOnTransform) + "/parameters";
                     return true;
                 }
 
-                BasisAvatar avatar = current.GetComponent<BasisAvatar>();
-                if (avatar != null)
+                if (current.TryGetComponent(out BasisAvatar avatar))
                 {
                     scope = avatar.IsOwnedLocally ? OscScope.AvatarLocal : OscScope.AvatarRemote;
                     prefix = avatar.IsOwnedLocally ? AvatarParametersPrefix : null;
+                    scopeAvatar = avatar;
                     return true;
                 }
             }
 
-            if (BasisScene.SceneTraversalFindBasisScene(shim.gameObject, out BasisScene scene))
+            if (BasisScene.SceneTraversalFindBasisScene(gameObject, out BasisScene scene))
             {
                 scope = OscScope.Scene;
                 prefix = ScenePublishPrefix + "/" + GetScopedContentIdentifier(scene) + "/parameters";
@@ -907,36 +969,8 @@ namespace Basis.Shims
 
         private OscScope GetCurrentScopeForInspector()
         {
-            return GetCurrentScopeForInspector(this);
-        }
-
-        private static OscScope GetCurrentScopeForInspector(BasisOsc shim)
-        {
-            for (Transform current = shim.transform; current != null; current = current.parent)
-            {
-                if (current.GetComponent<BasisProp>() != null)
-                {
-                    return OscScope.Prop;
-                }
-
-                if (current.GetComponent<BasisScene>() != null)
-                {
-                    return OscScope.Scene;
-                }
-
-                BasisAvatar avatar = current.GetComponent<BasisAvatar>();
-                if (avatar != null)
-                {
-                    return avatar.IsOwnedLocally ? OscScope.AvatarLocal : OscScope.AvatarRemote;
-                }
-            }
-
-            if (BasisScene.SceneTraversalFindBasisScene(shim.gameObject, out _))
-            {
-                return OscScope.Scene;
-            }
-
-            return OscScope.None;
+            TryGetOscScope(out OscScope scope, out _);
+            return scope;
         }
 
         private static void WarnRestrictedAvatarSubscription(string address, OscScope scope)

--- a/Basis/Packages/com.basis.shim/Shims/BasisOsc.cs
+++ b/Basis/Packages/com.basis.shim/Shims/BasisOsc.cs
@@ -1,0 +1,1028 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Cilbox;
+using Basis.Scripts.BasisSdk;
+using HVR.Basis.Comms;
+using HVR.Basis.Comms.OSC;
+using UnityEngine;
+
+namespace Basis.Shims
+{
+    [DisallowMultipleComponent]
+    public class BasisOsc : CilboxShim
+    {
+        public delegate void OscMessageEvent(OscMessage message, OscData[] arguments);
+        public delegate void OscValueEvent(OscData value);
+        private const string AvatarParametersPrefix = "/avatar/parameters";
+        private const string AvatarPublicPrefix = "/avatar/public";
+        private const string PropPublishPrefix = "/prop";
+        private const string ScenePublishPrefix = "/scene";
+
+        private enum OscScope
+        {
+            None,
+            AvatarLocal,
+            AvatarRemote,
+            Prop,
+            Scene
+        }
+
+        public sealed class InspectorState
+        {
+            public bool HasScope { get; internal set; }
+            public string ScopeName { get; internal set; }
+            public string PublishPrefix { get; internal set; }
+            public string DefaultSubscriptionPrefix { get; internal set; }
+            public string EntityId { get; internal set; }
+            public bool IsActiveAndEnabled { get; internal set; }
+            public bool ReceiveAll { get; internal set; }
+            public bool CanPublish { get; internal set; }
+            public int OnMessageListenerCount { get; internal set; }
+            public int ExactCallbackCount { get; internal set; }
+            public int ExactValueCallbackCount { get; internal set; }
+            public int PrefixCallbackCount { get; internal set; }
+            public int PrefixValueCallbackCount { get; internal set; }
+            public string[] ExactSubscriptions { get; internal set; } = Array.Empty<string>();
+            public string[] PrefixSubscriptions { get; internal set; } = Array.Empty<string>();
+            public string[] ExactRegistrationLines { get; internal set; } = Array.Empty<string>();
+            public string[] PrefixRegistrationLines { get; internal set; } = Array.Empty<string>();
+        }
+
+        private readonly Dictionary<string, OscMessageEvent> exactCallbacks = new Dictionary<string, OscMessageEvent>(StringComparer.Ordinal);
+        private readonly Dictionary<string, OscMessageEvent> prefixCallbacks = new Dictionary<string, OscMessageEvent>(StringComparer.Ordinal);
+        private readonly Dictionary<string, OscValueEvent> exactValueCallbacks = new Dictionary<string, OscValueEvent>(StringComparer.Ordinal);
+        private readonly Dictionary<string, OscValueEvent> prefixValueCallbacks = new Dictionary<string, OscValueEvent>(StringComparer.Ordinal);
+        private readonly Dictionary<string, HashSet<string>> exactCallbackInputs = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+        private readonly Dictionary<string, HashSet<string>> prefixCallbackInputs = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+        private readonly Dictionary<string, HashSet<string>> exactValueCallbackInputs = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+        private readonly Dictionary<string, HashSet<string>> prefixValueCallbackInputs = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+        private int inspectorStateVersion;
+
+        public OscMessageEvent OnMessage { get; set; }
+
+        private bool receiveAll;
+        public bool ReceiveAll
+        {
+            get => receiveAll;
+            set
+            {
+                if (receiveAll == value)
+                {
+                    return;
+                }
+
+                receiveAll = value;
+                MarkInspectorStateDirty();
+                SyncQuerySubscriptions();
+            }
+        }
+
+        private void OnEnable()
+        {
+            BasisOscService.EnsureInitialized();
+            BasisOscService.RegisterReceiver(GetEntityId(), HandleMessage);
+            SyncQuerySubscriptions();
+        }
+
+        private void OnDisable()
+        {
+            BasisOscService.UnregisterReceiver(GetEntityId());
+            BasisOscService.ClearSubscriptions(GetEntityId());
+        }
+
+        private void OnDestroy()
+        {
+            BasisOscService.UnregisterReceiver(GetEntityId());
+            BasisOscService.ClearSubscriptions(GetEntityId());
+        }
+
+        public void Subscribe(string address, OscMessageEvent callback)
+        {
+            Subscribe(address, callback, out _);
+        }
+
+        public void Subscribe(string address, OscMessageEvent callback, bool localOnly)
+        {
+            Subscribe(address, callback, localOnly, out _);
+        }
+
+        public void Subscribe(string address, OscMessageEvent callback, out string resolvedAddress)
+        {
+            Subscribe(address, callback, false, out resolvedAddress);
+        }
+
+        public void Subscribe(string address, OscMessageEvent callback, bool localOnly, out string resolvedAddress)
+        {
+            resolvedAddress = NormalizeSubscriptionAddress(address, localOnly);
+            if (resolvedAddress != null)
+            {
+                AddCallback(exactCallbacks, resolvedAddress, callback);
+                TrackInput(exactCallbackInputs, resolvedAddress, address);
+                MarkInspectorStateDirty();
+                SyncQuerySubscriptions();
+            }
+        }
+
+        public void SubscribeValue(string address, OscValueEvent callback)
+        {
+            SubscribeValue(address, callback, out _);
+        }
+
+        public void SubscribeValue(string address, OscValueEvent callback, bool localOnly)
+        {
+            SubscribeValue(address, callback, localOnly, out _);
+        }
+
+        public void SubscribeValue(string address, OscValueEvent callback, out string resolvedAddress)
+        {
+            SubscribeValue(address, callback, false, out resolvedAddress);
+        }
+
+        public void SubscribeValue(string address, OscValueEvent callback, bool localOnly, out string resolvedAddress)
+        {
+            resolvedAddress = NormalizeSubscriptionAddress(address, localOnly);
+            if (resolvedAddress != null)
+            {
+                AddCallback(exactValueCallbacks, resolvedAddress, callback);
+                TrackInput(exactValueCallbackInputs, resolvedAddress, address);
+                MarkInspectorStateDirty();
+                SyncQuerySubscriptions();
+            }
+        }
+
+        public void SubscribePrefix(string prefix, OscMessageEvent callback)
+        {
+            SubscribePrefix(prefix, callback, out _);
+        }
+
+        public void SubscribePrefix(string prefix, OscMessageEvent callback, out string resolvedAddress)
+        {
+            resolvedAddress = NormalizeSubscriptionAddress(prefix);
+            if (resolvedAddress != null)
+            {
+                AddCallback(prefixCallbacks, resolvedAddress, callback);
+                TrackInput(prefixCallbackInputs, resolvedAddress, prefix);
+                MarkInspectorStateDirty();
+                SyncQuerySubscriptions();
+            }
+        }
+
+        public void SubscribePrefixValue(string prefix, OscValueEvent callback)
+        {
+            SubscribePrefixValue(prefix, callback, out _);
+        }
+
+        public void SubscribePrefixValue(string prefix, OscValueEvent callback, out string resolvedAddress)
+        {
+            resolvedAddress = NormalizeSubscriptionAddress(prefix);
+            if (resolvedAddress != null)
+            {
+                AddCallback(prefixValueCallbacks, resolvedAddress, callback);
+                TrackInput(prefixValueCallbackInputs, resolvedAddress, prefix);
+                MarkInspectorStateDirty();
+                SyncQuerySubscriptions();
+            }
+        }
+
+        /// <summary>
+        /// Removes all subscriptions and handlers for the normalized address. This is the "remove everything for this address"
+        /// variant: unlike <see cref="Unsubscribe(string, OscMessageEvent)"/>, which removes a single handler through
+        /// <see cref="RemoveCallback{TDelegate}(Dictionary{string, TDelegate}, string, TDelegate)"/>, this overload clears the
+        /// full address entry and all delegates that were previously added through <see cref="AddCallback{TDelegate}(Dictionary{string, TDelegate}, string, TDelegate)"/>.
+        /// When <see cref="RemoveCallback{TDelegate}(Dictionary{string, TDelegate}, string, TDelegate)"/> receives a null callback it
+        /// also removes the whole key, which is the same "remove all" behavior exposed intentionally by <see cref="Unsubscribe(string)"/>.
+        /// </summary>
+        public void Unsubscribe(string address)
+        {
+            string normalizedAddress = NormalizeSubscriptionAddress(address);
+            if (normalizedAddress != null)
+            {
+                exactCallbacks.Remove(normalizedAddress);
+                exactValueCallbacks.Remove(normalizedAddress);
+                exactCallbackInputs.Remove(normalizedAddress);
+                exactValueCallbackInputs.Remove(normalizedAddress);
+                MarkInspectorStateDirty();
+                SyncQuerySubscriptions();
+            }
+        }
+
+        public void Unsubscribe(string address, OscMessageEvent callback)
+        {
+            string normalizedAddress = NormalizeSubscriptionAddress(address);
+            if (normalizedAddress != null)
+            {
+                RemoveCallback(exactCallbacks, normalizedAddress, callback);
+                RemoveTrackedInputsWhenEmpty(exactCallbacks, exactCallbackInputs, normalizedAddress);
+                MarkInspectorStateDirty();
+                SyncQuerySubscriptions();
+            }
+        }
+
+        public void UnsubscribeValue(string address, OscValueEvent callback)
+        {
+            string normalizedAddress = NormalizeSubscriptionAddress(address);
+            if (normalizedAddress != null)
+            {
+                RemoveCallback(exactValueCallbacks, normalizedAddress, callback);
+                RemoveTrackedInputsWhenEmpty(exactValueCallbacks, exactValueCallbackInputs, normalizedAddress);
+                MarkInspectorStateDirty();
+                SyncQuerySubscriptions();
+            }
+        }
+
+        public void UnsubscribePrefix(string prefix)
+        {
+            string normalizedPrefix = NormalizeSubscriptionAddress(prefix);
+            if (normalizedPrefix != null)
+            {
+                prefixCallbacks.Remove(normalizedPrefix);
+                prefixValueCallbacks.Remove(normalizedPrefix);
+                prefixCallbackInputs.Remove(normalizedPrefix);
+                prefixValueCallbackInputs.Remove(normalizedPrefix);
+                MarkInspectorStateDirty();
+                SyncQuerySubscriptions();
+            }
+        }
+
+        public void UnsubscribePrefix(string prefix, OscMessageEvent callback)
+        {
+            string normalizedPrefix = NormalizeSubscriptionAddress(prefix);
+            if (normalizedPrefix != null)
+            {
+                RemoveCallback(prefixCallbacks, normalizedPrefix, callback);
+                RemoveTrackedInputsWhenEmpty(prefixCallbacks, prefixCallbackInputs, normalizedPrefix);
+                MarkInspectorStateDirty();
+                SyncQuerySubscriptions();
+            }
+        }
+
+        public void UnsubscribePrefixValue(string prefix, OscValueEvent callback)
+        {
+            string normalizedPrefix = NormalizeSubscriptionAddress(prefix);
+            if (normalizedPrefix != null)
+            {
+                RemoveCallback(prefixValueCallbacks, normalizedPrefix, callback);
+                RemoveTrackedInputsWhenEmpty(prefixValueCallbacks, prefixValueCallbackInputs, normalizedPrefix);
+                MarkInspectorStateDirty();
+                SyncQuerySubscriptions();
+            }
+        }
+
+        public void ClearSubscriptions()
+        {
+            exactCallbacks.Clear();
+            prefixCallbacks.Clear();
+            exactValueCallbacks.Clear();
+            prefixValueCallbacks.Clear();
+            exactCallbackInputs.Clear();
+            prefixCallbackInputs.Clear();
+            exactValueCallbackInputs.Clear();
+            prefixValueCallbackInputs.Clear();
+            MarkInspectorStateDirty();
+            SyncQuerySubscriptions();
+        }
+
+        public InspectorState GetInspectorState()
+        {
+            TryGetOscScope(out OscScope scope, out string publishPrefix);
+            return new InspectorState
+            {
+                HasScope = scope != OscScope.None,
+                ScopeName = GetScopeName(scope),
+                PublishPrefix = publishPrefix,
+                DefaultSubscriptionPrefix = GetDefaultSubscriptionPrefix(scope),
+                EntityId = GetEntityId().ToString(),
+                IsActiveAndEnabled = isActiveAndEnabled,
+                ReceiveAll = ReceiveAll,
+                CanPublish = scope != OscScope.None && scope != OscScope.AvatarRemote,
+                OnMessageListenerCount = GetInvocationCount(OnMessage),
+                ExactCallbackCount = exactCallbacks.Count,
+                ExactValueCallbackCount = exactValueCallbacks.Count,
+                PrefixCallbackCount = prefixCallbacks.Count,
+                PrefixValueCallbackCount = prefixValueCallbacks.Count,
+                ExactSubscriptions = BuildSortedUnion(exactCallbacks.Keys, exactValueCallbacks.Keys),
+                PrefixSubscriptions = BuildSortedUnion(prefixCallbacks.Keys, prefixValueCallbacks.Keys),
+                ExactRegistrationLines = BuildRegistrationLines(
+                    exactCallbacks, exactCallbackInputs, "Message Callback",
+                    exactValueCallbacks, exactValueCallbackInputs, "Value Callback"),
+                PrefixRegistrationLines = BuildRegistrationLines(
+                    prefixCallbacks, prefixCallbackInputs, "Message Callback",
+                    prefixValueCallbacks, prefixValueCallbackInputs, "Value Callback"),
+            };
+        }
+
+        public int GetInspectorCacheKey()
+        {
+            unchecked
+            {
+                int key = inspectorStateVersion;
+                key = (key * 397) ^ (isActiveAndEnabled ? 1 : 0);
+                key = (key * 397) ^ (ReceiveAll ? 1 : 0);
+                key = (key * 397) ^ GetInvocationCount(OnMessage);
+                key = (key * 397) ^ (int)GetCurrentScopeForInspector();
+                return key;
+            }
+        }
+
+        public bool IsSubscribed(string address)
+        {
+            string normalizedAddress = NormalizeSubscriptionAddress(address);
+            return normalizedAddress != null &&
+                   (exactCallbacks.ContainsKey(normalizedAddress) ||
+                    exactValueCallbacks.ContainsKey(normalizedAddress));
+        }
+
+        public bool IsPrefixSubscribed(string prefix)
+        {
+            string normalizedPrefix = NormalizeSubscriptionAddress(prefix);
+            return normalizedPrefix != null &&
+                   (prefixCallbacks.ContainsKey(normalizedPrefix) ||
+                    prefixValueCallbacks.ContainsKey(normalizedPrefix));
+        }
+
+        public void PublishValue(string address, OscData value)
+        {
+            PublishValue(address, value, out _);
+        }
+
+        public void PublishValue(string address, OscData value, out string resolvedAddress)
+        {
+            resolvedAddress = ResolvePublishAddress(address);
+            if (resolvedAddress == null)
+            {
+                return;
+            }
+
+            BasisOscService.PublishValue(resolvedAddress, value);
+            SubmitPublishedValueToVixxy(resolvedAddress, value);
+        }
+
+        public void PublishValues(string address, OscData[] values)
+        {
+            PublishValues(address, values, out _);
+        }
+
+        public void PublishValues(string address, OscData[] values, out string resolvedAddress)
+        {
+            resolvedAddress = ResolvePublishAddress(address);
+            if (resolvedAddress == null)
+            {
+                return;
+            }
+
+            BasisOscService.PublishValues(resolvedAddress, values);
+            SubmitPublishedValuesToVixxy(resolvedAddress, values);
+        }
+
+        private void HandleMessage(OscMessage message)
+        {
+            if (message == null)
+            {
+                return;
+            }
+
+            string path = message.Path ?? string.Empty;
+            bool matched = ReceiveAll && IsWithinReceiveAllScope(path);
+
+            OscMessageEvent callback = null;
+            OscValueEvent valueCallback = null;
+
+            if (exactCallbacks.TryGetValue(path, out OscMessageEvent exactCallback))
+            {
+                callback += exactCallback;
+                matched = true;
+            }
+
+            if (exactValueCallbacks.TryGetValue(path, out OscValueEvent exactValueCallback))
+            {
+                valueCallback += exactValueCallback;
+                matched = true;
+            }
+
+            #region CollectPrefixCallbacks
+            foreach (KeyValuePair<string, OscMessageEvent> entry in prefixCallbacks)
+            {
+                if (IsPathWithinPrefix(path, entry.Key))
+                {
+                    callback += entry.Value;
+                    matched = true;
+                }
+            }
+
+            foreach (KeyValuePair<string, OscValueEvent> entry in prefixValueCallbacks)
+            {
+                if (IsPathWithinPrefix(path, entry.Key))
+                {
+                    valueCallback += entry.Value;
+                    matched = true;
+                }
+            }
+            #endregion
+
+            if (!matched)
+            {
+                return;
+            }
+
+            OnMessage?.Invoke(message, message.Arguments);
+            callback?.Invoke(message, message.Arguments);
+            if (message.Arguments != null && message.Arguments.Length > 0)
+            {
+                valueCallback?.Invoke(message.Arguments[0]);
+            }
+        }
+
+        private bool IsWithinReceiveAllScope(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                return false;
+            }
+
+            string receiveAllPrefix = GetReceiveAllPrefix();
+            return !string.IsNullOrEmpty(receiveAllPrefix) && IsPathWithinPrefix(path, receiveAllPrefix);
+        }
+
+        private void SyncQuerySubscriptions()
+        {
+            if (!isActiveAndEnabled)
+            {
+                return;
+            }
+
+            HashSet<string> exactAddresses = new HashSet<string>(exactCallbacks.Keys, StringComparer.Ordinal);
+            exactAddresses.UnionWith(exactValueCallbacks.Keys);
+
+            HashSet<string> prefixAddresses = new HashSet<string>(prefixCallbacks.Keys, StringComparer.Ordinal);
+            prefixAddresses.UnionWith(prefixValueCallbacks.Keys);
+
+            BasisOscService.UpdateSubscriptions(GetEntityId(), ReceiveAll, exactAddresses, prefixAddresses);
+        }
+
+        private static string GetScopeName(OscScope scope)
+        {
+            switch (scope)
+            {
+                case OscScope.AvatarLocal:
+                    return "Avatar (Local)";
+                case OscScope.AvatarRemote:
+                    return "Avatar (Remote)";
+                case OscScope.Prop:
+                    return "Prop";
+                case OscScope.Scene:
+                    return "Scene";
+                default:
+                    return "None";
+            }
+        }
+
+        private static string GetDefaultSubscriptionPrefix(OscScope scope)
+        {
+            switch (scope)
+            {
+                case OscScope.AvatarRemote:
+                case OscScope.Prop:
+                case OscScope.Scene:
+                    return AvatarPublicPrefix;
+                default:
+                    return AvatarParametersPrefix;
+            }
+        }
+
+        private string GetReceiveAllPrefix()
+        {
+            if (TryGetOscScope(out OscScope scope, out _))
+            {
+                return GetDefaultSubscriptionPrefix(scope);
+            }
+
+            return AvatarParametersPrefix;
+        }
+
+        private static int GetInvocationCount(Delegate callback)
+        {
+            return callback?.GetInvocationList().Length ?? 0;
+        }
+
+        private void MarkInspectorStateDirty()
+        {
+            unchecked
+            {
+                inspectorStateVersion++;
+            }
+        }
+
+        private static void TrackInput(Dictionary<string, HashSet<string>> inputs, string normalizedAddress, string rawAddress)
+        {
+            if (string.IsNullOrEmpty(normalizedAddress))
+            {
+                return;
+            }
+
+            if (!inputs.TryGetValue(normalizedAddress, out HashSet<string> rawInputs))
+            {
+                rawInputs = new HashSet<string>(StringComparer.Ordinal);
+                inputs[normalizedAddress] = rawInputs;
+            }
+
+            string raw = string.IsNullOrWhiteSpace(rawAddress) ? normalizedAddress : rawAddress.Trim();
+            rawInputs.Add(raw);
+        }
+
+        private static void RemoveTrackedInputsWhenEmpty<TDelegate>(
+            Dictionary<string, TDelegate> callbacks,
+            Dictionary<string, HashSet<string>> trackedInputs,
+            string normalizedAddress)
+            where TDelegate : Delegate
+        {
+            if (string.IsNullOrEmpty(normalizedAddress))
+            {
+                return;
+            }
+
+            if (!callbacks.ContainsKey(normalizedAddress))
+            {
+                trackedInputs.Remove(normalizedAddress);
+            }
+        }
+
+        private static string[] BuildSortedUnion(params IEnumerable<string>[] sources)
+        {
+            HashSet<string> merged = new HashSet<string>(StringComparer.Ordinal);
+            if (sources != null)
+            {
+                for (int sourceIndex = 0; sourceIndex < sources.Length; sourceIndex++)
+                {
+                    IEnumerable<string> source = sources[sourceIndex];
+                    if (source == null)
+                    {
+                        continue;
+                    }
+
+                    foreach (string entry in source)
+                    {
+                        if (!string.IsNullOrEmpty(entry))
+                        {
+                            merged.Add(entry);
+                        }
+                    }
+                }
+            }
+
+            string[] result = new string[merged.Count];
+            merged.CopyTo(result);
+            Array.Sort(result, StringComparer.Ordinal);
+            return result;
+        }
+
+        private static string[] BuildRegistrationLines(
+            Dictionary<string, OscMessageEvent> messageCallbacks,
+            Dictionary<string, HashSet<string>> messageInputs,
+            string messageLabel,
+            Dictionary<string, OscValueEvent> valueCallbacks,
+            Dictionary<string, HashSet<string>> valueInputs,
+            string valueLabel)
+        {
+            List<string> lines = new List<string>();
+            AddRegistrationLines(lines, messageCallbacks, messageInputs, messageLabel);
+            AddRegistrationLines(lines, valueCallbacks, valueInputs, valueLabel);
+            lines.Sort(StringComparer.Ordinal);
+            return lines.ToArray();
+        }
+
+        private static void AddRegistrationLines<TDelegate>(
+            List<string> lines,
+            Dictionary<string, TDelegate> callbacks,
+            Dictionary<string, HashSet<string>> inputs,
+            string label)
+            where TDelegate : Delegate
+        {
+            if (callbacks == null || inputs == null)
+            {
+                return;
+            }
+
+            foreach (KeyValuePair<string, TDelegate> entry in callbacks)
+            {
+                if (inputs.TryGetValue(entry.Key, out HashSet<string> rawInputs))
+                {
+                    AddInputLines(lines, label, entry.Key, rawInputs);
+                }
+            }
+        }
+
+        private static void AddInputLines(List<string> lines, string label, string normalizedAddress, HashSet<string> rawInputs)
+        {
+            if (string.IsNullOrEmpty(normalizedAddress))
+            {
+                return;
+            }
+
+            if (rawInputs == null || rawInputs.Count == 0)
+            {
+                lines.Add(label + ": " + normalizedAddress);
+                return;
+            }
+
+            string[] sortedInputs = new string[rawInputs.Count];
+            rawInputs.CopyTo(sortedInputs);
+            Array.Sort(sortedInputs, StringComparer.Ordinal);
+
+            for (int i = 0; i < sortedInputs.Length; i++)
+            {
+                string rawInput = sortedInputs[i];
+                lines.Add(rawInput == normalizedAddress
+                    ? label + ": " + normalizedAddress
+                    : label + ": " + rawInput + " -> " + normalizedAddress);
+            }
+        }
+
+        private string NormalizeSubscriptionAddress(string address)
+        {
+            return NormalizeSubscriptionAddress(address, false);
+        }
+
+        private string NormalizeSubscriptionAddress(string address, bool localOnly)
+        {
+            if (string.IsNullOrWhiteSpace(address))
+            {
+                return null;
+            }
+
+            string trimmed = address.Trim();
+            if (trimmed.StartsWith("/", StringComparison.Ordinal))
+            {
+                #region NormalizeAbsoluteSubscriptionAddress
+                if (!TryGetOscScope(out OscScope scope, out _))
+                {
+                    return trimmed;
+                }
+
+                if (localOnly && scope == OscScope.AvatarRemote)
+                {
+                    return null;
+                }
+
+                if (scope == OscScope.AvatarRemote)
+                {
+                    #region NormalizeRemoteAvatarAbsoluteSubscriptionAddress
+                    if (IsPathWithinPrefix(trimmed, AvatarParametersPrefix))
+                    {
+                        return AvatarPublicPrefix + trimmed.Substring(AvatarParametersPrefix.Length);
+                    }
+
+                    if (IsPathWithinPrefix(trimmed, AvatarPublicPrefix) || !IsPathWithinPrefix(trimmed, "/avatar"))
+                    {
+                        return trimmed;
+                    }
+
+                    WarnRestrictedAvatarSubscription(address, scope);
+                    return null;
+                    #endregion
+                }
+
+                bool restrictAvatarSubscriptions = scope == OscScope.Prop || scope == OscScope.Scene;
+                if (!restrictAvatarSubscriptions || IsPathWithinPrefix(trimmed, AvatarPublicPrefix) || !IsPathWithinPrefix(trimmed, "/avatar"))
+                {
+                    return trimmed;
+                }
+
+                WarnRestrictedAvatarSubscription(address, scope);
+                return null;
+                #endregion
+            }
+
+            trimmed = trimmed.TrimStart('/');
+            #region GetDefaultAvatarSubscriptionPrefix
+            string defaultPrefix;
+            if (TryGetOscScope(out OscScope defaultScope, out _))
+            {
+                if (localOnly && defaultScope == OscScope.AvatarRemote)
+                {
+                    return null;
+                }
+
+                defaultPrefix = defaultScope == OscScope.AvatarRemote || defaultScope == OscScope.Prop || defaultScope == OscScope.Scene
+                    ? AvatarPublicPrefix
+                    : AvatarParametersPrefix;
+            }
+            else
+            {
+                defaultPrefix = AvatarParametersPrefix;
+            }
+            #endregion
+
+            return trimmed.Length == 0 ? defaultPrefix : defaultPrefix + "/" + trimmed;
+        }
+
+        private string ResolvePublishAddress(string address)
+        {
+            if (string.IsNullOrWhiteSpace(address) || !TryGetOscScope(out OscScope scope, out string prefix))
+            {
+                return null;
+            }
+
+            string trimmed = address.Trim();
+            if (scope == OscScope.AvatarRemote)
+            {
+                return null;
+            }
+
+            if (scope == OscScope.AvatarLocal && IsPathWithinPrefix(trimmed, AvatarPublicPrefix))
+            {
+                return trimmed;
+            }
+
+            if (trimmed.StartsWith(prefix, StringComparison.Ordinal) &&
+                (trimmed.Length == prefix.Length || trimmed[prefix.Length] == '/'))
+            {
+                return trimmed;
+            }
+
+            trimmed = trimmed.TrimStart('/');
+            return trimmed.Length == 0 ? prefix : prefix + "/" + trimmed;
+        }
+
+        private void SubmitPublishedValuesToVixxy(string resolvedAddress, OscData[] values) => SubmitPublishedValueToVixxy(resolvedAddress, values[0]);
+
+
+        private void SubmitPublishedValueToVixxy(string resolvedAddress, OscData value)
+        {
+            if (string.IsNullOrWhiteSpace(resolvedAddress) || value == null)
+            {
+                return;
+            }
+
+            if (!TryReadVixxyFloat(value, out float floatValue))
+            {
+                return;
+            }
+
+            if (!TryResolveVixxyAddress(resolvedAddress, out string vixxyAddress))
+            {
+                return;
+            }
+
+            HVRVariableStore variableStore = GetVixxyVariableStore();
+            if (variableStore == null)
+            {
+                return;
+            }
+
+            variableStore.SubmitOrDefineDefaultValue(HVRAddress.AddressToId(vixxyAddress), floatValue);
+        }
+
+        private HVRVariableStore GetVixxyVariableStore()
+        {
+            HVRAvatarComms avatarComms = HVRCommsUtil.GetComms(this);
+            if (avatarComms != null && avatarComms.VariableStore != null)
+            {
+                return avatarComms.VariableStore;
+            }
+
+            return AcquisitionService.SceneInstance.VariableStore;
+        }
+
+        private static bool TryReadVixxyFloat(OscData value, out float floatValue)
+        {
+            switch (value.Kind)
+            {
+                case OscDataKind.Boolean:
+                    floatValue = value.BoolValue ? 1f : 0f;
+                    return true;
+                case OscDataKind.Int32:
+                    floatValue = value.IntValue;
+                    return true;
+                case OscDataKind.Int64:
+                    floatValue = value.LongValue;
+                    return true;
+                case OscDataKind.Float32:
+                    floatValue = value.FloatValue;
+                    return true;
+                case OscDataKind.Float64:
+                    floatValue = (float)value.DoubleValue;
+                    return true;
+                default:
+                    floatValue = 0f;
+                    return false;
+            }
+        }
+
+        private static bool TryResolveVixxyAddress(string resolvedAddress, out string vixxyAddress)
+        {
+            vixxyAddress = null;
+            if (string.IsNullOrWhiteSpace(resolvedAddress))
+            {
+                return false;
+            }
+
+            string trimmed = resolvedAddress.Trim();
+            if (IsPathWithinPrefix(trimmed, AvatarParametersPrefix))
+            {
+                vixxyAddress = TrimAddressPrefix(trimmed, AvatarParametersPrefix);
+                return !string.IsNullOrEmpty(vixxyAddress);
+            }
+
+            if (IsPathWithinPrefix(trimmed, AvatarPublicPrefix))
+            {
+                vixxyAddress = TrimAddressPrefix(trimmed, AvatarPublicPrefix);
+                return !string.IsNullOrEmpty(vixxyAddress);
+            }
+
+            const string parametersSegment = "/parameters/";
+            int parametersIndex = trimmed.IndexOf(parametersSegment, StringComparison.Ordinal);
+            if (parametersIndex >= 0)
+            {
+                vixxyAddress = trimmed.Substring(parametersIndex + parametersSegment.Length);
+                return !string.IsNullOrEmpty(vixxyAddress);
+            }
+
+            vixxyAddress = trimmed.TrimStart('/');
+            return !string.IsNullOrEmpty(vixxyAddress);
+        }
+
+        private static string TrimAddressPrefix(string address, string prefix)
+        {
+            if (address.Length == prefix.Length)
+            {
+                return string.Empty;
+            }
+
+            return address.Substring(prefix.Length).TrimStart('/');
+        }
+
+        private static bool IsPathWithinPrefix(string path, string prefix)
+        {
+            return path.StartsWith(prefix, StringComparison.Ordinal) &&
+                   (path.Length == prefix.Length || prefix[prefix.Length - 1] == '/' || path[prefix.Length] == '/');
+        }
+
+        private bool TryGetOscScope(out OscScope scope, out string prefix)
+        {
+            return TryGetOscScope(this, out scope, out prefix);
+        }
+
+        private static bool TryGetOscScope(BasisOsc shim, out OscScope scope, out string prefix)
+        {
+            scope = OscScope.None;
+            prefix = null;
+
+            for (Transform current = shim.transform; current != null; current = current.parent)
+            {
+                BasisProp prop = current.GetComponent<BasisProp>();
+                if (prop != null)
+                {
+                    scope = OscScope.Prop;
+                    prefix = PropPublishPrefix + "/" + GetScopedContentIdentifier(prop) + "/parameters";
+                    return true;
+                }
+
+                BasisScene sceneOnTransform = current.GetComponent<BasisScene>();
+                if (sceneOnTransform != null)
+                {
+                    scope = OscScope.Scene;
+                    prefix = ScenePublishPrefix + "/" + GetScopedContentIdentifier(sceneOnTransform) + "/parameters";
+                    return true;
+                }
+
+                BasisAvatar avatar = current.GetComponent<BasisAvatar>();
+                if (avatar != null)
+                {
+                    scope = avatar.IsOwnedLocally ? OscScope.AvatarLocal : OscScope.AvatarRemote;
+                    prefix = avatar.IsOwnedLocally ? AvatarParametersPrefix : null;
+                    return true;
+                }
+            }
+
+            if (BasisScene.SceneTraversalFindBasisScene(shim.gameObject, out BasisScene scene))
+            {
+                scope = OscScope.Scene;
+                prefix = ScenePublishPrefix + "/" + GetScopedContentIdentifier(scene) + "/parameters";
+                return true;
+            }
+
+            return false;
+        }
+
+        private OscScope GetCurrentScopeForInspector()
+        {
+            return GetCurrentScopeForInspector(this);
+        }
+
+        private static OscScope GetCurrentScopeForInspector(BasisOsc shim)
+        {
+            for (Transform current = shim.transform; current != null; current = current.parent)
+            {
+                if (current.GetComponent<BasisProp>() != null)
+                {
+                    return OscScope.Prop;
+                }
+
+                if (current.GetComponent<BasisScene>() != null)
+                {
+                    return OscScope.Scene;
+                }
+
+                BasisAvatar avatar = current.GetComponent<BasisAvatar>();
+                if (avatar != null)
+                {
+                    return avatar.IsOwnedLocally ? OscScope.AvatarLocal : OscScope.AvatarRemote;
+                }
+            }
+
+            if (BasisScene.SceneTraversalFindBasisScene(shim.gameObject, out _))
+            {
+                return OscScope.Scene;
+            }
+
+            return OscScope.None;
+        }
+
+        private static void WarnRestrictedAvatarSubscription(string address, OscScope scope)
+        {
+            Debug.LogWarning(
+                $"BasisOsc.NormalizeSubscriptionAddress rejected Subscribe address '{address}' for scope {GetScopeName(scope)}. " +
+                $"Only absolute {AvatarPublicPrefix}/* avatar subscriptions are allowed in this scope. " +
+                $"Use {AvatarPublicPrefix}/* or a relative address instead of {AvatarParametersPrefix}/*.");
+        }
+
+        private static string GetScopedContentIdentifier(BasisNetworkContentBase content)
+        {
+            if (content != null && content.TryGetNetworkGUIDIdentifier(out string identifier) && !string.IsNullOrWhiteSpace(identifier))
+            {
+                #region SanitizePathSegment
+                StringBuilder builder = new StringBuilder(identifier.Length);
+                for (int i = 0; i < identifier.Length; i++)
+                {
+                    char c = identifier[i];
+                    if (char.IsLetterOrDigit(c) || c == '-' || c == '_')
+                    {
+                        builder.Append(c);
+                    }
+                    else
+                    {
+                        builder.Append('_');
+                        builder.Append(((int)c).ToString("x4"));
+                    }
+                }
+
+                return builder.ToString();
+                #endregion
+            }
+
+            ulong fallbackId = content != null ? EntityId.ToULong(content.GetEntityId()) : 0ul;
+            return "local-" + fallbackId.ToString("x16");
+        }
+
+        private static void AddCallback<TDelegate>(Dictionary<string, TDelegate> callbacks, string key, TDelegate callback)
+            where TDelegate : Delegate
+        {
+            if (callback == null)
+            {
+                return;
+            }
+
+            if (callbacks.TryGetValue(key, out TDelegate existing))
+            {
+                foreach (Delegate handler in existing.GetInvocationList())
+                {
+                    if (Equals(handler, callback))
+                    {
+                        return;
+                    }
+                }
+
+                callbacks[key] = (TDelegate)Delegate.Combine(existing, callback);
+                return;
+            }
+
+            callbacks[key] = callback;
+        }
+
+        private static void RemoveCallback<TDelegate>(Dictionary<string, TDelegate> callbacks, string key, TDelegate callback)
+            where TDelegate : Delegate
+        {
+            if (callback == null)
+            {
+                callbacks.Remove(key);
+                return;
+            }
+
+            if (!callbacks.TryGetValue(key, out TDelegate existing))
+            {
+                return;
+            }
+
+            Delegate updated = Delegate.Remove(existing, callback);
+            if (updated == null)
+            {
+                callbacks.Remove(key);
+            }
+            else
+            {
+                callbacks[key] = (TDelegate)updated;
+            }
+        }
+    }
+}

--- a/Basis/Packages/com.basis.shim/Shims/BasisOsc.cs
+++ b/Basis/Packages/com.basis.shim/Shims/BasisOsc.cs
@@ -975,10 +975,11 @@ namespace Basis.Shims
 
         private static void WarnRestrictedAvatarSubscription(string address, OscScope scope)
         {
-            Debug.LogWarning(
+            BasisDebug.LogWarning(
                 $"BasisOsc.NormalizeSubscriptionAddress rejected Subscribe address '{address}' for scope {GetScopeName(scope)}. " +
                 $"Only absolute {AvatarPublicPrefix}/* avatar subscriptions are allowed in this scope. " +
-                $"Use {AvatarPublicPrefix}/* or a relative address instead of {AvatarParametersPrefix}/*.");
+                $"Use {AvatarPublicPrefix}/* or a relative address instead of {AvatarParametersPrefix}/*.",
+                BasisDebug.LogTag.Shims);
         }
 
         private static string GetScopedContentIdentifier(BasisNetworkContentBase content)

--- a/Basis/Packages/com.basis.shim/Shims/BasisOsc.cs.meta
+++ b/Basis/Packages/com.basis.shim/Shims/BasisOsc.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 04f2bc2b96514b4589f0c5f1e1c6840d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Basis/Packages/com.basis.shim/Shims/CilboxBasisCommon.cs
+++ b/Basis/Packages/com.basis.shim/Shims/CilboxBasisCommon.cs
@@ -17,10 +17,12 @@ namespace Cilbox
 			"Basis.Scripts.BasisSdk.Interactions.BasisPickupInteractable", // Restrictive (See below), only access field.
 			"Basis.Scripts.BasisSdk.Interactions.BasisInteractableObject", // Restrictive (See below), only access field.
 			"Basis.BasisNetworkBehaviour",
+			"Basis.Shims.BasisOsc*",
 			"Basis.Network.Core.DeliveryMethod",
 			"Basis.SafeUtil",
 			"Basis.Scripts.BasisSdk.Players.BasisLocalPlayer",
 			"Basis.Scripts.Networking.NetworkedAvatar.BasisNetworkPlayer",
+			"HVR.Basis.Comms.OSC*",
 
 			// Cilbox types
 			"Cilbox.CilboxPublicUtils",

--- a/Basis/Packages/com.basis.shim/Shims/CilboxSceneBasis.cs
+++ b/Basis/Packages/com.basis.shim/Shims/CilboxSceneBasis.cs
@@ -19,6 +19,9 @@ namespace Cilbox
 			"BasisNetworkCommon+EventTiming",
 			"BasisSDKMirror",
 			"BasisSDKMirror+MirrorClearFlags",
+			"HVR.Basis.Comms.OSC.OscData",
+			"HVR.Basis.Comms.OSC.OscDataKind",
+			"HVR.Basis.Comms.OSC.OscMessage",
 			"Basis.Shims.*",
 
 			// System IO

--- a/Basis/Packages/com.basis.shim/Shims/Editor.meta
+++ b/Basis/Packages/com.basis.shim/Shims/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 76e9fa1f16266604bbc09b9ed256a3c0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Basis/Packages/com.basis.shim/Shims/Editor/BasisOscEditor.cs
+++ b/Basis/Packages/com.basis.shim/Shims/Editor/BasisOscEditor.cs
@@ -1,0 +1,154 @@
+#if UNITY_EDITOR
+using Basis.Scripts.BasisSdk;
+using UnityEditor;
+using UnityEngine;
+
+namespace Basis.Shims.Editor
+{
+    [CustomEditor(typeof(BasisOsc))]
+    internal class BasisOscEditor : UnityEditor.Editor
+    {
+        private bool _showExactSubscriptions = true;
+        private bool _showExactRegistrations = true;
+        private bool _showPrefixSubscriptions = true;
+        private bool _showPrefixRegistrations = true;
+        private BasisOsc.InspectorState _cachedState;
+        private int _cachedStateKey;
+        private EntityId _cachedTargetEntityId;
+        private bool _hasCachedState;
+        private bool _cachedPlayModeState;
+
+        public override void OnInspectorGUI()
+        {
+            BasisOsc osc = (BasisOsc)target;
+            RefreshInspectorState(osc);
+            BasisOsc.InspectorState state = _cachedState;
+
+            DrawScriptField(osc);
+            EditorGUILayout.Space();
+
+            EditorGUILayout.LabelField("OSC State", EditorStyles.boldLabel);
+            using (new EditorGUI.DisabledScope(true))
+            {
+                EditorGUILayout.Toggle("Active And Enabled", state.IsActiveAndEnabled);
+                EditorGUILayout.Toggle("Receive All", state.ReceiveAll);
+                EditorGUILayout.Toggle("Can Publish", state.CanPublish);
+                EditorGUILayout.TextField("Entity Id", state.EntityId ?? string.Empty);
+                EditorGUILayout.TextField("Scope", state.ScopeName ?? "None");
+                EditorGUILayout.TextField("Publish Prefix", state.PublishPrefix ?? "Unavailable");
+                EditorGUILayout.TextField("Default Subscribe Prefix", state.DefaultSubscriptionPrefix ?? string.Empty);
+                EditorGUILayout.IntField("OnMessage Listeners", state.OnMessageListenerCount);
+            }
+
+            if (!state.HasScope)
+            {
+                EditorGUILayout.HelpBox(
+                    "No OSC scope was resolved from a BasisAvatar, BasisProp, or BasisScene ancestor. Relative addresses will default to /avatar/parameters until the object is under a recognized scope.",
+                    MessageType.Info);
+            }
+
+            EditorGUILayout.Space();
+            EditorGUILayout.LabelField("Subscription Counts", EditorStyles.boldLabel);
+            using (new EditorGUI.DisabledScope(true))
+            {
+                EditorGUILayout.IntField("Exact Total", state.ExactSubscriptions.Length);
+                EditorGUILayout.IntField("Exact Message Callback Addresses", state.ExactCallbackCount);
+                EditorGUILayout.IntField("Exact Value Callback Addresses", state.ExactValueCallbackCount);
+                EditorGUILayout.IntField("Prefix Total", state.PrefixSubscriptions.Length);
+                EditorGUILayout.IntField("Prefix Message Callback Addresses", state.PrefixCallbackCount);
+                EditorGUILayout.IntField("Prefix Value Callback Addresses", state.PrefixValueCallbackCount);
+            }
+
+            EditorGUILayout.Space();
+            _showExactSubscriptions = EditorGUILayout.BeginFoldoutHeaderGroup(_showExactSubscriptions, $"Exact Subscriptions ({state.ExactSubscriptions.Length})");
+            if (_showExactSubscriptions)
+            {
+                DrawStringList(state.ExactSubscriptions, "No exact subscriptions registered.");
+            }
+            EditorGUILayout.EndFoldoutHeaderGroup();
+
+            _showExactRegistrations = EditorGUILayout.BeginFoldoutHeaderGroup(_showExactRegistrations, $"Exact Registration Sources ({state.ExactRegistrationLines.Length})");
+            if (_showExactRegistrations)
+            {
+                DrawStringList(state.ExactRegistrationLines, "No exact registration sources tracked.");
+            }
+            EditorGUILayout.EndFoldoutHeaderGroup();
+
+            _showPrefixSubscriptions = EditorGUILayout.BeginFoldoutHeaderGroup(_showPrefixSubscriptions, $"Prefix Subscriptions ({state.PrefixSubscriptions.Length})");
+            if (_showPrefixSubscriptions)
+            {
+                DrawStringList(state.PrefixSubscriptions, "No prefix subscriptions registered.");
+            }
+            EditorGUILayout.EndFoldoutHeaderGroup();
+
+            _showPrefixRegistrations = EditorGUILayout.BeginFoldoutHeaderGroup(_showPrefixRegistrations, $"Prefix Registration Sources ({state.PrefixRegistrationLines.Length})");
+            if (_showPrefixRegistrations)
+            {
+                DrawStringList(state.PrefixRegistrationLines, "No prefix registration sources tracked.");
+            }
+            EditorGUILayout.EndFoldoutHeaderGroup();
+
+            if (!Application.isPlaying)
+            {
+                EditorGUILayout.Space();
+                EditorGUILayout.HelpBox("Subscription lists are most useful in play mode after runtime subscriptions have been registered.", MessageType.None);
+            }
+        }
+
+        public override bool RequiresConstantRepaint()
+        {
+            return Application.isPlaying;
+        }
+
+        private void RefreshInspectorState(BasisOsc osc)
+        {
+            if (osc == null)
+            {
+                _cachedState = null;
+                _hasCachedState = false;
+                return;
+            }
+
+            bool isPlaying = Application.isPlaying;
+            int stateKey = osc.GetInspectorCacheKey();
+            EntityId targetEntityId = osc.GetEntityId();
+            if (_hasCachedState && _cachedState != null && _cachedStateKey == stateKey && _cachedPlayModeState == isPlaying && _cachedTargetEntityId.Equals(targetEntityId))
+            {
+                return;
+            }
+
+            _cachedState = osc.GetInspectorState();
+            _cachedStateKey = stateKey;
+            _cachedTargetEntityId = targetEntityId;
+            _cachedPlayModeState = isPlaying;
+            _hasCachedState = true;
+        }
+
+        private static void DrawScriptField(BasisOsc osc)
+        {
+            using (new EditorGUI.DisabledScope(true))
+            {
+                MonoScript script = MonoScript.FromMonoBehaviour(osc);
+                EditorGUILayout.ObjectField("Script", script, typeof(MonoScript), false);
+            }
+        }
+
+        private static void DrawStringList(string[] values, string emptyMessage)
+        {
+            if (values == null || values.Length == 0)
+            {
+                EditorGUILayout.HelpBox(emptyMessage, MessageType.None);
+                return;
+            }
+
+            using (new EditorGUI.DisabledScope(true))
+            {
+                for (int i = 0; i < values.Length; i++)
+                {
+                    EditorGUILayout.TextField(values[i] ?? string.Empty);
+                }
+            }
+        }
+    }
+}
+#endif

--- a/Basis/Packages/com.basis.shim/Shims/Editor/BasisOscEditor.cs
+++ b/Basis/Packages/com.basis.shim/Shims/Editor/BasisOscEditor.cs
@@ -23,6 +23,12 @@ namespace Basis.Shims.Editor
             BasisOsc osc = (BasisOsc)target;
             RefreshInspectorState(osc);
             BasisOsc.InspectorState state = _cachedState;
+            if (state == null)
+            {
+                EditorGUILayout.HelpBox("Inspector state is unavailable.", MessageType.Warning);
+                DrawScriptField(osc);
+                return;
+            }
 
             DrawScriptField(osc);
             EditorGUILayout.Space();

--- a/Basis/Packages/com.basis.shim/Shims/Editor/BasisOscEditor.cs
+++ b/Basis/Packages/com.basis.shim/Shims/Editor/BasisOscEditor.cs
@@ -149,7 +149,8 @@ namespace Basis.Shims.Editor
 
             using (new EditorGUI.DisabledScope(true))
             {
-                for (int i = 0; i < values.Length; i++)
+                int valueCount = values.Length;
+                for (int i = 0; i < valueCount; i++)
                 {
                     EditorGUILayout.TextField(values[i] ?? string.Empty);
                 }

--- a/Basis/Packages/com.basis.shim/Shims/Editor/BasisOscEditor.cs.meta
+++ b/Basis/Packages/com.basis.shim/Shims/Editor/BasisOscEditor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d7b7a3a2b095f1c43946040737d288f4

--- a/Basis/Packages/com.basis.shim/Shims/link.xml
+++ b/Basis/Packages/com.basis.shim/Shims/link.xml
@@ -256,6 +256,7 @@
         <type fullname="Basis.BasisUrl" preserve="all"/>
         <type fullname="Basis.IBasisImageDownload" preserve="all"/>
         <type fullname="Basis.SafeUtil" preserve="all"/>
+        <type fullname="Basis.Shims.BasisOsc*" preserve="all"/>
     </assembly>
     <assembly fullname="Basis Framework">
         <type fullname="Basis.BasisNetworkBehaviour" preserve="all"/>
@@ -276,5 +277,11 @@
         <type fullname="TMPro.TMP_Text" preserve="all"/>
         <type fullname="TMPro.TMP_Dropdown" preserve="all"/>
         <type fullname="TMPro.TMP_InputField" preserve="all"/>
+    </assembly>
+    <assembly fullname="HVR.Basis.Comms">
+        <type fullname="HVR.Vixxy.HVRVixxyMenuItem" preserve="all"/>
+        <type fullname="HVR.Basis.Comms.OSC.OscData" preserve="all"/>
+        <type fullname="HVR.Basis.Comms.OSC.OscDataKind" preserve="all"/>
+        <type fullname="HVR.Basis.Comms.OSC.OscMessage" preserve="all"/>
     </assembly>
 </linker>

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Editor/OSCAcquisitionServerEditor.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Editor/OSCAcquisitionServerEditor.cs
@@ -1,4 +1,5 @@
-﻿using UnityEditor;
+using System.Collections.Generic;
+using UnityEditor;
 using UnityEngine;
 
 namespace HVR.Basis.Comms.Editor
@@ -6,22 +7,43 @@ namespace HVR.Basis.Comms.Editor
     [CustomEditor(typeof(OSCAcquisitionServer))]
     public class OSCAcquisitionServerEditor : UnityEditor.Editor
     {
+        private readonly List<KeyValuePair<string, int>> _exactSubscriptionCounts = new();
+        private readonly List<KeyValuePair<string, int>> _prefixSubscriptionCounts = new();
+
         public override void OnInspectorGUI()
         {
             DrawDefaultInspector();
 
-            if (Application.isPlaying)
+            if (!Application.isPlaying)
             {
-                var my = (OSCAcquisitionServer)target;
+                return;
+            }
 
-                EditorGUILayout.LabelField("Received addresses / Count", EditorStyles.boldLabel);
-                foreach (var debugUpdate in my._debugUpdates)
-                {
-                    EditorGUILayout.BeginHorizontal();
-                    EditorGUILayout.TextField(debugUpdate.Key);
-                    EditorGUILayout.LabelField(debugUpdate.Value.ToString(), GUILayout.Width(50));
-                    EditorGUILayout.EndHorizontal();
-                }
+            var my = (OSCAcquisitionServer)target;
+            my.CopyDebugSubscriptionCounts(_exactSubscriptionCounts, _prefixSubscriptionCounts);
+
+            EditorGUILayout.LabelField("Exact subscriptions / Count", EditorStyles.boldLabel);
+            DrawCounts(_exactSubscriptionCounts);
+
+            EditorGUILayout.Space();
+            EditorGUILayout.LabelField("Prefix subscriptions / Count", EditorStyles.boldLabel);
+            DrawCounts(_prefixSubscriptionCounts);
+        }
+
+        private static void DrawCounts(List<KeyValuePair<string, int>> counts)
+        {
+            if (counts.Count == 0)
+            {
+                EditorGUILayout.LabelField("None");
+                return;
+            }
+
+            foreach (KeyValuePair<string, int> count in counts)
+            {
+                EditorGUILayout.BeginHorizontal();
+                EditorGUILayout.TextField(count.Key);
+                EditorGUILayout.LabelField(count.Value.ToString(), GUILayout.Width(50));
+                EditorGUILayout.EndHorizontal();
             }
         }
     }

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Editor/OSCAcquisitionServerEditor.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Editor/OSCAcquisitionServerEditor.cs
@@ -41,7 +41,7 @@ namespace HVR.Basis.Comms.Editor
             foreach (KeyValuePair<string, int> count in counts)
             {
                 EditorGUILayout.BeginHorizontal();
-                EditorGUILayout.TextField(count.Key);
+                EditorGUILayout.SelectableLabel(count.Key, EditorStyles.textField, GUILayout.Height(EditorGUIUtility.singleLineHeight));
                 EditorGUILayout.LabelField(count.Value.ToString(), GUILayout.Width(50));
                 EditorGUILayout.EndHorizontal();
             }

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/Components/Acquisition/OSCAcquisition.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/Components/Acquisition/OSCAcquisition.cs
@@ -33,12 +33,12 @@ namespace HVR.Basis.Comms
             if (!isWearer) return;
 
             if (_alreadyInitialized) return;
-            _alreadyInitialized = true;
 
             _acquisitionServer = OSCAcquisitionServer.SceneInstance;
             _acquisitionServer.SendWakeUpMessage(FakeWakeUpMessage);
             BasisOscService.RegisterAddressReceiver(_oscOwnerId, OnOscAddressUpdated);
             BasisOscService.UpdateSubscriptions(_oscOwnerId, true, Array.Empty<string>(), Array.Empty<string>());
+            _alreadyInitialized = true;
         }
 
         private void OnDestroy()
@@ -48,8 +48,11 @@ namespace HVR.Basis.Comms
                 avatar.OnAvatarReady -= OnAvatarReady;
             }
 
-            BasisOscService.UnregisterAddressReceiver(_oscOwnerId);
-            BasisOscService.ClearSubscriptions(_oscOwnerId);
+            if (_alreadyInitialized)
+            {
+                BasisOscService.UnregisterAddressReceiver(_oscOwnerId);
+                BasisOscService.ClearSubscriptions(_oscOwnerId);
+            }
         }
 
         private void OnOscAddressUpdated(int address, float value)
@@ -57,7 +60,7 @@ namespace HVR.Basis.Comms
             if (!isActiveAndEnabled) return;
 
             _activityRelay?.NotifySourceSample();
-            acquisitionService.Submit(address, value);
-        }
+            acquisitionService?.Submit(address, value);
+        }    
     }
 }

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/Components/Acquisition/OSCAcquisition.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/Components/Acquisition/OSCAcquisition.cs
@@ -1,3 +1,4 @@
+using System;
 using Basis.Scripts.BasisSdk;
 using UnityEngine;
 
@@ -14,12 +15,14 @@ namespace HVR.Basis.Comms
         private OSCAcquisitionServer _acquisitionServer;
         private bool _alreadyInitialized;
         private FaceTrackingActivityRelay _activityRelay;
+        private EntityId _oscOwnerId;
 
         private void Awake()
         {
             if (avatar == null) avatar = HVRCommsUtil.GetAvatar(this);
             if (acquisitionService == null) acquisitionService = AcquisitionService.SceneInstance;
             _activityRelay = FaceTrackingActivityRelay.GetOrCreate(avatar);
+            _oscOwnerId = gameObject.GetEntityId();
 
             avatar.OnAvatarReady -= OnAvatarReady;
             avatar.OnAvatarReady += OnAvatarReady;
@@ -34,31 +37,27 @@ namespace HVR.Basis.Comms
 
             _acquisitionServer = OSCAcquisitionServer.SceneInstance;
             _acquisitionServer.SendWakeUpMessage(FakeWakeUpMessage);
-
-            _acquisitionServer.OnAddressUpdated -= OnAddressUpdated;
-            _acquisitionServer.OnAddressUpdated += OnAddressUpdated;
+            BasisOscService.RegisterAddressReceiver(_oscOwnerId, OnOscAddressUpdated);
+            BasisOscService.UpdateSubscriptions(_oscOwnerId, true, Array.Empty<string>(), Array.Empty<string>());
         }
 
         private void OnDestroy()
         {
-            avatar.OnAvatarReady -= OnAvatarReady;
-
-            if (_acquisitionServer != null)
-            {
-                _acquisitionServer.OnAddressUpdated -= OnAddressUpdated;
-            }
             if (avatar != null)
             {
                 avatar.OnAvatarReady -= OnAvatarReady;
             }
+
+            BasisOscService.UnregisterAddressReceiver(_oscOwnerId);
+            BasisOscService.ClearSubscriptions(_oscOwnerId);
         }
 
-        private void OnAddressUpdated(string address, float value)
+        private void OnOscAddressUpdated(int address, float value)
         {
             if (!isActiveAndEnabled) return;
 
             _activityRelay?.NotifySourceSample();
-            acquisitionService.Submit(HVRAddress.AddressToId(address), value);
+            acquisitionService.Submit(address, value);
         }
     }
 }

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/Components/Acquisition/OSCAcquisitionServer.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/Components/Acquisition/OSCAcquisitionServer.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 namespace HVR.Basis.Comms
 {
     [AddComponentMenu("HVR.Basis/Comms/Internal/OSC Acquisition Server")]
-    internal class OSCAcquisitionServer : MonoBehaviour
+    public class OSCAcquisitionServer : MonoBehaviour
     {
         public static OSCAcquisitionServer SceneInstance => HVRCommsUtil.GetOrCreateSceneInstance(ref _sceneInstance);
         private static OSCAcquisitionServer _sceneInstance;
@@ -30,6 +30,16 @@ namespace HVR.Basis.Comms
         private readonly Dictionary<EntityId, SubscriptionSnapshot> _subscriptionSnapshots = new Dictionary<EntityId, SubscriptionSnapshot>();
         private readonly Dictionary<string, int> _exactSubscriptionCounts = new Dictionary<string, int>(StringComparer.Ordinal);
         private readonly Dictionary<string, int> _prefixSubscriptionCounts = new Dictionary<string, int>(StringComparer.Ordinal);
+
+        public static void Simulate()
+        {
+            if (_sceneInstance == null)
+            {
+                return;
+            }
+
+            _sceneInstance.SimulateInstance();
+        }
 
         private sealed class SubscriptionSnapshot
         {
@@ -98,7 +108,7 @@ namespace HVR.Basis.Comms
             }
         }
 
-        private void Update()
+        private void SimulateInstance()
         {
             if (_client == null) return;
 
@@ -289,7 +299,8 @@ namespace HVR.Basis.Comms
             string[] segments = requestPath.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
             OsushiNode current = _oscQueryRoot;
 
-            for (int i = 0; i < segments.Length; i++)
+            int segmentCount = segments.Length;
+            for (int i = 0; i < segmentCount; i++)
             {
                 if (current.CONTENTS == null || !current.CONTENTS.TryGetValue(segments[i], out current))
                 {
@@ -571,7 +582,8 @@ namespace HVR.Basis.Comms
                 return;
             }
 
-            for (int i = 0; i < values.Length; i++)
+            int valueCount = values.Length;
+            for (int i = 0; i < valueCount; i++)
             {
                 OscData value = values[i];
                 if (value == null)
@@ -600,7 +612,8 @@ namespace HVR.Basis.Comms
                 return result;
             }
 
-            for (int i = 0; i < values.Length; i++)
+            int valueCount = values.Length;
+            for (int i = 0; i < valueCount; i++)
             {
                 result.Add(values[i]?.ToQueryValue());
             }
@@ -615,8 +628,9 @@ namespace HVR.Basis.Comms
                 return Array.Empty<object>();
             }
 
-            object[] result = new object[values.Length];
-            for (int i = 0; i < values.Length; i++)
+            int valueCount = values.Length;
+            object[] result = new object[valueCount];
+            for (int i = 0; i < valueCount; i++)
             {
                 result[i] = values[i]?.ToOscArgument();
             }

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/Components/Acquisition/OSCAcquisitionServer.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/Components/Acquisition/OSCAcquisitionServer.cs
@@ -18,8 +18,10 @@ namespace HVR.Basis.Comms
         private OsushiQuery _osushi;
         private const int OurFakeServerPort = 9000;
         private const int ExternalProgramReceiverPort = 9001;
+        // Access levels for OSC query nodes. These are arbitrary values that the server uses to indicate the meaning of nodes to clients.
         private const int SubscriptionAccess = 2;
         private const int PublishAccess = 3;
+
         private bool _settingSubscribed;
         private bool _running;
         private string _lastWakeUp;
@@ -77,7 +79,7 @@ namespace HVR.Basis.Comms
             }
             catch (Exception e)
             {
-                Debug.LogWarning($"Failed to start OSC client ({e.Message}");
+                Debug.LogWarning($"Failed to start OSC client ({e.Message})");
                 StopClient();
             }
         }
@@ -131,7 +133,7 @@ namespace HVR.Basis.Comms
                 }
                 catch (Exception e)
                 {
-                    Debug.LogWarning($"Failed to close client ({e.Message}");
+                    Debug.LogWarning($"Failed to close client ({e.Message})");
                 }
                 _client = null;
             }
@@ -144,7 +146,7 @@ namespace HVR.Basis.Comms
                 }
                 catch (Exception e)
                 {
-                    Debug.LogWarning($"Failed to close osushi service ({e.Message}");
+                    Debug.LogWarning($"Failed to close osushi service ({e.Message})");
                 }
                 _osushi = null;
             }
@@ -162,7 +164,7 @@ namespace HVR.Basis.Comms
             }
             catch (Exception e)
             {
-                Debug.LogWarning($"Failed to send wake up message ({e.Message}");
+                Debug.LogWarning($"Failed to send wake up message ({e.Message})");
             }
         }
 
@@ -196,7 +198,7 @@ namespace HVR.Basis.Comms
                 }
                 catch (Exception e)
                 {
-                    Debug.LogWarning($"Failed to publish OSC value ({e.Message}");
+                    Debug.LogWarning($"Failed to publish OSC value ({e.Message})");
                 }
             }
         }
@@ -471,7 +473,7 @@ namespace HVR.Basis.Comms
         private void RemoveExactSubscriptionNode(string fullPath)
         {
             OsushiNode node = ResolveQueryNode(fullPath);
-            if (node == null)
+            if (node == null || node == _oscQueryRoot || node.FULL_PATH != fullPath)
             {
                 return;
             }

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/Components/Acquisition/OSCAcquisitionServer.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/Components/Acquisition/OSCAcquisitionServer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Basis.BasisUI;
 using HVR.Basis.Comms.OSC;
@@ -18,14 +18,22 @@ namespace HVR.Basis.Comms
         private OsushiQuery _osushi;
         private const int OurFakeServerPort = 9000;
         private const int ExternalProgramReceiverPort = 9001;
+        private const int SubscriptionAccess = 2;
+        private const int PublishAccess = 3;
         private bool _settingSubscribed;
         private bool _running;
         private string _lastWakeUp;
+        private readonly object _queryLock = new object();
+        private OsushiNode _oscQueryRoot;
+        private readonly Dictionary<EntityId, SubscriptionSnapshot> _subscriptionSnapshots = new Dictionary<EntityId, SubscriptionSnapshot>();
+        private readonly Dictionary<string, int> _exactSubscriptionCounts = new Dictionary<string, int>(StringComparer.Ordinal);
+        private readonly Dictionary<string, int> _prefixSubscriptionCounts = new Dictionary<string, int>(StringComparer.Ordinal);
 
-        public event AddressUpdated OnAddressUpdated;
-        public delegate void AddressUpdated(string address, float value);
-
-        internal Dictionary<string, int> _debugUpdates = new();
+        private sealed class SubscriptionSnapshot
+        {
+            public HashSet<string> ExactAddresses { get; } = new HashSet<string>(StringComparer.Ordinal);
+            public HashSet<string> PrefixAddresses { get; } = new HashSet<string>(StringComparer.Ordinal);
+        }
 
         private void OnEnable()
         {
@@ -37,7 +45,6 @@ namespace HVR.Basis.Comms
 
             if (!BasisSettingsDefaults.EnableOSC.RawValue)
             {
-                // OSC is turned off in settings — stay idle until the user enables it.
                 return;
             }
 
@@ -54,22 +61,22 @@ namespace HVR.Basis.Comms
                 _client.Start();
                 _client.SetReceiverOscPort(ExternalProgramReceiverPort);
 
-                var root = OsushiUtil.CreateFaceTrackingNodes();
-                var rootText = JsonConvert.SerializeObject(root, Formatting.Indented);
-                var avtrText = JsonConvert.SerializeObject(root.CONTENTS["avatar"], Formatting.Indented);
-                _osushi = new OsushiQuery(rootText, avtrText);
+                lock (_queryLock)
+                {
+                    EnsureOscQueryRoot();
+                    _osushi = new OsushiQuery(GetOscQueryResponse);
+                }
+
                 _osushi.Start();
                 _running = true;
 
                 if (_lastWakeUp != null)
                 {
-                    // Re-announce avatar presence after a toggle-off/toggle-on cycle.
                     SendWakeUpMessage(_lastWakeUp);
                 }
             }
             catch (Exception e)
             {
-                // Prevent avatar loading failure (i.e. there are two OSC clients opened on this device)
                 Debug.LogWarning($"Failed to start OSC client ({e.Message}");
                 StopClient();
             }
@@ -93,32 +100,9 @@ namespace HVR.Basis.Comms
         {
             if (_client == null) return;
 
-            var messages = _client.PullMessages();
-            foreach (var message in messages)
-            {
-                if (message.arguments.Length > 0)
-                {
-                    var arg = message.arguments[0];
-                    if (arg is float floatValue)
-                    {
-                        if (_debugUpdates.TryGetValue(message.path, out var count))
-                        {
-                            _debugUpdates[message.path] = count + 1;
-                        }
-                        else
-                        {
-                            _debugUpdates.Add(message.path, 1);
-                        }
-
-                        var messagePath = message.path;
-                        if (messagePath.StartsWith("/avatar/parameters/"))
-                        {
-                            messagePath = messagePath.Substring(19);
-                        }
-                        OnAddressUpdated?.Invoke(messagePath, floatValue);
-                    }
-                }
-            }
+            // Hybrid design: background thread receives/decodes UDP, main thread routes callbacks.
+            var messages = _client.DrainReceivedMessages();
+            BasisOscService.SubmitRawMessages(messages);
         }
 
         private void OnDisable()
@@ -147,7 +131,6 @@ namespace HVR.Basis.Comms
                 }
                 catch (Exception e)
                 {
-                    // Prevent avatar loading failure (i.e. there are two OSC clients opened on this device)
                     Debug.LogWarning($"Failed to close client ({e.Message}");
                 }
                 _client = null;
@@ -161,7 +144,6 @@ namespace HVR.Basis.Comms
                 }
                 catch (Exception e)
                 {
-                    // Prevent avatar loading failure
                     Debug.LogWarning($"Failed to close osushi service ({e.Message}");
                 }
                 _osushi = null;
@@ -180,9 +162,464 @@ namespace HVR.Basis.Comms
             }
             catch (Exception e)
             {
-                // Prevent avatar loading failure (i.e. there are two OSC clients opened on this device)
                 Debug.LogWarning($"Failed to send wake up message ({e.Message}");
             }
+        }
+
+        public void PublishValue(string address, OscData value)
+        {
+            PublishValues(address, value == null ? Array.Empty<OscData>() : new[] { value });
+        }
+
+        public void PublishValues(string address, OscData[] values)
+        {
+            string normalizedAddress = NormalizeQueryAddress(address);
+            if (normalizedAddress == null)
+            {
+                return;
+            }
+
+            lock (_queryLock)
+            {
+                EnsureOscQueryRoot();
+                OsushiNode leaf = EnsureQueryNode(normalizedAddress);
+                leaf.ACCESS = PublishAccess;
+                leaf.TYPE = BuildTypeTag(values);
+                leaf.VALUE = BuildQueryValues(values);
+            }
+
+            if (_client != null)
+            {
+                try
+                {
+                    _client.SendOscMultivalue(normalizedAddress, BuildOscArguments(values));
+                }
+                catch (Exception e)
+                {
+                    Debug.LogWarning($"Failed to publish OSC value ({e.Message}");
+                }
+            }
+        }
+
+        public void UpdateSubscriptions(EntityId ownerId, IEnumerable<string> subscribedAddresses, IEnumerable<string> subscribedPrefixes)
+        {
+            lock (_queryLock)
+            {
+                EnsureOscQueryRoot();
+
+                SubscriptionSnapshot next = CreateSnapshot(subscribedAddresses, subscribedPrefixes);
+                _subscriptionSnapshots.TryGetValue(ownerId, out SubscriptionSnapshot previous);
+
+                UpdateSubscriptionCounts(previous?.ExactAddresses, next.ExactAddresses, _exactSubscriptionCounts, EnsureExactSubscriptionNode, RemoveExactSubscriptionNode);
+                UpdateSubscriptionCounts(previous?.PrefixAddresses, next.PrefixAddresses, _prefixSubscriptionCounts, EnsurePrefixSubscriptionNode, RemovePrefixSubscriptionNode);
+
+                if (next.ExactAddresses.Count == 0 && next.PrefixAddresses.Count == 0)
+                {
+                    _subscriptionSnapshots.Remove(ownerId);
+                }
+                else
+                {
+                    _subscriptionSnapshots[ownerId] = next;
+                }
+            }
+        }
+
+        public void ClearSubscriptions(EntityId ownerId)
+        {
+            lock (_queryLock)
+            {
+                if (!_subscriptionSnapshots.TryGetValue(ownerId, out SubscriptionSnapshot previous))
+                {
+                    return;
+                }
+
+                UpdateSubscriptionCounts(previous.ExactAddresses, null, _exactSubscriptionCounts, EnsureExactSubscriptionNode, RemoveExactSubscriptionNode);
+                UpdateSubscriptionCounts(previous.PrefixAddresses, null, _prefixSubscriptionCounts, EnsurePrefixSubscriptionNode, RemovePrefixSubscriptionNode);
+                _subscriptionSnapshots.Remove(ownerId);
+            }
+        }
+
+        internal void CopyDebugSubscriptionCounts(List<KeyValuePair<string, int>> exactCounts, List<KeyValuePair<string, int>> prefixCounts)
+        {
+            lock (_queryLock)
+            {
+                exactCounts.Clear();
+                prefixCounts.Clear();
+
+                foreach (KeyValuePair<string, int> count in _exactSubscriptionCounts)
+                {
+                    exactCounts.Add(count);
+                }
+
+                foreach (KeyValuePair<string, int> count in _prefixSubscriptionCounts)
+                {
+                    prefixCounts.Add(count);
+                }
+            }
+        }
+
+        private string GetOscQueryResponse(string rawUrl)
+        {
+            lock (_queryLock)
+            {
+                EnsureOscQueryRoot();
+                OsushiNode payload = ResolveQueryNode(rawUrl) ?? _oscQueryRoot;
+                return JsonConvert.SerializeObject(payload, Formatting.Indented);
+            }
+        }
+
+        private void EnsureOscQueryRoot()
+        {
+            if (_oscQueryRoot == null)
+            {
+                _oscQueryRoot = OsushiUtil.CreateFaceTrackingNodes();
+            }
+        }
+
+        private OsushiNode ResolveQueryNode(string rawUrl)
+        {
+            string requestPath = NormalizeRequestPath(rawUrl);
+            if (string.IsNullOrEmpty(requestPath) || requestPath == "/")
+            {
+                return _oscQueryRoot;
+            }
+
+            string[] segments = requestPath.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+            OsushiNode current = _oscQueryRoot;
+
+            for (int i = 0; i < segments.Length; i++)
+            {
+                if (current.CONTENTS == null || !current.CONTENTS.TryGetValue(segments[i], out current))
+                {
+                    return _oscQueryRoot;
+                }
+            }
+
+            return current;
+        }
+
+        private static string NormalizeRequestPath(string rawUrl)
+        {
+            if (string.IsNullOrWhiteSpace(rawUrl))
+            {
+                return "/";
+            }
+
+            int queryIndex = rawUrl.IndexOf('?');
+            string path = queryIndex >= 0 ? rawUrl.Substring(0, queryIndex) : rawUrl;
+            return path.StartsWith("/", StringComparison.Ordinal) ? path : "/" + path;
+        }
+
+        private static string NormalizeQueryAddress(string address)
+        {
+            if (string.IsNullOrWhiteSpace(address))
+            {
+                return null;
+            }
+
+            string trimmed = address.Trim();
+            if (trimmed.StartsWith("/", StringComparison.Ordinal))
+            {
+                return trimmed;
+            }
+
+            return "/avatar/parameters/" + trimmed;
+        }
+
+        private static string NormalizeSubscriptionPath(string address)
+        {
+            if (string.IsNullOrWhiteSpace(address))
+            {
+                return null;
+            }
+
+            string normalized = address.Trim();
+            if (!normalized.StartsWith("/", StringComparison.Ordinal))
+            {
+                normalized = "/" + normalized;
+            }
+
+            while (normalized.Length > 1 && normalized.EndsWith("/", StringComparison.Ordinal))
+            {
+                normalized = normalized.Substring(0, normalized.Length - 1);
+            }
+
+            return normalized;
+        }
+
+        private OsushiNode EnsureQueryNode(string fullPath)
+        {
+            string[] segments = fullPath.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+            OsushiNode current = _oscQueryRoot;
+            string currentPath = string.Empty;
+
+            foreach (string segment in segments)
+            {
+                current.CONTENTS ??= new Dictionary<string, OsushiNode>();
+                currentPath += "/" + segment;
+                if (!current.CONTENTS.TryGetValue(segment, out OsushiNode next))
+                {
+                    next = new OsushiNode
+                    {
+                        FULL_PATH = currentPath,
+                        ACCESS = 0,
+                    };
+                    current.CONTENTS[segment] = next;
+                }
+
+                current = next;
+            }
+
+            current.FULL_PATH = fullPath;
+            return current;
+        }
+
+        private SubscriptionSnapshot CreateSnapshot(IEnumerable<string> subscribedAddresses, IEnumerable<string> subscribedPrefixes)
+        {
+            SubscriptionSnapshot snapshot = new SubscriptionSnapshot();
+            AddNormalizedPaths(snapshot.ExactAddresses, subscribedAddresses);
+            AddNormalizedPaths(snapshot.PrefixAddresses, subscribedPrefixes);
+            return snapshot;
+        }
+
+        private static void AddNormalizedPaths(HashSet<string> target, IEnumerable<string> source)
+        {
+            if (source == null)
+            {
+                return;
+            }
+
+            foreach (string rawPath in source)
+            {
+                string normalizedPath = NormalizeSubscriptionPath(rawPath);
+                if (normalizedPath != null)
+                {
+                    target.Add(normalizedPath);
+                }
+            }
+        }
+
+        private void UpdateSubscriptionCounts(
+            HashSet<string> previousPaths,
+            HashSet<string> nextPaths,
+            Dictionary<string, int> counts,
+            Action<string> onAdded,
+            Action<string> onRemoved)
+        {
+            if (previousPaths != null)
+            {
+                foreach (string path in previousPaths)
+                {
+                    if (nextPaths != null && nextPaths.Contains(path))
+                    {
+                        continue;
+                    }
+
+                    if (counts.TryGetValue(path, out int currentCount))
+                    {
+                        currentCount--;
+                        if (currentCount <= 0)
+                        {
+                            counts.Remove(path);
+                            onRemoved(path);
+                        }
+                        else
+                        {
+                            counts[path] = currentCount;
+                        }
+                    }
+                }
+            }
+
+            if (nextPaths == null)
+            {
+                return;
+            }
+
+            foreach (string path in nextPaths)
+            {
+                if (previousPaths != null && previousPaths.Contains(path))
+                {
+                    continue;
+                }
+
+                if (counts.TryGetValue(path, out int currentCount))
+                {
+                    counts[path] = currentCount + 1;
+                    continue;
+                }
+
+                counts[path] = 1;
+                onAdded(path);
+            }
+        }
+
+        private void EnsureExactSubscriptionNode(string fullPath)
+        {
+            OsushiNode node = EnsureQueryNode(fullPath);
+            if (node.ACCESS == 0 && node.TYPE == null && node.VALUE == null)
+            {
+                node.ACCESS = SubscriptionAccess;
+            }
+        }
+
+        private void EnsurePrefixSubscriptionNode(string fullPath)
+        {
+            _ = EnsureQueryNode(fullPath);
+        }
+
+        private void RemoveExactSubscriptionNode(string fullPath)
+        {
+            OsushiNode node = ResolveQueryNode(fullPath);
+            if (node == null)
+            {
+                return;
+            }
+
+            if (node.ACCESS == SubscriptionAccess && node.TYPE == null && node.VALUE == null)
+            {
+                node.ACCESS = 0;
+            }
+
+            if (!_prefixSubscriptionCounts.ContainsKey(fullPath))
+            {
+                PruneQueryNode(fullPath);
+            }
+        }
+
+        private void RemovePrefixSubscriptionNode(string fullPath)
+        {
+            if (_exactSubscriptionCounts.ContainsKey(fullPath))
+            {
+                return;
+            }
+
+            PruneQueryNode(fullPath);
+        }
+
+        private void PruneQueryNode(string fullPath)
+        {
+            string normalizedPath = NormalizeSubscriptionPath(fullPath);
+            if (string.IsNullOrEmpty(normalizedPath) || normalizedPath == "/")
+            {
+                return;
+            }
+
+            string[] segments = normalizedPath.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+            PruneQueryNode(_oscQueryRoot, segments, 0);
+        }
+
+        private static bool PruneQueryNode(OsushiNode current, string[] segments, int index)
+        {
+            if (current == null || current.CONTENTS == null || index >= segments.Length)
+            {
+                return false;
+            }
+
+            string segment = segments[index];
+            if (!current.CONTENTS.TryGetValue(segment, out OsushiNode child))
+            {
+                return false;
+            }
+
+            if (index == segments.Length - 1)
+            {
+                if (CanRemoveNode(child))
+                {
+                    current.CONTENTS.Remove(segment);
+                    return current.CONTENTS.Count == 0;
+                }
+
+                return false;
+            }
+
+            bool childEmpty = PruneQueryNode(child, segments, index + 1);
+            if (childEmpty && CanRemoveNode(child))
+            {
+                current.CONTENTS.Remove(segment);
+            }
+
+            return current.CONTENTS.Count == 0;
+        }
+
+        private static bool CanRemoveNode(OsushiNode node)
+        {
+            bool hasChildren = node.CONTENTS != null && node.CONTENTS.Count > 0;
+            bool hasValue = node.VALUE != null;
+            bool hasType = !string.IsNullOrEmpty(node.TYPE);
+            return !hasChildren && !hasValue && !hasType && node.ACCESS == 0;
+        }
+
+        private static string BuildTypeTag(OscData[] values)
+        {
+            if (values == null || values.Length == 0)
+            {
+                return ",";
+            }
+
+            System.Text.StringBuilder builder = new System.Text.StringBuilder(",");
+            AppendTypeTags(builder, values);
+            return builder.ToString();
+        }
+
+        private static void AppendTypeTags(System.Text.StringBuilder builder, OscData[] values)
+        {
+            if (values == null)
+            {
+                return;
+            }
+
+            for (int i = 0; i < values.Length; i++)
+            {
+                OscData value = values[i];
+                if (value == null)
+                {
+                    builder.Append('N');
+                    continue;
+                }
+
+                if (value.Kind == OscDataKind.Array)
+                {
+                    builder.Append('[');
+                    AppendTypeTags(builder, value.Elements);
+                    builder.Append(']');
+                    continue;
+                }
+
+                builder.Append(value.GetTypeTagChar());
+            }
+        }
+
+        private static List<object> BuildQueryValues(OscData[] values)
+        {
+            List<object> result = new List<object>();
+            if (values == null)
+            {
+                return result;
+            }
+
+            for (int i = 0; i < values.Length; i++)
+            {
+                result.Add(values[i]?.ToQueryValue());
+            }
+
+            return result;
+        }
+
+        private static object[] BuildOscArguments(OscData[] values)
+        {
+            if (values == null || values.Length == 0)
+            {
+                return Array.Empty<object>();
+            }
+
+            object[] result = new object[values.Length];
+            for (int i = 0; i < values.Length; i++)
+            {
+                result[i] = values[i]?.ToOscArgument();
+            }
+
+            return result;
         }
     }
 }

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/Components/Acquisition/OSCAcquisitionServer.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/Components/Acquisition/OSCAcquisitionServer.cs
@@ -79,7 +79,7 @@ namespace HVR.Basis.Comms
             }
             catch (Exception e)
             {
-                Debug.LogWarning($"Failed to start OSC client ({e.Message})");
+                BasisDebug.LogWarning($"Failed to start OSC client ({e.Message})", BasisDebug.LogTag.LocalNetwork);
                 StopClient();
             }
         }
@@ -133,7 +133,7 @@ namespace HVR.Basis.Comms
                 }
                 catch (Exception e)
                 {
-                    Debug.LogWarning($"Failed to close client ({e.Message})");
+                    BasisDebug.LogWarning($"Failed to close client ({e.Message})", BasisDebug.LogTag.LocalNetwork);
                 }
                 _client = null;
             }
@@ -146,7 +146,7 @@ namespace HVR.Basis.Comms
                 }
                 catch (Exception e)
                 {
-                    Debug.LogWarning($"Failed to close osushi service ({e.Message})");
+                    BasisDebug.LogWarning($"Failed to close osushi service ({e.Message})", BasisDebug.LogTag.LocalNetwork);
                 }
                 _osushi = null;
             }
@@ -164,7 +164,7 @@ namespace HVR.Basis.Comms
             }
             catch (Exception e)
             {
-                Debug.LogWarning($"Failed to send wake up message ({e.Message})");
+                BasisDebug.LogWarning($"Failed to send wake up message ({e.Message})", BasisDebug.LogTag.LocalNetwork);
             }
         }
 
@@ -198,7 +198,7 @@ namespace HVR.Basis.Comms
                 }
                 catch (Exception e)
                 {
-                    Debug.LogWarning($"Failed to publish OSC value ({e.Message})");
+                    BasisDebug.LogWarning($"Failed to publish OSC value ({e.Message})", BasisDebug.LogTag.LocalNetwork);
                 }
             }
         }

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/BasisOscService.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/BasisOscService.cs
@@ -74,7 +74,7 @@ namespace HVR.Basis.Comms
 
         private static readonly object ReceiverLock = new object();
         private static readonly Dictionary<EntityId, ReceiverRegistration> Receivers = new Dictionary<EntityId, ReceiverRegistration>();
-        private static readonly Dictionary<string, int> RawPathToAddressId = new Dictionary<string, int>(StringComparer.Ordinal);
+        private static readonly ConcurrentDictionary<string, int> RawPathToAddressId = new ConcurrentDictionary<string, int>(StringComparer.Ordinal);
 
         private static DispatcherState _dispatcherState = DispatcherState.Empty;
 
@@ -216,7 +216,7 @@ namespace HVR.Basis.Comms
                 registration.PrefixAddresses = prefixAddresses;
                 RebuildDispatcherState_NoLock();
             }
-
+            // (eventual consistency is acceptable) and this avoids a potential deadlock if the acquisition server needs to call back into this service while processing the subscription update.
             OSCAcquisitionServer.SceneInstance.UpdateSubscriptions(ownerId, exactAddresses, prefixAddresses);
         }
 
@@ -597,7 +597,7 @@ namespace HVR.Basis.Comms
                 : rawPath;
 
             addressId = HVRAddress.AddressToId(normalizedPath);
-            RawPathToAddressId[rawPath] = addressId;
+            RawPathToAddressId.TryAdd(rawPath, addressId);
             return addressId;
         }
     }

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/BasisOscService.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/BasisOscService.cs
@@ -75,6 +75,8 @@ namespace HVR.Basis.Comms
         private static readonly object ReceiverLock = new object();
         private static readonly Dictionary<EntityId, ReceiverRegistration> Receivers = new Dictionary<EntityId, ReceiverRegistration>();
         private static readonly ConcurrentDictionary<string, int> RawPathToAddressId = new ConcurrentDictionary<string, int>(StringComparer.Ordinal);
+        // Main-thread dispatch scratch buffer. Rebuilt with receiver capacity whenever subscriptions change.
+        private static EntityId[] _dispatchOwnerBuffer = Array.Empty<EntityId>();
 
         private static DispatcherState _dispatcherState = DispatcherState.Empty;
 
@@ -160,7 +162,7 @@ namespace HVR.Basis.Comms
             DeliverMessage(snapshot, message, MatchOwners(snapshot, message.Path ?? string.Empty));
         }
 
-        internal static void SubmitRawMessages(IReadOnlyList<SimpleOSC.OSCMessage> messages)
+        internal static void SubmitRawMessages(List<SimpleOSC.OSCMessage> messages)
         {
             if (messages == null || messages.Count == 0)
             {
@@ -243,6 +245,8 @@ namespace HVR.Basis.Comms
 
         private static void RebuildDispatcherState_NoLock()
         {
+            EnsureDispatchOwnerBufferCapacity_NoLock(Math.Max(Receivers.Count, 4));
+
             Dictionary<EntityId, Action<OscMessage>> handlers = new Dictionary<EntityId, Action<OscMessage>>();
             Dictionary<EntityId, Action<int, float>> addressHandlers = new Dictionary<EntityId, Action<int, float>>();
             Dictionary<string, List<EntityId>> exactRouteLists = new Dictionary<string, List<EntityId>>(StringComparer.Ordinal);
@@ -294,6 +298,16 @@ namespace HVR.Basis.Comms
 
             Array.Sort(prefixRoutes, ComparePrefixRoutes);
             Volatile.Write(ref _dispatcherState, new DispatcherState(handlers, addressHandlers, exactRoutes, prefixRoutes, receiveAllOwners.ToArray()));
+        }
+
+        private static void EnsureDispatchOwnerBufferCapacity_NoLock(int requiredCapacity)
+        {
+            if (_dispatchOwnerBuffer.Length >= requiredCapacity)
+            {
+                return;
+            }
+
+            _dispatchOwnerBuffer = new EntityId[requiredCapacity];
         }
 
         private static int ComparePrefixRoutes(PrefixRoute left, PrefixRoute right)
@@ -472,14 +486,14 @@ namespace HVR.Basis.Comms
             matchesBuffer = expandedBuffer;
         }
 
-        private static void DispatchRawMessages(DispatcherState snapshot, IReadOnlyList<SimpleOSC.OSCMessage> messages)
+        private static void DispatchRawMessages(DispatcherState snapshot, List<SimpleOSC.OSCMessage> messages)
         {
             int messageCount = messages.Count;
             for (int messageIndex = 0; messageIndex < messageCount; messageIndex++)
             {
                 SimpleOSC.OSCMessage rawMessage = messages[messageIndex];
-                EntityId[] matchedOwners = MatchOwners(snapshot, rawMessage.path ?? string.Empty);
-                bool hasMatchedOwners = matchedOwners != null && matchedOwners.Length > 0;
+                int matchedOwnerCount = CollectMatchedOwners(snapshot, rawMessage.path ?? string.Empty, _dispatchOwnerBuffer);
+                bool hasMatchedOwners = matchedOwnerCount > 0;
                 bool hasGlobalListeners = MessageReceived != null;
                 if (!hasMatchedOwners && !hasGlobalListeners)
                 {
@@ -506,10 +520,10 @@ namespace HVR.Basis.Comms
                     continue;
                 }
 
-                int matchedOwnerCount = matchedOwners.Length;
                 for (int ownerIndex = 0; ownerIndex < matchedOwnerCount; ownerIndex++)
                 {
-                    if (!snapshot.Handlers.TryGetValue(matchedOwners[ownerIndex], out Action<OscMessage> handler) || handler == null)
+                    EntityId ownerId = _dispatchOwnerBuffer[ownerIndex];
+                    if (!snapshot.Handlers.TryGetValue(ownerId, out Action<OscMessage> handler) || handler == null)
                     {
                         continue;
                     }
@@ -549,14 +563,14 @@ namespace HVR.Basis.Comms
             }
         }
 
-        private static void DispatchAddressValues(DispatcherState snapshot, IReadOnlyList<SimpleOSC.OSCMessage> messages)
+        private static void DispatchAddressValues(DispatcherState snapshot, List<SimpleOSC.OSCMessage> messages)
         {
             int messageCount = messages.Count;
             for (int messageIndex = 0; messageIndex < messageCount; messageIndex++)
             {
                 SimpleOSC.OSCMessage rawMessage = messages[messageIndex];
-                EntityId[] matchedOwners = MatchOwners(snapshot, rawMessage.path ?? string.Empty);
-                if (matchedOwners == null || matchedOwners.Length == 0)
+                int matchedOwnerCount = CollectMatchedOwners(snapshot, rawMessage.path ?? string.Empty, _dispatchOwnerBuffer);
+                if (matchedOwnerCount == 0)
                 {
                     continue;
                 }
@@ -566,13 +580,70 @@ namespace HVR.Basis.Comms
                     continue;
                 }
 
-                int matchedOwnerCount = matchedOwners.Length;
                 for (int ownerIndex = 0; ownerIndex < matchedOwnerCount; ownerIndex++)
                 {
-                    if (snapshot.AddressHandlers.TryGetValue(matchedOwners[ownerIndex], out Action<int, float> addressHandler) && addressHandler != null)
+                    EntityId ownerId = _dispatchOwnerBuffer[ownerIndex];
+                    if (snapshot.AddressHandlers.TryGetValue(ownerId, out Action<int, float> addressHandler) && addressHandler != null)
                     {
                         addressHandler(addressId, value);
                     }
+                }
+            }
+        }
+
+        private static int CollectMatchedOwners(DispatcherState snapshot, string path, EntityId[] ownerBuffer)
+        {
+            if (snapshot == null || !snapshot.HasRoutes || ownerBuffer == null || ownerBuffer.Length == 0)
+            {
+                return 0;
+            }
+
+            int ownerCount = 0;
+            AddMatchedOwnersNoAlloc(ownerBuffer, ref ownerCount, snapshot.ReceiveAllRoutes);
+
+            if (snapshot.ExactRoutes.TryGetValue(path, out EntityId[] exactOwners))
+            {
+                AddMatchedOwnersNoAlloc(ownerBuffer, ref ownerCount, exactOwners);
+            }
+
+            PrefixRoute[] prefixRoutes = snapshot.PrefixRoutes;
+            int prefixRouteCount = prefixRoutes.Length;
+            for (int i = 0; i < prefixRouteCount; i++)
+            {
+                PrefixRoute route = prefixRoutes[i];
+                if (path.StartsWith(route.Prefix, StringComparison.Ordinal))
+                {
+                    AddMatchedOwnersNoAlloc(ownerBuffer, ref ownerCount, route.OwnerIds);
+                }
+            }
+
+            return ownerCount;
+        }
+
+        private static void AddMatchedOwnersNoAlloc(EntityId[] ownerBuffer, ref int ownerCount, EntityId[] owners)
+        {
+            if (owners == null || owners.Length == 0)
+            {
+                return;
+            }
+
+            int sourceOwnerCount = owners.Length;
+            for (int sourceIndex = 0; sourceIndex < sourceOwnerCount; sourceIndex++)
+            {
+                EntityId ownerId = owners[sourceIndex];
+                bool alreadyAdded = false;
+                for (int existingIndex = 0; existingIndex < ownerCount; existingIndex++)
+                {
+                    if (ownerBuffer[existingIndex].Equals(ownerId))
+                    {
+                        alreadyAdded = true;
+                        break;
+                    }
+                }
+
+                if (!alreadyAdded)
+                {
+                    ownerBuffer[ownerCount++] = ownerId;
                 }
             }
         }

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/BasisOscService.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/BasisOscService.cs
@@ -492,7 +492,7 @@ namespace HVR.Basis.Comms
                     }
                     catch (Exception e)
                     {
-                        Debug.LogWarning($"Failed to convert inbound OSC message {rawMessage.path} ({e.Message})");
+                        BasisDebug.LogWarning($"Failed to convert inbound OSC message {rawMessage.path} ({e.Message})", BasisDebug.LogTag.LocalNetwork);
                         continue;
                     }
                 }
@@ -517,7 +517,7 @@ namespace HVR.Basis.Comms
                         }
                         catch (Exception e)
                         {
-                            Debug.LogWarning($"Failed to convert inbound OSC message {rawMessage.path} ({e.Message})");
+                            BasisDebug.LogWarning($"Failed to convert inbound OSC message {rawMessage.path} ({e.Message})", BasisDebug.LogTag.LocalNetwork);
                             break;
                         }
                     }

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/BasisOscService.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/BasisOscService.cs
@@ -1,0 +1,604 @@
+using System;
+using System.Buffers;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using HVR.Basis.Comms.OSC;
+using HVR.Basis.Comms.OSC.Lyuma;
+using UnityEngine;
+
+namespace HVR.Basis.Comms
+{
+    public static class BasisOscService
+    {
+        private const string AvatarParametersPrefix = "/avatar/parameters/";
+        public static event Action<OscMessage> MessageReceived;
+
+        private sealed class ReceiverRegistration
+        {
+            public Action<OscMessage> Handler;
+            public Action<int, float> AddressHandler;
+            public bool ReceiveAll;
+            public string[] ExactAddresses = Array.Empty<string>();
+            public string[] PrefixAddresses = Array.Empty<string>();
+        }
+
+        private readonly struct PrefixRoute
+        {
+            public PrefixRoute(string prefix, EntityId[] ownerIds)
+            {
+                Prefix = prefix;
+                OwnerIds = ownerIds;
+            }
+
+            public string Prefix { get; }
+            public EntityId[] OwnerIds { get; }
+        }
+
+        private sealed class DispatcherState
+        {
+            public static readonly DispatcherState Empty = new DispatcherState(
+                new Dictionary<EntityId, Action<OscMessage>>(),
+                new Dictionary<EntityId, Action<int, float>>(),
+                new Dictionary<string, EntityId[]>(StringComparer.Ordinal),
+                Array.Empty<PrefixRoute>(),
+                Array.Empty<EntityId>());
+
+            public DispatcherState(
+                Dictionary<EntityId, Action<OscMessage>> handlers,
+                Dictionary<EntityId, Action<int, float>> addressHandlers,
+                Dictionary<string, EntityId[]> exactRoutes,
+                PrefixRoute[] prefixRoutes,
+                EntityId[] receiveAllRoutes)
+            {
+                Handlers = handlers;
+                AddressHandlers = addressHandlers;
+                ExactRoutes = exactRoutes;
+                PrefixRoutes = prefixRoutes;
+                ReceiveAllRoutes = receiveAllRoutes;
+                ResolvedPathCache = new ConcurrentDictionary<string, EntityId[]>(StringComparer.Ordinal);
+            }
+
+            public Dictionary<EntityId, Action<OscMessage>> Handlers { get; }
+            public Dictionary<EntityId, Action<int, float>> AddressHandlers { get; }
+            public Dictionary<string, EntityId[]> ExactRoutes { get; }
+            public PrefixRoute[] PrefixRoutes { get; }
+            public EntityId[] ReceiveAllRoutes { get; }
+            public ConcurrentDictionary<string, EntityId[]> ResolvedPathCache { get; }
+
+            public bool HasRoutes =>
+                ReceiveAllRoutes.Length > 0 ||
+                ExactRoutes.Count > 0 ||
+                PrefixRoutes.Length > 0;
+        }
+
+        private static readonly object ReceiverLock = new object();
+        private static readonly Dictionary<EntityId, ReceiverRegistration> Receivers = new Dictionary<EntityId, ReceiverRegistration>();
+        private static readonly Dictionary<string, int> RawPathToAddressId = new Dictionary<string, int>(StringComparer.Ordinal);
+
+        private static DispatcherState _dispatcherState = DispatcherState.Empty;
+
+        public static void EnsureInitialized()
+        {
+            _ = OSCAcquisitionServer.SceneInstance;
+        }
+
+        public static void RegisterReceiver(EntityId ownerId, Action<OscMessage> handler)
+        {
+            lock (ReceiverLock)
+            {
+                if (!Receivers.TryGetValue(ownerId, out ReceiverRegistration registration))
+                {
+                    registration = new ReceiverRegistration();
+                    Receivers[ownerId] = registration;
+                }
+
+                registration.Handler = handler;
+                RebuildDispatcherState_NoLock();
+            }
+        }
+
+        public static void RegisterAddressReceiver(EntityId ownerId, Action<int, float> handler)
+        {
+            lock (ReceiverLock)
+            {
+                if (!Receivers.TryGetValue(ownerId, out ReceiverRegistration registration))
+                {
+                    registration = new ReceiverRegistration();
+                    Receivers[ownerId] = registration;
+                }
+
+                registration.AddressHandler = handler;
+                RebuildDispatcherState_NoLock();
+            }
+        }
+
+        public static void UnregisterReceiver(EntityId ownerId)
+        {
+            lock (ReceiverLock)
+            {
+                if (Receivers.TryGetValue(ownerId, out ReceiverRegistration registration))
+                {
+                    registration.Handler = null;
+                    if (registration.AddressHandler == null)
+                    {
+                        Receivers.Remove(ownerId);
+                    }
+
+                    RebuildDispatcherState_NoLock();
+                }
+            }
+        }
+
+        public static void UnregisterAddressReceiver(EntityId ownerId)
+        {
+            lock (ReceiverLock)
+            {
+                if (Receivers.TryGetValue(ownerId, out ReceiverRegistration registration))
+                {
+                    registration.AddressHandler = null;
+                    if (registration.Handler == null)
+                    {
+                        Receivers.Remove(ownerId);
+                    }
+
+                    RebuildDispatcherState_NoLock();
+                }
+            }
+        }
+
+        internal static void Publish(OscMessage message)
+        {
+            if (message == null)
+            {
+                return;
+            }
+
+            MessageReceived?.Invoke(message);
+
+            DispatcherState snapshot = Volatile.Read(ref _dispatcherState);
+            DeliverMessage(snapshot, message, MatchOwners(snapshot, message.Path ?? string.Empty));
+        }
+
+        internal static void SubmitRawMessages(IReadOnlyList<SimpleOSC.OSCMessage> messages)
+        {
+            if (messages == null || messages.Count == 0)
+            {
+                return;
+            }
+
+            DispatcherState snapshot = Volatile.Read(ref _dispatcherState);
+            bool hasAddressConsumers = snapshot.AddressHandlers.Count > 0;
+            bool hasOscConsumers = snapshot.Handlers.Count > 0 || MessageReceived != null;
+            if (!snapshot.HasRoutes && !hasAddressConsumers && !hasOscConsumers)
+            {
+                return;
+            }
+
+            if (hasAddressConsumers)
+            {
+                DispatchAddressValues(snapshot, messages);
+            }
+
+            if (!hasOscConsumers)
+            {
+                return;
+            }
+
+            DispatchRawMessages(snapshot, messages);
+        }
+
+        public static void PublishValue(string address, OscData value)
+        {
+            PublishValues(address, value == null ? Array.Empty<OscData>() : new[] { value });
+        }
+
+        public static void PublishValues(string address, OscData[] values)
+        {
+            OSCAcquisitionServer.SceneInstance.PublishValues(address, values);
+        }
+
+        public static void UpdateSubscriptions(EntityId ownerId, bool receiveAll, IEnumerable<string> subscribedAddresses, IEnumerable<string> subscribedPrefixes)
+        {
+            string[] exactAddresses = ToSortedUniqueArray(subscribedAddresses);
+            string[] prefixAddresses = ToSortedUniqueArray(subscribedPrefixes);
+
+            lock (ReceiverLock)
+            {
+                if (!Receivers.TryGetValue(ownerId, out ReceiverRegistration registration))
+                {
+                    registration = new ReceiverRegistration();
+                    Receivers[ownerId] = registration;
+                }
+
+                registration.ReceiveAll = receiveAll;
+                registration.ExactAddresses = exactAddresses;
+                registration.PrefixAddresses = prefixAddresses;
+                RebuildDispatcherState_NoLock();
+            }
+
+            OSCAcquisitionServer.SceneInstance.UpdateSubscriptions(ownerId, exactAddresses, prefixAddresses);
+        }
+
+        public static void UpdateSubscriptions(EntityId ownerId, IEnumerable<string> subscribedAddresses, IEnumerable<string> subscribedPrefixes)
+        {
+            UpdateSubscriptions(ownerId, false, subscribedAddresses, subscribedPrefixes);
+        }
+
+        public static void ClearSubscriptions(EntityId ownerId)
+        {
+            lock (ReceiverLock)
+            {
+                if (Receivers.TryGetValue(ownerId, out ReceiverRegistration registration))
+                {
+                    registration.ReceiveAll = false;
+                    registration.ExactAddresses = Array.Empty<string>();
+                    registration.PrefixAddresses = Array.Empty<string>();
+                    RebuildDispatcherState_NoLock();
+                }
+            }
+
+            OSCAcquisitionServer.SceneInstance.ClearSubscriptions(ownerId);
+        }
+
+        private static void RebuildDispatcherState_NoLock()
+        {
+            Dictionary<EntityId, Action<OscMessage>> handlers = new Dictionary<EntityId, Action<OscMessage>>();
+            Dictionary<EntityId, Action<int, float>> addressHandlers = new Dictionary<EntityId, Action<int, float>>();
+            Dictionary<string, List<EntityId>> exactRouteLists = new Dictionary<string, List<EntityId>>(StringComparer.Ordinal);
+            Dictionary<string, List<EntityId>> prefixRouteLists = new Dictionary<string, List<EntityId>>(StringComparer.Ordinal);
+            List<EntityId> receiveAllOwners = new List<EntityId>();
+
+            foreach (KeyValuePair<EntityId, ReceiverRegistration> pair in Receivers)
+            {
+                EntityId ownerId = pair.Key;
+                ReceiverRegistration registration = pair.Value;
+                bool hasMessageHandler = registration?.Handler != null;
+                bool hasAddressHandler = registration?.AddressHandler != null;
+                if (!hasMessageHandler && !hasAddressHandler)
+                {
+                    continue;
+                }
+
+                if (hasMessageHandler)
+                {
+                    handlers[ownerId] = registration.Handler;
+                }
+
+                if (hasAddressHandler)
+                {
+                    addressHandlers[ownerId] = registration.AddressHandler;
+                }
+
+                if (registration.ReceiveAll)
+                {
+                    receiveAllOwners.Add(ownerId);
+                }
+
+                AddOwnerToRoutes(exactRouteLists, registration.ExactAddresses, ownerId);
+                AddOwnerToRoutes(prefixRouteLists, registration.PrefixAddresses, ownerId);
+            }
+
+            Dictionary<string, EntityId[]> exactRoutes = new Dictionary<string, EntityId[]>(exactRouteLists.Count, StringComparer.Ordinal);
+            foreach (KeyValuePair<string, List<EntityId>> pair in exactRouteLists)
+            {
+                exactRoutes[pair.Key] = pair.Value.ToArray();
+            }
+
+            PrefixRoute[] prefixRoutes = new PrefixRoute[prefixRouteLists.Count];
+            int prefixIndex = 0;
+            foreach (KeyValuePair<string, List<EntityId>> pair in prefixRouteLists)
+            {
+                prefixRoutes[prefixIndex++] = new PrefixRoute(pair.Key, pair.Value.ToArray());
+            }
+
+            Array.Sort(prefixRoutes, ComparePrefixRoutes);
+            Volatile.Write(ref _dispatcherState, new DispatcherState(handlers, addressHandlers, exactRoutes, prefixRoutes, receiveAllOwners.ToArray()));
+        }
+
+        private static int ComparePrefixRoutes(PrefixRoute left, PrefixRoute right)
+        {
+            return string.CompareOrdinal(left.Prefix, right.Prefix);
+        }
+
+        private static void AddOwnerToRoutes(Dictionary<string, List<EntityId>> routes, string[] paths, EntityId ownerId)
+        {
+            if (paths == null)
+            {
+                return;
+            }
+
+            for (int i = 0; i < paths.Length; i++)
+            {
+                string path = paths[i];
+                if (string.IsNullOrEmpty(path))
+                {
+                    continue;
+                }
+
+                if (!routes.TryGetValue(path, out List<EntityId> owners))
+                {
+                    owners = new List<EntityId>();
+                    routes[path] = owners;
+                }
+
+                owners.Add(ownerId);
+            }
+        }
+
+        private static string[] ToSortedUniqueArray(IEnumerable<string> paths)
+        {
+            if (paths == null)
+            {
+                return Array.Empty<string>();
+            }
+
+            HashSet<string> normalized = new HashSet<string>(StringComparer.Ordinal);
+            foreach (string path in paths)
+            {
+                if (!string.IsNullOrEmpty(path))
+                {
+                    normalized.Add(path);
+                }
+            }
+
+            string[] result = new string[normalized.Count];
+            normalized.CopyTo(result);
+            Array.Sort(result, StringComparer.Ordinal);
+            return result;
+        }
+
+        private static EntityId[] MatchOwners(DispatcherState snapshot, string path)
+        {
+            if (snapshot == null || !snapshot.HasRoutes)
+            {
+                return Array.Empty<EntityId>();
+            }
+
+            if (snapshot.PrefixRoutes.Length == 0)
+            {
+                if (snapshot.ReceiveAllRoutes.Length == 0)
+                {
+                    return snapshot.ExactRoutes.TryGetValue(path, out EntityId[] exactOnlyOwners)
+                        ? exactOnlyOwners
+                        : Array.Empty<EntityId>();
+                }
+
+                if (snapshot.ExactRoutes.Count == 0)
+                {
+                    return snapshot.ReceiveAllRoutes;
+                }
+            }
+
+            if (snapshot.ResolvedPathCache.TryGetValue(path, out EntityId[] cachedOwners))
+            {
+                return cachedOwners;
+            }
+
+            EntityId[] resolvedOwners = ResolveOwners(snapshot, path);
+            return snapshot.ResolvedPathCache.GetOrAdd(path, resolvedOwners);
+        }
+
+        private static EntityId[] ResolveOwners(DispatcherState snapshot, string path)
+        {
+            EntityId[] matchesBuffer = null;
+            int matchCount = 0;
+
+            try
+            {
+                AddOwners(ref matchesBuffer, ref matchCount, snapshot.ReceiveAllRoutes);
+
+                if (snapshot.ExactRoutes.TryGetValue(path, out EntityId[] exactOwners))
+                {
+                    AddOwners(ref matchesBuffer, ref matchCount, exactOwners);
+                }
+
+                PrefixRoute[] prefixRoutes = snapshot.PrefixRoutes;
+                for (int i = 0; i < prefixRoutes.Length; i++)
+                {
+                    PrefixRoute route = prefixRoutes[i];
+                    if (path.StartsWith(route.Prefix, StringComparison.Ordinal))
+                    {
+                        AddOwners(ref matchesBuffer, ref matchCount, route.OwnerIds);
+                    }
+                }
+
+                if (matchCount == 0)
+                {
+                    return Array.Empty<EntityId>();
+                }
+
+                EntityId[] resolvedOwners = new EntityId[matchCount];
+                Array.Copy(matchesBuffer, 0, resolvedOwners, 0, matchCount);
+                return resolvedOwners;
+            }
+            finally
+            {
+                if (matchesBuffer != null)
+                {
+                    ArrayPool<EntityId>.Shared.Return(matchesBuffer, false);
+                }
+            }
+        }
+
+        private static void AddOwners(ref EntityId[] matchesBuffer, ref int matchCount, EntityId[] owners)
+        {
+            if (owners == null || owners.Length == 0)
+            {
+                return;
+            }
+
+            EnsureMatchCapacity(ref matchesBuffer, matchCount, matchCount + owners.Length);
+            for (int ownerIndex = 0; ownerIndex < owners.Length; ownerIndex++)
+            {
+                EntityId ownerId = owners[ownerIndex];
+                bool alreadyAdded = false;
+                for (int matchIndex = 0; matchIndex < matchCount; matchIndex++)
+                {
+                    if (matchesBuffer[matchIndex].Equals(ownerId))
+                    {
+                        alreadyAdded = true;
+                        break;
+                    }
+                }
+
+                if (!alreadyAdded)
+                {
+                    matchesBuffer[matchCount++] = ownerId;
+                }
+            }
+        }
+
+        private static void EnsureMatchCapacity(ref EntityId[] matchesBuffer, int matchCount, int requiredCapacity)
+        {
+            if (matchesBuffer == null)
+            {
+                matchesBuffer = ArrayPool<EntityId>.Shared.Rent(Math.Max(requiredCapacity, 4));
+                return;
+            }
+
+            if (matchesBuffer.Length >= requiredCapacity)
+            {
+                return;
+            }
+
+            int expandedCapacity = Math.Max(requiredCapacity, matchesBuffer.Length * 2);
+            EntityId[] expandedBuffer = ArrayPool<EntityId>.Shared.Rent(expandedCapacity);
+            Array.Copy(matchesBuffer, 0, expandedBuffer, 0, matchCount);
+            ArrayPool<EntityId>.Shared.Return(matchesBuffer, false);
+            matchesBuffer = expandedBuffer;
+        }
+
+        private static void DispatchRawMessages(DispatcherState snapshot, IReadOnlyList<SimpleOSC.OSCMessage> messages)
+        {
+            for (int messageIndex = 0; messageIndex < messages.Count; messageIndex++)
+            {
+                SimpleOSC.OSCMessage rawMessage = messages[messageIndex];
+                EntityId[] matchedOwners = MatchOwners(snapshot, rawMessage.path ?? string.Empty);
+                bool hasMatchedOwners = matchedOwners != null && matchedOwners.Length > 0;
+                bool hasGlobalListeners = MessageReceived != null;
+                if (!hasMatchedOwners && !hasGlobalListeners)
+                {
+                    continue;
+                }
+
+                OscMessage convertedMessage = null;
+                if (hasGlobalListeners)
+                {
+                    try
+                    {
+                        convertedMessage = OscMessage.FromRaw(rawMessage);
+                        MessageReceived?.Invoke(convertedMessage);
+                    }
+                    catch (Exception e)
+                    {
+                        Debug.LogWarning($"Failed to convert inbound OSC message {rawMessage.path} ({e.Message})");
+                        continue;
+                    }
+                }
+
+                if (!hasMatchedOwners)
+                {
+                    continue;
+                }
+
+                for (int ownerIndex = 0; ownerIndex < matchedOwners.Length; ownerIndex++)
+                {
+                    if (!snapshot.Handlers.TryGetValue(matchedOwners[ownerIndex], out Action<OscMessage> handler) || handler == null)
+                    {
+                        continue;
+                    }
+
+                    if (convertedMessage == null)
+                    {
+                        try
+                        {
+                            convertedMessage = OscMessage.FromRaw(rawMessage);
+                        }
+                        catch (Exception e)
+                        {
+                            Debug.LogWarning($"Failed to convert inbound OSC message {rawMessage.path} ({e.Message})");
+                            break;
+                        }
+                    }
+
+                    handler(convertedMessage);
+                }
+            }
+        }
+
+        private static void DeliverMessage(DispatcherState currentState, OscMessage message, EntityId[] matchedOwners)
+        {
+            if (currentState == null || matchedOwners == null || matchedOwners.Length == 0)
+            {
+                return;
+            }
+
+            for (int ownerIndex = 0; ownerIndex < matchedOwners.Length; ownerIndex++)
+            {
+                if (currentState.Handlers.TryGetValue(matchedOwners[ownerIndex], out Action<OscMessage> handler) && handler != null)
+                {
+                    handler(message);
+                }
+            }
+        }
+
+        private static void DispatchAddressValues(DispatcherState snapshot, IReadOnlyList<SimpleOSC.OSCMessage> messages)
+        {
+            for (int messageIndex = 0; messageIndex < messages.Count; messageIndex++)
+            {
+                SimpleOSC.OSCMessage rawMessage = messages[messageIndex];
+                EntityId[] matchedOwners = MatchOwners(snapshot, rawMessage.path ?? string.Empty);
+                if (matchedOwners == null || matchedOwners.Length == 0)
+                {
+                    continue;
+                }
+
+                if (!TryResolveAddressValue(rawMessage, out int addressId, out float value))
+                {
+                    continue;
+                }
+
+                for (int ownerIndex = 0; ownerIndex < matchedOwners.Length; ownerIndex++)
+                {
+                    if (snapshot.AddressHandlers.TryGetValue(matchedOwners[ownerIndex], out Action<int, float> addressHandler) && addressHandler != null)
+                    {
+                        addressHandler(addressId, value);
+                    }
+                }
+            }
+        }
+
+        private static bool TryResolveAddressValue(SimpleOSC.OSCMessage message, out int addressId, out float value)
+        {
+            addressId = 0;
+            value = 0f;
+
+            object[] arguments = message.arguments;
+            if (arguments == null || arguments.Length == 0 || !(arguments[0] is float floatValue))
+            {
+                return false;
+            }
+
+            addressId = ResolveAddressId(message.path ?? string.Empty);
+            value = floatValue;
+            return true;
+        }
+
+        private static int ResolveAddressId(string rawPath)
+        {
+            if (RawPathToAddressId.TryGetValue(rawPath, out int addressId))
+            {
+                return addressId;
+            }
+
+            string normalizedPath = rawPath.StartsWith(AvatarParametersPrefix, StringComparison.Ordinal)
+                ? rawPath.Substring(AvatarParametersPrefix.Length)
+                : rawPath;
+
+            addressId = HVRAddress.AddressToId(normalizedPath);
+            RawPathToAddressId[rawPath] = addressId;
+            return addressId;
+        }
+    }
+}

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/BasisOscService.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/BasisOscService.cs
@@ -308,7 +308,8 @@ namespace HVR.Basis.Comms
                 return;
             }
 
-            for (int i = 0; i < paths.Length; i++)
+            int pathCount = paths.Length;
+            for (int i = 0; i < pathCount; i++)
             {
                 string path = paths[i];
                 if (string.IsNullOrEmpty(path))
@@ -394,7 +395,8 @@ namespace HVR.Basis.Comms
                 }
 
                 PrefixRoute[] prefixRoutes = snapshot.PrefixRoutes;
-                for (int i = 0; i < prefixRoutes.Length; i++)
+                int prefixRouteCount = prefixRoutes.Length;
+                for (int i = 0; i < prefixRouteCount; i++)
                 {
                     PrefixRoute route = prefixRoutes[i];
                     if (path.StartsWith(route.Prefix, StringComparison.Ordinal))
@@ -428,8 +430,9 @@ namespace HVR.Basis.Comms
                 return;
             }
 
-            EnsureMatchCapacity(ref matchesBuffer, matchCount, matchCount + owners.Length);
-            for (int ownerIndex = 0; ownerIndex < owners.Length; ownerIndex++)
+            int ownerCount = owners.Length;
+            EnsureMatchCapacity(ref matchesBuffer, matchCount, matchCount + ownerCount);
+            for (int ownerIndex = 0; ownerIndex < ownerCount; ownerIndex++)
             {
                 EntityId ownerId = owners[ownerIndex];
                 bool alreadyAdded = false;
@@ -471,7 +474,8 @@ namespace HVR.Basis.Comms
 
         private static void DispatchRawMessages(DispatcherState snapshot, IReadOnlyList<SimpleOSC.OSCMessage> messages)
         {
-            for (int messageIndex = 0; messageIndex < messages.Count; messageIndex++)
+            int messageCount = messages.Count;
+            for (int messageIndex = 0; messageIndex < messageCount; messageIndex++)
             {
                 SimpleOSC.OSCMessage rawMessage = messages[messageIndex];
                 EntityId[] matchedOwners = MatchOwners(snapshot, rawMessage.path ?? string.Empty);
@@ -502,7 +506,8 @@ namespace HVR.Basis.Comms
                     continue;
                 }
 
-                for (int ownerIndex = 0; ownerIndex < matchedOwners.Length; ownerIndex++)
+                int matchedOwnerCount = matchedOwners.Length;
+                for (int ownerIndex = 0; ownerIndex < matchedOwnerCount; ownerIndex++)
                 {
                     if (!snapshot.Handlers.TryGetValue(matchedOwners[ownerIndex], out Action<OscMessage> handler) || handler == null)
                     {
@@ -534,7 +539,8 @@ namespace HVR.Basis.Comms
                 return;
             }
 
-            for (int ownerIndex = 0; ownerIndex < matchedOwners.Length; ownerIndex++)
+            int matchedOwnerCount = matchedOwners.Length;
+            for (int ownerIndex = 0; ownerIndex < matchedOwnerCount; ownerIndex++)
             {
                 if (currentState.Handlers.TryGetValue(matchedOwners[ownerIndex], out Action<OscMessage> handler) && handler != null)
                 {
@@ -545,7 +551,8 @@ namespace HVR.Basis.Comms
 
         private static void DispatchAddressValues(DispatcherState snapshot, IReadOnlyList<SimpleOSC.OSCMessage> messages)
         {
-            for (int messageIndex = 0; messageIndex < messages.Count; messageIndex++)
+            int messageCount = messages.Count;
+            for (int messageIndex = 0; messageIndex < messageCount; messageIndex++)
             {
                 SimpleOSC.OSCMessage rawMessage = messages[messageIndex];
                 EntityId[] matchedOwners = MatchOwners(snapshot, rawMessage.path ?? string.Empty);
@@ -559,7 +566,8 @@ namespace HVR.Basis.Comms
                     continue;
                 }
 
-                for (int ownerIndex = 0; ownerIndex < matchedOwners.Length; ownerIndex++)
+                int matchedOwnerCount = matchedOwners.Length;
+                for (int ownerIndex = 0; ownerIndex < matchedOwnerCount; ownerIndex++)
                 {
                     if (snapshot.AddressHandlers.TryGetValue(matchedOwners[ownerIndex], out Action<int, float> addressHandler) && addressHandler != null)
                     {

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/BasisOscService.cs.meta
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/BasisOscService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6a6e60cf081b4c0ea3e13508b0d993bf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/HVROsc.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/HVROsc.cs
@@ -7,13 +7,14 @@ namespace HVR.Basis.Comms.OSC
     public class HVROsc
     {
         private const int DefaultReceiverPort = 9000;
+        private const int InitialMessageQueueCapacity = 128;
         private int _currentReceiverPort;
         
         private readonly int _oscPort;
         private readonly SimpleOSC _client;
         
         private readonly byte[] _byteBuffer = new byte[65535];
-        private readonly List<SimpleOSC.OSCMessage> _queue = new();
+        private readonly List<SimpleOSC.OSCMessage> _queue = new List<SimpleOSC.OSCMessage>(InitialMessageQueueCapacity);
 
         public HVROsc(int oscPort)
         {

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/HVROsc.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/HVROsc.cs
@@ -59,7 +59,9 @@ namespace HVR.Basis.Comms.OSC
             }, _byteBuffer);
         }
 
-        public List<SimpleOSC.OSCMessage> PullMessages()
+        // The UDP socket receives and decodes on a background thread; the main thread
+        // drains the decoded messages and performs all routing/callback dispatch.
+        public List<SimpleOSC.OSCMessage> DrainReceivedMessages()
         {
             _queue.Clear();
             _client.GetIncomingOSC(_queue);

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/Lyuma/SimpleOSC.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/Lyuma/SimpleOSC.cs
@@ -75,6 +75,21 @@ public class SimpleOSC
 			}
 #endif
 	}
+	public struct OSCSymbol {
+		public string value;
+		public override string ToString() {
+			return "OSCSymbol<" + value + ">";
+		}
+	}
+	public struct OSCMidi {
+		public byte port;
+		public byte status;
+		public byte data1;
+		public byte data2;
+		public override string ToString() {
+			return "OSCMidi<" + port + "," + status + "," + data1 + "," + data2 + ">";
+		}
+	}
 	public struct OSCMessage {
 		public IPEndPoint sender;
 		public uint bundleId; // 0 if not in a bundle; positive integer if part of a bundle.
@@ -156,6 +171,12 @@ public class SimpleOSC
 				case bool b:
 					sb.Append(b.ToString());
 					break;
+				case OSCSymbol symbol:
+					sb.Append(symbol.ToString());
+					break;
+				case OSCMidi midi:
+					sb.Append(midi.ToString());
+					break;
 				default:
 					sb.Append("(");
 					sb.Append(arg.GetType().Name);
@@ -208,6 +229,16 @@ public class SimpleOSC
 				offset = strend;
 				offset = (offset + 4) & ~3;
 				return System.Text.Encoding.UTF8.GetString(tmp);
+			case 'S':
+				strend = offset;
+				while (data[strend] != 0) {
+					strend++;
+				}
+				tmp = new byte[strend - offset];
+				Array.Copy(data, offset, tmp, 0, strend - offset);
+				offset = strend;
+				offset = (offset + 4) & ~3;
+				return new OSCSymbol { value = System.Text.Encoding.UTF8.GetString(tmp) };
 			case 'b':
 				int len = IPAddress.NetworkToHostOrder(BitConverter.ToInt32(data, offset));
 				offset += 4;
@@ -240,6 +271,12 @@ public class SimpleOSC
 				uint cret = (uint)IPAddress.NetworkToHostOrder(BitConverter.ToInt32(data, offset));
 				offset += 4;
 				return cret;
+			case 'm':
+				byte port = data[offset++];
+				byte status = data[offset++];
+				byte data1 = data[offset++];
+				byte data2 = data[offset++];
+				return new OSCMidi { port = port, status = status, data1 = data1, data2 = data2 };
 			default:
 				CryWolf("Unknown type tag " + typeTag + " offset " + offset);
 				break;
@@ -286,6 +323,24 @@ public class SimpleOSC
 				break;
 			case 's':
 				tmp = System.Text.Encoding.UTF8.GetBytes((string)value);
+				Array.Copy(tmp, 0, data, offset, tmp.Length);
+				data[tmp.Length + offset] = 0;
+				offset += tmp.Length;
+				for (int endOffset = (offset + 4) & ~3; offset < endOffset; offset++) {
+					data[offset] = 0;
+				}
+				break;
+			case 'S':
+				string symbolValue;
+				switch (value) {
+					case OSCSymbol symbol:
+						symbolValue = symbol.value;
+						break;
+					default:
+						symbolValue = value?.ToString() ?? "";
+						break;
+				}
+				tmp = System.Text.Encoding.UTF8.GetBytes(symbolValue);
 				Array.Copy(tmp, 0, data, offset, tmp.Length);
 				data[tmp.Length + offset] = 0;
 				offset += tmp.Length;
@@ -340,6 +395,22 @@ public class SimpleOSC
 			case 'c':
 				Array.Copy(BitConverter.GetBytes(IPAddress.HostToNetworkOrder((int)(uint)value)), 0, data, offset, 4);
 				offset += 4;
+				break;
+			case 'm':
+				OSCMidi midi;
+				switch (value) {
+					case OSCMidi oscMidi:
+						midi = oscMidi;
+						break;
+					default:
+						CryWolf("Invalid MIDI value " + value?.GetType());
+						midi = default;
+						break;
+				}
+				data[offset++] = midi.port;
+				data[offset++] = midi.status;
+				data[offset++] = midi.data1;
+				data[offset++] = midi.data2;
 				break;
 			default:
 				CryWolf("Unexpected type tag to serialize " + typeTag + " offset " + offset);
@@ -452,6 +523,9 @@ public class SimpleOSC
 				case string s:
 					typeTag.Append('s');
 					break;
+				case OSCSymbol symbol:
+					typeTag.Append('S');
+					break;
 				case byte[] b:
 					typeTag.Append('b');
 					break;
@@ -469,6 +543,9 @@ public class SimpleOSC
 					break;
 				case uint c: // represent OSC char as uint. confusing???
 					typeTag.Append('c');
+					break;
+				case OSCMidi midi:
+					typeTag.Append('m');
 					break;
 				default:
 					CryWolf("Invalid type " + po.GetType() + " at " + typeTag);

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/Lyuma/SimpleOSC.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/Lyuma/SimpleOSC.cs
@@ -37,19 +37,50 @@ public class SimpleOSC
 {
 	public enum Impulse {IMPULSE}
 	public struct TimeTag {
-		public int secs;
-		public int nsecs;
+		public uint secs;
+		public uint nsecs;
 		public override string ToString() {
 			return "" + secs + ":" + nsecs;
 		}
 #if UNITY
-			public static implicit operator UnityEngine.Vector2Int(TimeTag tt) {
-				return new UnityEngine.Vector2Int { x = tt.secs, y = tt.nsecs };
+			// Vector2Int is signed; this conversion is only for raw 32-bit compatibility.
+			public static explicit operator UnityEngine.Vector2Int(TimeTag tt) {
+				return new UnityEngine.Vector2Int { x = unchecked((int)tt.secs), y = unchecked((int)tt.nsecs) };
 			}
-			public static implicit operator TimeTag(UnityEngine.Vector2Int v2) {
-				return new TimeTag { secs = v2.x, nsecs = v2.y };
+			public static explicit operator TimeTag(UnityEngine.Vector2Int v2) {
+				return new TimeTag { secs = unchecked((uint)v2.x), nsecs = unchecked((uint)v2.y) };
 			}
 #endif
+	}
+	private static uint ReadUInt32NetworkOrder(byte[] data, int offset) {
+		return ((uint)data[offset] << 24) |
+		       ((uint)data[offset + 1] << 16) |
+		       ((uint)data[offset + 2] << 8) |
+		       data[offset + 3];
+	}
+	private static void WriteUInt32NetworkOrder(byte[] data, int offset, uint value) {
+		data[offset] = (byte)(value >> 24);
+		data[offset + 1] = (byte)(value >> 16);
+		data[offset + 2] = (byte)(value >> 8);
+		data[offset + 3] = (byte)value;
+	}
+	private static string ParsePaddedString(byte[] data, ref int offset) {
+		int start = offset;
+		while (offset < data.Length && data[offset] != 0) {
+			offset++;
+		}
+		if (offset >= data.Length) {
+			CryWolf("OSC string missing null terminator at offset " + start);
+			offset = data.Length;
+			return string.Empty;
+		}
+		string value = System.Text.Encoding.UTF8.GetString(data, start, offset - start);
+		offset = (offset + 4) & ~3;
+		if (offset > data.Length) {
+			CryWolf("OSC string padding exceeded packet length at offset " + start);
+			offset = data.Length;
+		}
+		return value;
 	}
 	public struct OSCColor {
 		public byte r;
@@ -215,30 +246,14 @@ public class SimpleOSC
 				offset += 4;
 				return fret;
 			case 't':
-				int secs = IPAddress.NetworkToHostOrder(BitConverter.ToInt32(data, offset));
-				int nanosecs = IPAddress.NetworkToHostOrder(BitConverter.ToInt32(data, offset + 4));
+				uint secs = ReadUInt32NetworkOrder(data, offset);
+				uint nanosecs = ReadUInt32NetworkOrder(data, offset + 4);
 				offset += 8;
 				return new TimeTag { secs = secs, nsecs = nanosecs };
 			case 's':
-				int strend = offset;
-				while (data[strend] != 0) {
-					strend++;
-				}
-				tmp = new byte[strend - offset];
-				Array.Copy(data, offset, tmp, 0, strend - offset);
-				offset = strend;
-				offset = (offset + 4) & ~3;
-				return System.Text.Encoding.UTF8.GetString(tmp);
+				return ParsePaddedString(data, ref offset);
 			case 'S':
-				strend = offset;
-				while (data[strend] != 0) {
-					strend++;
-				}
-				tmp = new byte[strend - offset];
-				Array.Copy(data, offset, tmp, 0, strend - offset);
-				offset = strend;
-				offset = (offset + 4) & ~3;
-				return new OSCSymbol { value = System.Text.Encoding.UTF8.GetString(tmp) };
+				return new OSCSymbol { value = ParsePaddedString(data, ref offset) };
 			case 'b':
 				int len = IPAddress.NetworkToHostOrder(BitConverter.ToInt32(data, offset));
 				offset += 4;
@@ -317,8 +332,8 @@ public class SimpleOSC
 						v2 = (TimeTag)value;
 						break;
 				}
-				Array.Copy(BitConverter.GetBytes(IPAddress.HostToNetworkOrder((int)v2.secs)), 0, data, offset, 4);
-				Array.Copy(BitConverter.GetBytes(IPAddress.HostToNetworkOrder((int)v2.nsecs)), 0, data, offset + 4, 4);
+				WriteUInt32NetworkOrder(data, offset, v2.secs);
+				WriteUInt32NetworkOrder(data, offset + 4, v2.nsecs);
 				offset += 8;
 				break;
 			case 's':
@@ -421,8 +436,8 @@ public class SimpleOSC
 	public static void DecodeOSCInto(ConcurrentQueue<OSCMessage> outQueue, byte[] data, int offset, int length, IPEndPoint senderIp=null, uint bundleId=0, TimeTag bundleTimetag=new TimeTag(), uint bundleIdNested=0) {
 		if (offset == 0 && length > 20 && data[offset] == '#' && data[offset + 1] == 'b' && data[offset + 2] == 'u' && data[offset + 3] == 'n' &&
 		    data[offset + 4] == 'd' && data[offset + 5] == 'l' && data[offset + 6] == 'e' && data[offset + 7] == 0) {
-			int secs = IPAddress.NetworkToHostOrder(BitConverter.ToInt32(data, offset + 8));
-			int nanosecs = IPAddress.NetworkToHostOrder(BitConverter.ToInt32(data, offset + 12));
+			uint secs = ReadUInt32NetworkOrder(data, offset + 8);
+			uint nanosecs = ReadUInt32NetworkOrder(data, offset + 12);
 			bundleTimetag = new TimeTag { secs = secs, nsecs = nanosecs };
 			offset += 16;
 			while (offset < length) {
@@ -599,12 +614,12 @@ public class SimpleOSC
 			}
 		}
 	}
-
+	private static readonly byte[] bundleHeader = new byte[]{(byte)'#',(byte)'b',(byte)'u',(byte)'n',(byte)'d',(byte)'l',(byte)'e',0};
 	public static void EncodeOSCBundleInto(byte[] data, ref int offset, List<OSCMessage> packets, TimeTag tt) {
-		Array.Copy(new byte[]{(byte)'#',(byte)'b',(byte)'u',(byte)'n',(byte)'d',(byte)'l',(byte)'e',0}, 0, data, offset, 8);
+		Array.Copy(bundleHeader, 0, data, offset, 8);
 		offset += 8;
-		Array.Copy(BitConverter.GetBytes(IPAddress.HostToNetworkOrder((int)tt.secs)), 0, data, offset, 4);
-		Array.Copy(BitConverter.GetBytes(IPAddress.HostToNetworkOrder((int)tt.nsecs)), 0, data, offset + 4, 4);
+		WriteUInt32NetworkOrder(data, offset, tt.secs);
+		WriteUInt32NetworkOrder(data, offset + 4, tt.nsecs);
 		offset += 8;
 		foreach (var msg in packets) {
 			int startOffset = offset;

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/Lyuma/SimpleOSC.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/Lyuma/SimpleOSC.cs
@@ -157,8 +157,8 @@ public class SimpleOSC
 	public static bool DebugLoggingEnabled = true; // Set to false to handle bad data without logspam.
 	static void CryWolf(string logMsg) {
 		if (DebugLoggingEnabled) {
-#if UNITY
-					UnityEngine.Debug.LogWarning(logMsg);
+#if UNITY && BASIS_FRAMEWORK_EXISTS
+					BasisDebug.LogWarning(logMsg, BasisDebug.LogTag.LocalNetwork);
 #else
 			System.Console.WriteLine(logMsg);
 #endif

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/Lyuma/SimpleOSC.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/Lyuma/SimpleOSC.cs
@@ -472,7 +472,8 @@ public class SimpleOSC
 		List<object> topLevelArguments = new List<object>();
 		List<List<object>> nested = new List<List<object>>();
 		nested.Add(topLevelArguments);
-		for (int i = 1; i < msg.typeTag.Length; i++) {
+		int typeTagLength = msg.typeTag.Length;
+		for (int i = 1; i < typeTagLength; i++) {
 			// Debug.Log("doing type tag " + msg.typeTag[i] + " offset: " + offset);
 			object obj;
 			switch (msg.typeTag[i]) {

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/OscData.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/OscData.cs
@@ -147,8 +147,9 @@ namespace HVR.Basis.Comms.OSC
                 return Array.Empty<OscData>();
             }
 
-            OscData[] converted = new OscData[arguments.Length];
-            for (int i = 0; i < arguments.Length; i++)
+            int argumentCount = arguments.Length;
+            OscData[] converted = new OscData[argumentCount];
+            for (int i = 0; i < argumentCount; i++)
             {
                 converted[i] = FromRaw(arguments[i]);
             }
@@ -266,8 +267,9 @@ namespace HVR.Basis.Comms.OSC
                 case OscDataKind.Midi:
                     return new[] { (int)MidiPort, (int)MidiStatus, (int)MidiData1, (int)MidiData2 };
                 case OscDataKind.Array:
-                    object[] nested = new object[Elements?.Length ?? 0];
-                    for (int i = 0; i < nested.Length; i++)
+                    int elementCount = Elements?.Length ?? 0;
+                    object[] nested = new object[elementCount];
+                    for (int i = 0; i < elementCount; i++)
                     {
                         OscData element = Elements[i];
                         nested[i] = element != null ? element.ToQueryValue() : null;
@@ -330,8 +332,9 @@ namespace HVR.Basis.Comms.OSC
                         data2 = MidiData2,
                     };
                 case OscDataKind.Array:
-                    object[] nested = new object[Elements?.Length ?? 0];
-                    for (int i = 0; i < nested.Length; i++)
+                    int elementCount = Elements?.Length ?? 0;
+                    object[] nested = new object[elementCount];
+                    for (int i = 0; i < elementCount; i++)
                     {
                         OscData element = Elements[i];
                         nested[i] = element != null ? element.ToOscArgument() : null;

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/OscData.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/OscData.cs
@@ -1,0 +1,345 @@
+using System;
+using HVR.Basis.Comms.OSC.Lyuma;
+
+namespace HVR.Basis.Comms.OSC
+{
+    public enum OscDataKind
+    {
+        Boolean,
+        Nil,
+        Impulse,
+        Int32,
+        Float32,
+        TimeTag,
+        String,
+        Symbol,
+        Blob,
+        Color,
+        Int64,
+        Float64,
+        Char,
+        Midi,
+        Array,
+    }
+
+    public sealed class OscData
+    {
+        public OscDataKind Kind { get; private set; }
+        public bool BoolValue { get; private set; }
+        public int IntValue { get; private set; }
+        public long LongValue { get; private set; }
+        public uint UIntValue { get; private set; }
+        public float FloatValue { get; private set; }
+        public double DoubleValue { get; private set; }
+        public string StringValue { get; private set; }
+        public byte[] BlobValue { get; private set; }
+        public OscData[] Elements { get; private set; } = Array.Empty<OscData>();
+        public int TimeTagSeconds { get; private set; }
+        public int TimeTagNanoseconds { get; private set; }
+        public byte ColorR { get; private set; }
+        public byte ColorG { get; private set; }
+        public byte ColorB { get; private set; }
+        public byte ColorA { get; private set; }
+        public byte MidiPort { get; private set; }
+        public byte MidiStatus { get; private set; }
+        public byte MidiData1 { get; private set; }
+        public byte MidiData2 { get; private set; }
+
+        public static OscData Boolean(bool value) => new OscData
+        {
+            Kind = OscDataKind.Boolean,
+            BoolValue = value,
+        };
+
+        public static OscData Nil() => new OscData
+        {
+            Kind = OscDataKind.Nil,
+        };
+
+        public static OscData Impulse() => new OscData
+        {
+            Kind = OscDataKind.Impulse,
+        };
+
+        public static OscData Int32(int value) => new OscData
+        {
+            Kind = OscDataKind.Int32,
+            IntValue = value,
+        };
+
+        public static OscData Float32(float value) => new OscData
+        {
+            Kind = OscDataKind.Float32,
+            FloatValue = value,
+        };
+
+        public static OscData TimeTag(int seconds, int nanoseconds) => new OscData
+        {
+            Kind = OscDataKind.TimeTag,
+            TimeTagSeconds = seconds,
+            TimeTagNanoseconds = nanoseconds,
+        };
+
+        public static OscData String(string value) => new OscData
+        {
+            Kind = OscDataKind.String,
+            StringValue = value ?? string.Empty,
+        };
+
+        public static OscData Symbol(string value) => new OscData
+        {
+            Kind = OscDataKind.Symbol,
+            StringValue = value ?? string.Empty,
+        };
+
+        public static OscData Blob(byte[] value) => new OscData
+        {
+            Kind = OscDataKind.Blob,
+            BlobValue = value == null ? Array.Empty<byte>() : (byte[])value.Clone(),
+        };
+
+        public static OscData Color(byte r, byte g, byte b, byte a) => new OscData
+        {
+            Kind = OscDataKind.Color,
+            ColorR = r,
+            ColorG = g,
+            ColorB = b,
+            ColorA = a,
+        };
+
+        public static OscData Int64(long value) => new OscData
+        {
+            Kind = OscDataKind.Int64,
+            LongValue = value,
+        };
+
+        public static OscData Float64(double value) => new OscData
+        {
+            Kind = OscDataKind.Float64,
+            DoubleValue = value,
+        };
+
+        public static OscData Char(uint value) => new OscData
+        {
+            Kind = OscDataKind.Char,
+            UIntValue = value,
+        };
+
+        public static OscData Midi(byte port, byte status, byte data1, byte data2) => new OscData
+        {
+            Kind = OscDataKind.Midi,
+            MidiPort = port,
+            MidiStatus = status,
+            MidiData1 = data1,
+            MidiData2 = data2,
+        };
+
+        public static OscData ArrayValue(params OscData[] elements) => new OscData
+        {
+            Kind = OscDataKind.Array,
+            Elements = elements == null ? Array.Empty<OscData>() : (OscData[])elements.Clone(),
+        };
+
+        public static OscData[] ConvertArguments(object[] arguments)
+        {
+            if (arguments == null || arguments.Length == 0)
+            {
+                return Array.Empty<OscData>();
+            }
+
+            OscData[] converted = new OscData[arguments.Length];
+            for (int i = 0; i < arguments.Length; i++)
+            {
+                converted[i] = FromRaw(arguments[i]);
+            }
+
+            return converted;
+        }
+
+        public static OscData FromRaw(object raw)
+        {
+            switch (raw)
+            {
+                case null:
+                    return Nil();
+                case bool boolValue:
+                    return Boolean(boolValue);
+                case int intValue:
+                    return Int32(intValue);
+                case float floatValue:
+                    return Float32(floatValue);
+                case SimpleOSC.TimeTag timeTag:
+                    return TimeTag(timeTag.secs, timeTag.nsecs);
+                case string stringValue:
+                    return String(stringValue);
+                case SimpleOSC.OSCSymbol symbolValue:
+                    return Symbol(symbolValue.value);
+                case byte[] blobValue:
+                    return Blob(blobValue);
+                case SimpleOSC.OSCColor colorValue:
+                    return Color(colorValue.r, colorValue.g, colorValue.b, colorValue.a);
+                case long longValue:
+                    return Int64(longValue);
+                case double doubleValue:
+                    return Float64(doubleValue);
+                case uint charValue:
+                    return Char(charValue);
+                case SimpleOSC.OSCMidi midiValue:
+                    return Midi(midiValue.port, midiValue.status, midiValue.data1, midiValue.data2);
+                case object[] elements:
+                    return ArrayValue(ConvertArguments(elements));
+                case SimpleOSC.Impulse impulseValue:
+                    return Impulse();
+                default:
+                    throw new NotSupportedException($"Unsupported OSC raw data type: {raw.GetType().FullName}");
+            }
+        }
+
+        internal char GetTypeTagChar()
+        {
+            switch (Kind)
+            {
+                case OscDataKind.Boolean:
+                    return BoolValue ? 'T' : 'F';
+                case OscDataKind.Nil:
+                    return 'N';
+                case OscDataKind.Impulse:
+                    return 'I';
+                case OscDataKind.Int32:
+                    return 'i';
+                case OscDataKind.Float32:
+                    return 'f';
+                case OscDataKind.TimeTag:
+                    return 't';
+                case OscDataKind.String:
+                    return 's';
+                case OscDataKind.Symbol:
+                    return 'S';
+                case OscDataKind.Blob:
+                    return 'b';
+                case OscDataKind.Color:
+                    return 'r';
+                case OscDataKind.Int64:
+                    return 'h';
+                case OscDataKind.Float64:
+                    return 'd';
+                case OscDataKind.Char:
+                    return 'c';
+                case OscDataKind.Midi:
+                    return 'm';
+                case OscDataKind.Array:
+                    return '[';
+                default:
+                    throw new NotSupportedException($"Unsupported OSC data kind: {Kind}");
+            }
+        }
+
+        internal object ToQueryValue()
+        {
+            switch (Kind)
+            {
+                case OscDataKind.Boolean:
+                    return BoolValue;
+                case OscDataKind.Nil:
+                    return null;
+                case OscDataKind.Impulse:
+                    return "impulse";
+                case OscDataKind.Int32:
+                    return IntValue;
+                case OscDataKind.Float32:
+                    return FloatValue;
+                case OscDataKind.TimeTag:
+                    return new[] { TimeTagSeconds, TimeTagNanoseconds };
+                case OscDataKind.String:
+                case OscDataKind.Symbol:
+                    return StringValue ?? string.Empty;
+                case OscDataKind.Blob:
+                    return Array.ConvertAll(BlobValue ?? Array.Empty<byte>(), b => (int)b);
+                case OscDataKind.Color:
+                    return new[] { (int)ColorR, (int)ColorG, (int)ColorB, (int)ColorA };
+                case OscDataKind.Int64:
+                    return LongValue;
+                case OscDataKind.Float64:
+                    return DoubleValue;
+                case OscDataKind.Char:
+                    return UIntValue;
+                case OscDataKind.Midi:
+                    return new[] { (int)MidiPort, (int)MidiStatus, (int)MidiData1, (int)MidiData2 };
+                case OscDataKind.Array:
+                    object[] nested = new object[Elements?.Length ?? 0];
+                    for (int i = 0; i < nested.Length; i++)
+                    {
+                        OscData element = Elements[i];
+                        nested[i] = element != null ? element.ToQueryValue() : null;
+                    }
+                    return nested;
+                default:
+                    throw new NotSupportedException($"Unsupported OSC data kind: {Kind}");
+            }
+        }
+
+        internal object ToOscArgument()
+        {
+            switch (Kind)
+            {
+                case OscDataKind.Boolean:
+                    return BoolValue;
+                case OscDataKind.Nil:
+                    return null;
+                case OscDataKind.Impulse:
+                    return SimpleOSC.Impulse.IMPULSE;
+                case OscDataKind.Int32:
+                    return IntValue;
+                case OscDataKind.Float32:
+                    return FloatValue;
+                case OscDataKind.TimeTag:
+                    return new SimpleOSC.TimeTag
+                    {
+                        secs = TimeTagSeconds,
+                        nsecs = TimeTagNanoseconds,
+                    };
+                case OscDataKind.String:
+                    return StringValue ?? string.Empty;
+                case OscDataKind.Symbol:
+                    return new SimpleOSC.OSCSymbol
+                    {
+                        value = StringValue ?? string.Empty,
+                    };
+                case OscDataKind.Blob:
+                    return BlobValue ?? Array.Empty<byte>();
+                case OscDataKind.Color:
+                    return new SimpleOSC.OSCColor
+                    {
+                        r = ColorR,
+                        g = ColorG,
+                        b = ColorB,
+                        a = ColorA,
+                    };
+                case OscDataKind.Int64:
+                    return LongValue;
+                case OscDataKind.Float64:
+                    return DoubleValue;
+                case OscDataKind.Char:
+                    return UIntValue;
+                case OscDataKind.Midi:
+                    return new SimpleOSC.OSCMidi
+                    {
+                        port = MidiPort,
+                        status = MidiStatus,
+                        data1 = MidiData1,
+                        data2 = MidiData2,
+                    };
+                case OscDataKind.Array:
+                    object[] nested = new object[Elements?.Length ?? 0];
+                    for (int i = 0; i < nested.Length; i++)
+                    {
+                        OscData element = Elements[i];
+                        nested[i] = element != null ? element.ToOscArgument() : null;
+                    }
+                    return nested;
+                default:
+                    throw new NotSupportedException($"Unsupported OSC data kind: {Kind}");
+            }
+        }
+    }
+}

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/OscData.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/OscData.cs
@@ -34,8 +34,8 @@ namespace HVR.Basis.Comms.OSC
         public string StringValue { get; private set; }
         public byte[] BlobValue { get; private set; }
         public OscData[] Elements { get; private set; } = Array.Empty<OscData>();
-        public int TimeTagSeconds { get; private set; }
-        public int TimeTagNanoseconds { get; private set; }
+        public uint TimeTagSeconds { get; private set; }
+        public uint TimeTagNanoseconds { get; private set; }
         public byte ColorR { get; private set; }
         public byte ColorG { get; private set; }
         public byte ColorB { get; private set; }
@@ -73,7 +73,7 @@ namespace HVR.Basis.Comms.OSC
             FloatValue = value,
         };
 
-        public static OscData TimeTag(int seconds, int nanoseconds) => new OscData
+        public static OscData TimeTag(uint seconds, uint nanoseconds) => new OscData
         {
             Kind = OscDataKind.TimeTag,
             TimeTagSeconds = seconds,
@@ -306,7 +306,7 @@ namespace HVR.Basis.Comms.OSC
                         value = StringValue ?? string.Empty,
                     };
                 case OscDataKind.Blob:
-                    return BlobValue ?? Array.Empty<byte>();
+                    return BlobValue != null ? (byte[])BlobValue.Clone() : Array.Empty<byte>();
                 case OscDataKind.Color:
                     return new SimpleOSC.OSCColor
                     {

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/OscData.cs.meta
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/OscData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 09d1365203234732967e7d6674683acf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/OscMessage.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/OscMessage.cs
@@ -15,8 +15,8 @@ namespace HVR.Basis.Comms.OSC
         public int SenderPort { get; private set; }
         public uint BundleId { get; private set; }
         public bool HasTimeTag { get; private set; }
-        public int TimeTagSeconds { get; private set; }
-        public int TimeTagNanoseconds { get; private set; }
+        public uint TimeTagSeconds { get; private set; }
+        public uint TimeTagNanoseconds { get; private set; }
 
         public static OscMessage FromRaw(SimpleOSC.OSCMessage message)
         {
@@ -30,7 +30,7 @@ namespace HVR.Basis.Comms.OSC
                 Path = path,
                 NormalizedPath = normalizedPath,
                 TypeTag = message.typeTag ?? string.Empty,
-                Arguments = OscData.ConvertArguments(message.arguments),
+                Arguments = OscData.ConvertArguments(message.arguments) ?? Array.Empty<OscData>(),
                 SenderAddress = message.sender?.Address?.ToString() ?? string.Empty,
                 SenderPort = message.sender?.Port ?? 0,
                 BundleId = message.bundleId,

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/OscMessage.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/OscMessage.cs
@@ -1,0 +1,43 @@
+using System;
+using HVR.Basis.Comms.OSC.Lyuma;
+
+namespace HVR.Basis.Comms.OSC
+{
+    public sealed class OscMessage
+    {
+        private const string AvatarParametersPrefix = "/avatar/parameters/";
+
+        public string Path { get; private set; }
+        public string NormalizedPath { get; private set; }
+        public string TypeTag { get; private set; }
+        public OscData[] Arguments { get; private set; } = Array.Empty<OscData>();
+        public string SenderAddress { get; private set; }
+        public int SenderPort { get; private set; }
+        public uint BundleId { get; private set; }
+        public bool HasTimeTag { get; private set; }
+        public int TimeTagSeconds { get; private set; }
+        public int TimeTagNanoseconds { get; private set; }
+
+        public static OscMessage FromRaw(SimpleOSC.OSCMessage message)
+        {
+            string path = message.path ?? string.Empty;
+            string normalizedPath = path.StartsWith(AvatarParametersPrefix, StringComparison.Ordinal)
+                ? path.Substring(AvatarParametersPrefix.Length)
+                : path;
+
+            return new OscMessage
+            {
+                Path = path,
+                NormalizedPath = normalizedPath,
+                TypeTag = message.typeTag ?? string.Empty,
+                Arguments = OscData.ConvertArguments(message.arguments),
+                SenderAddress = message.sender?.Address?.ToString() ?? string.Empty,
+                SenderPort = message.sender?.Port ?? 0,
+                BundleId = message.bundleId,
+                HasTimeTag = message.time.secs != 0 || message.time.nsecs != 0,
+                TimeTagSeconds = message.time.secs,
+                TimeTagNanoseconds = message.time.nsecs,
+            };
+        }
+    }
+}

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/OscMessage.cs.meta
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OSC/OscMessage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bf47ee3ec3c5415faf6f0ca34f06b425
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OsushiQuery/OsushiNode.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OsushiQuery/OsushiNode.cs
@@ -83,6 +83,21 @@ namespace HVR.Osushi
                                 }
                             }
                         }
+                    },
+                    ["chatbox"] = new()
+                    {
+                        DESCRIPTION = "Basis ChatBox OSC endpoints.",
+                        FULL_PATH = "/chatbox",
+                        ACCESS = 0,
+                        CONTENTS = new Dictionary<string, OsushiNode>
+                        {
+                            ["input"] = new()
+                            {
+                                DESCRIPTION = "Accepted signatures: (string [, shouldOpenKeyboard [, playNotificationSound]]) and (bool typing).",
+                                FULL_PATH = "/chatbox/input",
+                                ACCESS = 2,
+                            }
+                        }
                     }
                 }
             };

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OsushiQuery/OsushiQuery.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OsushiQuery/OsushiQuery.cs
@@ -9,16 +9,17 @@ namespace HVR.Osushi
 {
     internal class OsushiQuery
     {
-        private readonly string _root;
-        private readonly string _avtr;
+        private readonly Func<string, string> _responseResolver;
         private bool _isStarted;
+        private volatile bool _isStopping;
         private ServiceDiscovery _serviceDiscovery;
         private Thread _httpThread;
+        private HttpListener _listener;
+        private readonly object _serverLock = new object();
 
-        public OsushiQuery(string root, string avtr)
+        public OsushiQuery(Func<string, string> responseResolver)
         {
-            _root = root;
-            _avtr = avtr;
+            _responseResolver = responseResolver;
         }
 
         public void Start()
@@ -33,19 +34,25 @@ namespace HVR.Osushi
             {
                 try
                 {
-                    StartHttpServer(httpPort, _root, _avtr);
+                    StartHttpServer(httpPort);
                 }
                 catch (ThreadAbortException)
                 {
-                  //  BasisDebug.LogError($"ThreadAbortException", BasisDebug.LogTag.LocalNetwork);
+                    // Expected during script/domain reload and shutdown on Mono.
                 }
                 catch (ThreadInterruptedException)
                 {
-                 //   BasisDebug.LogError($"ThreadInterruptedException", BasisDebug.LogTag.LocalNetwork);
+                    if (!_isStopping)
+                    {
+                        BasisDebug.LogError("ThreadInterruptedException", BasisDebug.LogTag.LocalNetwork);
+                    }
                 }
                 catch (Exception e)
                 {
-                    BasisDebug.LogError($"HTTP server thread died: {e}", BasisDebug.LogTag.LocalNetwork);
+                    if (!_isStopping)
+                    {
+                        BasisDebug.LogError($"HTTP server thread died: {e}", BasisDebug.LogTag.LocalNetwork);
+                    }
                 }
             });
             _httpThread.IsBackground = true;
@@ -70,20 +77,38 @@ namespace HVR.Osushi
         {
             if (!_isStarted) return;
             _isStarted = false;
+            _isStopping = true;
 
             try
             {
-                _httpThread.Interrupt();
+                lock (_serverLock)
+                {
+                    _listener?.Close();
+                    _listener = null;
+                }
             }
             catch (Exception e)
             {
-                BasisDebug.LogError($"HTTP server stopped: {e}", BasisDebug.LogTag.LocalNetwork);
+                BasisDebug.LogError($"HTTP server stop failed: {e}", BasisDebug.LogTag.LocalNetwork);
+            }
+
+            try
+            {
+                if (_httpThread != null && _httpThread.IsAlive)
+                {
+                    _httpThread.Join(250);
+                }
+            }
+            catch (Exception e)
+            {
+                BasisDebug.LogError($"HTTP server join failed: {e}", BasisDebug.LogTag.LocalNetwork);
             }
 
             _httpThread = null;
 
-            _serviceDiscovery.Dispose();
+            _serviceDiscovery?.Dispose();
             _serviceDiscovery = null;
+            _isStopping = false;
         }
 
         static int GetRandomFreePort()
@@ -95,7 +120,7 @@ namespace HVR.Osushi
             return port;
         }
 
-        static void StartHttpServer(int port, string root, string avtr)
+        private void StartHttpServer(int port)
         {
             if (!HttpListener.IsSupported)
             {
@@ -107,40 +132,70 @@ namespace HVR.Osushi
             listener.Prefixes.Add($"http://localhost:{port}/");
             listener.Prefixes.Add($"http://127.0.0.1:{port}/");
             listener.Start();
+            lock (_serverLock)
+            {
+                _listener = listener;
+            }
             BasisDebug.Log($"HTTP server listening on http://localhost:{port}/", BasisDebug.LogTag.LocalNetwork);
 
-            while (true)
+            try
             {
-                try
+                while (!_isStopping)
                 {
-                    var ctx = listener.GetContext();
-                    BasisDebug.Log($"HTTP request: {ctx.Request.RawUrl}", BasisDebug.LogTag.LocalNetwork);
+                    try
+                    {
+                        var ctx = listener.GetContext();
+                        BasisDebug.Log($"HTTP request: {ctx.Request.RawUrl}", BasisDebug.LogTag.LocalNetwork);
 
-                    var res = ctx.Response;
-                    var json = ctx.Request.RawUrl.EndsWith("/avatar") ? avtr : root;
-                    var buffer = Encoding.UTF8.GetBytes(json);
-                    res.ContentType = "application/json";
-                    res.ContentLength64 = buffer.Length;
-                    res.OutputStream.Write(buffer, 0, buffer.Length);
-                    res.OutputStream.Close();
+                        var res = ctx.Response;
+                        var json = _responseResolver(ctx.Request.RawUrl);
+                        var buffer = Encoding.UTF8.GetBytes(json);
+                        res.ContentType = "application/json";
+                        res.ContentLength64 = buffer.Length;
+                        res.OutputStream.Write(buffer, 0, buffer.Length);
+                        res.OutputStream.Close();
+                    }
+                    catch (ThreadAbortException)
+                    {
+                        // Expected during script/domain reload and shutdown on Mono.
+                        break;
+                    }
+                    catch (HttpListenerException e)
+                    {
+                        if (!_isStopping)
+                        {
+                            BasisDebug.LogError($"HttpListener closed unexpectedly: {e.Message}", BasisDebug.LogTag.LocalNetwork);
+                        }
+                        break;
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        if (!_isStopping)
+                        {
+                            BasisDebug.LogError("HttpListener disposed unexpectedly", BasisDebug.LogTag.LocalNetwork);
+                        }
+                        break;
+                    }
+                    catch (Exception e)
+                    {
+                        if (!_isStopping)
+                        {
+                            BasisDebug.LogError($"Request error (continuing): {e.Message}", BasisDebug.LogTag.LocalNetwork);
+                        }
+                    }
                 }
-                catch (HttpListenerException e)
+            }
+            finally
+            {
+                lock (_serverLock)
                 {
-                    BasisDebug.LogError($"HttpListener closed: {e.Message}", BasisDebug.LogTag.LocalNetwork);
-                    break;
+                    if (ReferenceEquals(_listener, listener))
+                    {
+                        _listener = null;
+                    }
                 }
-                catch (ThreadAbortException)
-                {
-                    break;
-                }
-                catch (ThreadInterruptedException)
-                {
-                    break;
-                }
-                catch (Exception e)
-                {
-                    BasisDebug.LogError($"[Request error (continuing): {e.Message}", BasisDebug.LogTag.LocalNetwork);
-                }
+
+                listener.Close();
             }
         }
     }

--- a/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OsushiQuery/OsushiQuery.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Scripts/Systems/Runtime/OsushiQuery/OsushiQuery.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
@@ -19,7 +20,7 @@ namespace HVR.Osushi
 
         public OsushiQuery(Func<string, string> responseResolver)
         {
-            _responseResolver = responseResolver;
+            _responseResolver = responseResolver ?? throw new ArgumentNullException(nameof(responseResolver));
         }
 
         public void Start()
@@ -147,13 +148,38 @@ namespace HVR.Osushi
                         var ctx = listener.GetContext();
                         BasisDebug.Log($"HTTP request: {ctx.Request.RawUrl}", BasisDebug.LogTag.LocalNetwork);
 
-                        var res = ctx.Response;
-                        var json = _responseResolver(ctx.Request.RawUrl);
-                        var buffer = Encoding.UTF8.GetBytes(json);
-                        res.ContentType = "application/json";
-                        res.ContentLength64 = buffer.Length;
-                        res.OutputStream.Write(buffer, 0, buffer.Length);
-                        res.OutputStream.Close();
+                        try
+                        {
+                            using (var res = ctx.Response)
+                            {
+                                var json = _responseResolver(ctx.Request.RawUrl) ?? "{}";
+                                var buffer = Encoding.UTF8.GetBytes(json);
+                                res.ContentType = "application/json";
+                                res.ContentLength64 = buffer.Length;
+                                res.OutputStream.Write(buffer, 0, buffer.Length);
+                            }
+                        }
+                        catch (HttpListenerException e)
+                        {
+                            if (!_isStopping)
+                            {
+                                BasisDebug.Log($"HTTP client disconnected before response completed: {e.Message}", BasisDebug.LogTag.LocalNetwork);
+                            }
+                        }
+                        catch (IOException e)
+                        {
+                            if (!_isStopping)
+                            {
+                                BasisDebug.Log($"HTTP client disconnected during response write: {e.Message}", BasisDebug.LogTag.LocalNetwork);
+                            }
+                        }
+                        catch (ObjectDisposedException e)
+                        {
+                            if (!_isStopping)
+                            {
+                                BasisDebug.Log($"HTTP response disposed before write completed: {e.Message}", BasisDebug.LogTag.LocalNetwork);
+                            }
+                        }
                     }
                     catch (ThreadAbortException)
                     {

--- a/Basis/Packages/dev.hai-vr.basis.comms/Tests.meta
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1fab38901aa34e6baa9d61611c5242dc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Basis/Packages/dev.hai-vr.basis.comms/Tests/Runtime.meta
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Tests/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3a0f5ec4a21346cc9dc6e428bcfa6606
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Basis/Packages/dev.hai-vr.basis.comms/Tests/Runtime/HVR.Basis.Comms.Tests.asmdef
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Tests/Runtime/HVR.Basis.Comms.Tests.asmdef
@@ -1,0 +1,26 @@
+{
+    "name": "HVR.Basis.Comms.Tests",
+    "rootNamespace": "",
+    "references": [
+        "HVR.Basis.Comms",
+        "Basis Framework",
+        "BasisNetworkCore",
+        "BasisSDK",
+        "BasisShims",
+        "Cilbox",
+        "UnityEngine.TestRunner"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Basis/Packages/dev.hai-vr.basis.comms/Tests/Runtime/HVR.Basis.Comms.Tests.asmdef.meta
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Tests/Runtime/HVR.Basis.Comms.Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 87dd2b7bc7224b9fb76d7d3dbf8d4346
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Basis/Packages/dev.hai-vr.basis.comms/Tests/Runtime/OscBridgeTests.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Tests/Runtime/OscBridgeTests.cs
@@ -1,0 +1,1265 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using Basis.BasisUI;
+using Basis.Network.Core;
+using Basis.Shims;
+using Basis.Scripts.BasisSdk;
+using Cilbox;
+using HVR.Basis.Comms;
+using HVR.Basis.Comms.OSC;
+using HVR.Basis.Comms.OSC.Lyuma;
+using NUnit.Framework;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace HVR.Basis.Comms.Tests
+{
+    public class OscBridgeTests
+    {
+        [TearDown]
+        public void TearDown()
+        {
+            DestroySceneInstance();
+        }
+
+        [Test]
+        public void SimpleOsc_EncodesAndDecodes_SymbolAndMidi()
+        {
+            byte[] buffer = new byte[1024];
+            int offset = 0;
+            SimpleOSC.OSCMessage outbound = new SimpleOSC.OSCMessage
+            {
+                path = "/test",
+                arguments = new object[]
+                {
+                    new SimpleOSC.OSCSymbol { value = "symbolic" },
+                    new SimpleOSC.OSCMidi { port = 1, status = 2, data1 = 3, data2 = 4 },
+                }
+            };
+
+            SimpleOSC.EncodeOSCInto(buffer, ref offset, outbound);
+
+            ConcurrentQueue<SimpleOSC.OSCMessage> queue = new ConcurrentQueue<SimpleOSC.OSCMessage>();
+            SimpleOSC.DecodeOSCInto(queue, buffer, 0, offset);
+
+            Assert.That(queue.TryDequeue(out SimpleOSC.OSCMessage inbound), Is.True);
+            Assert.That(inbound.typeTag, Is.EqualTo(",Sm"));
+            Assert.That(((SimpleOSC.OSCSymbol)inbound.arguments[0]).value, Is.EqualTo("symbolic"));
+
+            SimpleOSC.OSCMidi midi = (SimpleOSC.OSCMidi)inbound.arguments[1];
+            Assert.That(midi.port, Is.EqualTo(1));
+            Assert.That(midi.status, Is.EqualTo(2));
+            Assert.That(midi.data1, Is.EqualTo(3));
+            Assert.That(midi.data2, Is.EqualTo(4));
+        }
+
+        [Test]
+        public void OscMessage_ConvertsAllSupportedDataKinds()
+        {
+            SimpleOSC.OSCMessage raw = new SimpleOSC.OSCMessage
+            {
+                path = "/avatar/parameters/Test",
+                typeTag = ",TFNiftsSbrhdcm[is]I",
+                arguments = new object[]
+                {
+                    true,
+                    false,
+                    null,
+                    7,
+                    2.5f,
+                    new SimpleOSC.TimeTag { secs = 1, nsecs = 2 },
+                    "text",
+                    new SimpleOSC.OSCSymbol { value = "symbol" },
+                    new byte[] { 9, 8 },
+                    new SimpleOSC.OSCColor { r = 1, g = 2, b = 3, a = 4 },
+                    99L,
+                    10.5d,
+                    (uint)65,
+                    new SimpleOSC.OSCMidi { port = 5, status = 6, data1 = 7, data2 = 8 },
+                    new object[] { 3, "nested" },
+                    SimpleOSC.Impulse.IMPULSE,
+                }
+            };
+
+            OscMessage message = OscMessage.FromRaw(raw);
+
+            Assert.That(message.Path, Is.EqualTo("/avatar/parameters/Test"));
+            Assert.That(message.NormalizedPath, Is.EqualTo("Test"));
+            Assert.That(message.Arguments.Length, Is.EqualTo(16));
+            Assert.That(message.Arguments[0].Kind, Is.EqualTo(OscDataKind.Boolean));
+            Assert.That(message.Arguments[1].Kind, Is.EqualTo(OscDataKind.Boolean));
+            Assert.That(message.Arguments[2].Kind, Is.EqualTo(OscDataKind.Nil));
+            Assert.That(message.Arguments[3].Kind, Is.EqualTo(OscDataKind.Int32));
+            Assert.That(message.Arguments[4].Kind, Is.EqualTo(OscDataKind.Float32));
+            Assert.That(message.Arguments[5].Kind, Is.EqualTo(OscDataKind.TimeTag));
+            Assert.That(message.Arguments[6].Kind, Is.EqualTo(OscDataKind.String));
+            Assert.That(message.Arguments[7].Kind, Is.EqualTo(OscDataKind.Symbol));
+            Assert.That(message.Arguments[8].Kind, Is.EqualTo(OscDataKind.Blob));
+            Assert.That(message.Arguments[9].Kind, Is.EqualTo(OscDataKind.Color));
+            Assert.That(message.Arguments[10].Kind, Is.EqualTo(OscDataKind.Int64));
+            Assert.That(message.Arguments[11].Kind, Is.EqualTo(OscDataKind.Float64));
+            Assert.That(message.Arguments[12].Kind, Is.EqualTo(OscDataKind.Char));
+            Assert.That(message.Arguments[13].Kind, Is.EqualTo(OscDataKind.Midi));
+            Assert.That(message.Arguments[14].Kind, Is.EqualTo(OscDataKind.Array));
+            Assert.That(message.Arguments[15].Kind, Is.EqualTo(OscDataKind.Impulse));
+            Assert.That(message.Arguments[14].Elements[1].StringValue, Is.EqualTo("nested"));
+        }
+
+        [Test]
+        public void BasisOsc_FiltersExactAndPrefixSubscriptions()
+        {
+            GameObject go = new GameObject("OscShimTest");
+            MethodInfo publish = typeof(BasisOscService).GetMethod("Publish", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.That(publish, Is.Not.Null);
+
+            try
+            {
+                BasisOsc shim = go.AddComponent<BasisOsc>();
+                int callCount = 0;
+
+                shim.OnMessage = (message, arguments) => callCount++;
+                shim.Subscribe("/exact", (message, arguments) => { });
+                shim.SubscribePrefix("/prefix/", (message, arguments) => { });
+
+                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/nope", arguments = new object[0] }) });
+                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/exact", arguments = new object[0] }) });
+                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/prefix/value", arguments = new object[0] }) });
+
+                Assert.That(callCount, Is.EqualTo(2));
+
+                shim.enabled = false;
+                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/exact", arguments = new object[0] }) });
+
+                Assert.That(callCount, Is.EqualTo(2));
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+
+        [Test]
+        public void BasisOsc_NormalizesAvatarParameterSubscriptions()
+        {
+            GameObject go = new GameObject("OscShimNormalizeTest");
+            MethodInfo publish = typeof(BasisOscService).GetMethod("Publish", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.That(publish, Is.Not.Null);
+
+            try
+            {
+                BasisOsc shim = go.AddComponent<BasisOsc>();
+                int callCount = 0;
+
+                shim.OnMessage = (message, arguments) => callCount++;
+                shim.Subscribe("Face/Smile", (message, arguments) => { });
+                shim.SubscribePrefix("FT/", (message, arguments) => { });
+
+                Assert.That(shim.IsSubscribed("/avatar/parameters/Face/Smile"), Is.True);
+                Assert.That(shim.IsPrefixSubscribed("/avatar/parameters/FT/"), Is.True);
+
+                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/avatar/parameters/Face/Smile", arguments = new object[0] }) });
+                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/avatar/parameters/FT/v2/JawOpen", arguments = new object[0] }) });
+
+                Assert.That(callCount, Is.EqualTo(2));
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+
+        [Test]
+        public void BasisOsc_SubscribeWithCallback_InvokesExactHandler()
+        {
+            GameObject go = new GameObject("OscShimCallbackTest");
+            MethodInfo publish = typeof(BasisOscService).GetMethod("Publish", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.That(publish, Is.Not.Null);
+
+            try
+            {
+                BasisOsc shim = go.AddComponent<BasisOsc>();
+                int callCount = 0;
+
+                shim.Subscribe("/avatar/parameters/Callback", (message, arguments) =>
+                {
+                    callCount++;
+                    Assert.That(message.Path, Is.EqualTo("/avatar/parameters/Callback"));
+                    Assert.That(arguments[0].FloatValue, Is.EqualTo(2.5f));
+                });
+
+                publish.Invoke(null, new object[]
+                {
+                    OscMessage.FromRaw(new SimpleOSC.OSCMessage
+                    {
+                        path = "/avatar/parameters/Callback",
+                        arguments = new object[] { 2.5f }
+                    })
+                });
+
+                Assert.That(callCount, Is.EqualTo(1));
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+
+        [Test]
+        public void BasisOsc_SubmitRawMessages_DeliversRepeatedPackets()
+        {
+            GameObject go = new GameObject("OscShimRepeatedRawCallbackTest");
+            MethodInfo submitRawMessages = typeof(BasisOscService).GetMethod("SubmitRawMessages", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.That(submitRawMessages, Is.Not.Null);
+
+            try
+            {
+                BasisOsc shim = go.AddComponent<BasisOsc>();
+                int callCount = 0;
+                float lastValue = 0f;
+
+                shim.Subscribe("/avatar/parameters/Callback", (message, arguments) =>
+                {
+                    callCount++;
+                    lastValue = arguments[0].FloatValue;
+                });
+
+                submitRawMessages.Invoke(null, new object[]
+                {
+                    new List<SimpleOSC.OSCMessage>
+                    {
+                        new SimpleOSC.OSCMessage
+                        {
+                            path = "/avatar/parameters/Callback",
+                            arguments = new object[] { 1f }
+                        }
+                    }
+                });
+
+                submitRawMessages.Invoke(null, new object[]
+                {
+                    new List<SimpleOSC.OSCMessage>
+                    {
+                        new SimpleOSC.OSCMessage
+                        {
+                            path = "/avatar/parameters/Callback",
+                            arguments = new object[] { 2f }
+                        }
+                    }
+                });
+
+                Assert.That(callCount, Is.EqualTo(2));
+                Assert.That(lastValue, Is.EqualTo(2f));
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+
+        [Test]
+        public void BasisOsc_SubscribeValue_InvokesFirstArgument()
+        {
+            GameObject go = new GameObject("OscShimValueCallbackTest");
+            MethodInfo publish = typeof(BasisOscService).GetMethod("Publish", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.That(publish, Is.Not.Null);
+
+            try
+            {
+                BasisOsc shim = go.AddComponent<BasisOsc>();
+                OscData received = null;
+
+                shim.SubscribeValue("/avatar/parameters/ValueCallback", value => received = value);
+
+                publish.Invoke(null, new object[]
+                {
+                    OscMessage.FromRaw(new SimpleOSC.OSCMessage
+                    {
+                        path = "/avatar/parameters/ValueCallback",
+                        arguments = new object[] { "text", 5 }
+                    })
+                });
+
+                Assert.That(received, Is.Not.Null);
+                Assert.That(received.Kind, Is.EqualTo(OscDataKind.String));
+                Assert.That(received.StringValue, Is.EqualTo("text"));
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+
+        [Test]
+        public void BasisOsc_SubscribeValue_DoesNotInvokeForEmptyArgumentMessages()
+        {
+            GameObject go = new GameObject("OscShimEmptyValueCallbackTest");
+            MethodInfo publish = typeof(BasisOscService).GetMethod("Publish", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.That(publish, Is.Not.Null);
+
+            try
+            {
+                BasisOsc shim = go.AddComponent<BasisOsc>();
+                bool called = false;
+
+                shim.SubscribeValue("/avatar/parameters/ValueCallback", value => called = true);
+
+                publish.Invoke(null, new object[]
+                {
+                    OscMessage.FromRaw(new SimpleOSC.OSCMessage
+                    {
+                        path = "/avatar/parameters/ValueCallback",
+                        arguments = Array.Empty<object>()
+                    })
+                });
+
+                Assert.That(called, Is.False);
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+
+        [Test]
+        public void OscData_Factories_DefensivelyCopyInputArrays()
+        {
+            byte[] blob = { 1, 2, 3 };
+            OscData[] elements = { OscData.Int32(7) };
+
+            OscData blobData = OscData.Blob(blob);
+            OscData arrayData = OscData.ArrayValue(elements);
+
+            blob[0] = 99;
+            elements[0] = OscData.Int32(11);
+
+            Assert.That(blobData.BlobValue[0], Is.EqualTo(1));
+            Assert.That(arrayData.Elements[0].IntValue, Is.EqualTo(7));
+        }
+
+        [Test]
+        public void OscData_ArrayConversions_HandleNullNestedElements()
+        {
+            OscData data = OscData.ArrayValue(OscData.Int32(7), null, OscData.String("x"));
+            MethodInfo toQueryValue = typeof(OscData).GetMethod("ToQueryValue", BindingFlags.NonPublic | BindingFlags.Instance);
+            MethodInfo toOscArgument = typeof(OscData).GetMethod("ToOscArgument", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            Assert.That(toQueryValue, Is.Not.Null);
+            Assert.That(toOscArgument, Is.Not.Null);
+
+            object[] queryValue = (object[])toQueryValue.Invoke(data, null);
+            object[] oscArgument = (object[])toOscArgument.Invoke(data, null);
+
+            Assert.That(queryValue.Length, Is.EqualTo(3));
+            Assert.That(queryValue[0], Is.EqualTo(7));
+            Assert.That(queryValue[1], Is.Null);
+            Assert.That(queryValue[2], Is.EqualTo("x"));
+
+            Assert.That(oscArgument.Length, Is.EqualTo(3));
+            Assert.That(oscArgument[0], Is.EqualTo(7));
+            Assert.That(oscArgument[1], Is.Null);
+            Assert.That(oscArgument[2], Is.EqualTo("x"));
+        }
+
+        [Test]
+        public void CilboxWhitelists_AllowDirectOscTypes()
+        {
+            Assert.That(new CilboxSceneBasis().CheckTypeAllowed("HVR.Basis.Comms.OSC.OscMessage"), Is.True);
+            Assert.That(new CilboxPropBasis().CheckTypeAllowed("HVR.Basis.Comms.OSC.OscData"), Is.True);
+            Assert.That(new CilboxAvatarBasis().CheckTypeAllowed("HVR.Basis.Comms.OSC.OscDataKind"), Is.True);
+            Assert.That(new CilboxAvatarBasis().CheckTypeAllowed("Basis.Shims.BasisOsc"), Is.True);
+            Assert.That(new CilboxAvatarBasis().CheckTypeAllowed("Basis.Shims.BasisOsc+OscValueEvent"), Is.True);
+        }
+
+        [Test]
+        public void BasisOscService_PublishesValuesIntoNodeMap()
+        {
+            DestroySceneInstance();
+            BasisOscService.PublishValues("Custom/TestNode", new[]
+            {
+                OscData.Float32(0.5f),
+                OscData.String("hello"),
+            });
+
+            System.Type serverType = GetServerType();
+            Assert.That(serverType, Is.Not.Null);
+
+            FieldInfo sceneInstanceField = GetSceneInstanceField(serverType);
+            Assert.That(sceneInstanceField, Is.Not.Null);
+
+            MonoBehaviour sceneInstance = (MonoBehaviour)sceneInstanceField.GetValue(null);
+            Assert.That(sceneInstance, Is.Not.Null);
+
+            try
+            {
+                FieldInfo rootField = serverType.GetField("_oscQueryRoot", BindingFlags.NonPublic | BindingFlags.Instance);
+                Assert.That(rootField, Is.Not.Null);
+                object rootNode = rootField.GetValue(sceneInstance);
+                Assert.That(rootNode, Is.Not.Null);
+
+                object leaf = ResolveNode(rootNode, "avatar", "parameters", "Custom", "TestNode");
+                Assert.That(leaf, Is.Not.Null);
+
+                System.Type nodeType = leaf.GetType();
+                Assert.That((string)nodeType.GetField("FULL_PATH").GetValue(leaf), Is.EqualTo("/avatar/parameters/Custom/TestNode"));
+                Assert.That((string)nodeType.GetField("TYPE").GetValue(leaf), Is.EqualTo(",fs"));
+
+                IList values = (IList)nodeType.GetField("VALUE").GetValue(leaf);
+                Assert.That(values.Count, Is.EqualTo(2));
+                Assert.That(values[0], Is.EqualTo(0.5f));
+                Assert.That(values[1], Is.EqualTo("hello"));
+            }
+            finally
+            {
+                Object.DestroyImmediate(sceneInstance.gameObject);
+                sceneInstanceField.SetValue(null, null);
+            }
+        }
+
+        [Test]
+        public void BasisOsc_Subscribe_RegistersExactAddressInNodeMap()
+        {
+            DestroySceneInstance();
+            GameObject go = new GameObject("OscExactQueryRegistration");
+
+            try
+            {
+                BasisOsc shim = go.AddComponent<BasisOsc>();
+                shim.Subscribe("Face/Smile", (message, arguments) => { });
+
+                object leaf = ResolveNode(GetQueryRoot(), "avatar", "parameters", "Face", "Smile");
+                Assert.That(leaf, Is.Not.Null);
+                Assert.That((string)leaf.GetType().GetField("FULL_PATH").GetValue(leaf), Is.EqualTo("/avatar/parameters/Face/Smile"));
+                Assert.That((int)leaf.GetType().GetField("ACCESS").GetValue(leaf), Is.EqualTo(2));
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+                DestroySceneInstance();
+            }
+        }
+
+        [Test]
+        public void BasisOsc_SubscribeWithCallback_ReturnsResolvedRelativeAddress()
+        {
+            GameObject go = new GameObject("OscResolvedSubscribe");
+
+            try
+            {
+                BasisOsc shim = go.AddComponent<BasisOsc>();
+                shim.Subscribe("Face/Smile", (message, arguments) => { }, out string resolvedAddress);
+
+                Assert.That(resolvedAddress, Is.EqualTo("/avatar/parameters/Face/Smile"));
+                Assert.That(shim.IsSubscribed(resolvedAddress), Is.True);
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+
+        [Test]
+        public void BasisOsc_Subscribe_LocalOnlyOnRemoteAvatar_DoesNotRegisterOrInvoke()
+        {
+            GameObject go = new GameObject("RemoteAvatarLocalOnlySubscribe");
+            MethodInfo publish = typeof(BasisOscService).GetMethod("Publish", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.That(publish, Is.Not.Null);
+
+            try
+            {
+                BasisAvatar avatar = go.AddComponent<BasisAvatar>();
+                avatar.IsOwnedLocally = false;
+
+                BasisOsc shim = go.AddComponent<BasisOsc>();
+                int callCount = 0;
+
+                shim.Subscribe("Blocked", (message, arguments) => callCount++, true, out string resolvedAddress);
+
+                Assert.That(resolvedAddress, Is.Null);
+                Assert.That(shim.IsSubscribed("/avatar/public/Blocked"), Is.False);
+
+                publish.Invoke(null, new object[]
+                {
+                    OscMessage.FromRaw(new SimpleOSC.OSCMessage
+                    {
+                        path = "/avatar/public/Blocked",
+                        arguments = Array.Empty<object>()
+                    })
+                });
+
+                Assert.That(callCount, Is.EqualTo(0));
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+
+        [Test]
+        public void BasisOsc_SubscribeValue_LocalOnlyOnRemoteAvatar_DoesNotRegisterOrInvoke()
+        {
+            GameObject go = new GameObject("RemoteAvatarLocalOnlyValueSubscribe");
+            MethodInfo publish = typeof(BasisOscService).GetMethod("Publish", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.That(publish, Is.Not.Null);
+
+            try
+            {
+                BasisAvatar avatar = go.AddComponent<BasisAvatar>();
+                avatar.IsOwnedLocally = false;
+
+                BasisOsc shim = go.AddComponent<BasisOsc>();
+                bool called = false;
+
+                shim.SubscribeValue("Blocked", value => called = true, true, out string resolvedAddress);
+
+                Assert.That(resolvedAddress, Is.Null);
+                Assert.That(shim.IsSubscribed("/avatar/public/Blocked"), Is.False);
+
+                publish.Invoke(null, new object[]
+                {
+                    OscMessage.FromRaw(new SimpleOSC.OSCMessage
+                    {
+                        path = "/avatar/public/Blocked",
+                        arguments = new object[] { 1f }
+                    })
+                });
+
+                Assert.That(called, Is.False);
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+
+        [Test]
+        public void BasisOsc_RemoteAvatarSubscription_RegistersNormalizedPublicAddressInNodeMap()
+        {
+            DestroySceneInstance();
+            GameObject go = new GameObject("RemoteAvatarQueryRegistration");
+
+            try
+            {
+                BasisAvatar avatar = go.AddComponent<BasisAvatar>();
+                avatar.IsOwnedLocally = false;
+
+                BasisOsc shim = go.AddComponent<BasisOsc>();
+                shim.Subscribe("/avatar/parameters/Blocked", (message, arguments) => { });
+
+                Assert.That(ResolveNode(GetQueryRoot(), "avatar", "parameters", "Blocked"), Is.Null);
+
+                object leaf = ResolveNode(GetQueryRoot(), "avatar", "public", "Blocked");
+                Assert.That(leaf, Is.Not.Null);
+                Assert.That((string)leaf.GetType().GetField("FULL_PATH").GetValue(leaf), Is.EqualTo("/avatar/public/Blocked"));
+                Assert.That((int)leaf.GetType().GetField("ACCESS").GetValue(leaf), Is.EqualTo(2));
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+                DestroySceneInstance();
+            }
+        }
+
+        [Test]
+        public void BasisOsc_RemoteAvatarSubscriptionWithCallback_ReturnsNormalizedPublicAddress()
+        {
+            GameObject go = new GameObject("RemoteAvatarResolvedSubscribe");
+
+            try
+            {
+                BasisAvatar avatar = go.AddComponent<BasisAvatar>();
+                avatar.IsOwnedLocally = false;
+
+                BasisOsc shim = go.AddComponent<BasisOsc>();
+                shim.Subscribe("/avatar/parameters/Blocked", (message, arguments) => { }, out string resolvedAddress);
+
+                Assert.That(resolvedAddress, Is.EqualTo("/avatar/public/Blocked"));
+                Assert.That(shim.IsSubscribed(resolvedAddress), Is.True);
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+
+        [Test]
+        public void BasisOsc_LocalAvatarPublishesIntoAvatarNamespace()
+        {
+            DestroySceneInstance();
+            GameObject go = new GameObject("AvatarPublisher");
+
+            try
+            {
+                BasisAvatar avatar = go.AddComponent<BasisAvatar>();
+                avatar.IsOwnedLocally = true;
+
+                BasisOsc shim = go.AddComponent<BasisOsc>();
+                shim.PublishValue("Face/Smile", OscData.Float32(1f));
+
+                object leaf = ResolveNode(GetQueryRoot(), "avatar", "parameters", "Face", "Smile");
+                Assert.That(leaf, Is.Not.Null);
+                Assert.That((string)leaf.GetType().GetField("FULL_PATH").GetValue(leaf), Is.EqualTo("/avatar/parameters/Face/Smile"));
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+                DestroySceneInstance();
+            }
+        }
+
+        [Test]
+        public void BasisOsc_LocalAvatarPublishValue_SubmitsFloatIntoVixxyVariableStore()
+        {
+            DestroySceneInstance();
+            GameObject go = new GameObject("AvatarVixxyPublisher");
+
+            try
+            {
+                BasisAvatar avatar = go.AddComponent<BasisAvatar>();
+                avatar.IsOwnedLocally = true;
+
+                BasisOsc shim = go.AddComponent<BasisOsc>();
+                shim.PublishValue("Face/Smile", OscData.Float32(0.75f));
+
+                int addressId = HVRAddress.AddressToId("Face/Smile");
+                Assert.That(AcquisitionService.SceneInstance.VariableStore.GetValue(addressId), Is.EqualTo(0.75f));
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+                DestroySceneInstance();
+            }
+        }
+
+        [Test]
+        public void BasisOsc_PublishValue_ReturnsResolvedRelativeAddress()
+        {
+            DestroySceneInstance();
+            GameObject go = new GameObject("AvatarResolvedPublisher");
+
+            try
+            {
+                BasisAvatar avatar = go.AddComponent<BasisAvatar>();
+                avatar.IsOwnedLocally = true;
+
+                BasisOsc shim = go.AddComponent<BasisOsc>();
+                shim.PublishValue("Face/Smile", OscData.Float32(1f), out string resolvedAddress);
+
+                Assert.That(resolvedAddress, Is.EqualTo("/avatar/parameters/Face/Smile"));
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+                DestroySceneInstance();
+            }
+        }
+
+        [Test]
+        public void BasisOsc_RemoteAvatarDoesNotPublish()
+        {
+            DestroySceneInstance();
+            GameObject go = new GameObject("RemoteAvatarPublisher");
+
+            try
+            {
+                BasisAvatar avatar = go.AddComponent<BasisAvatar>();
+                avatar.IsOwnedLocally = false;
+
+                BasisOsc shim = go.AddComponent<BasisOsc>();
+                shim.PublishValue("Blocked", OscData.Float32(1f));
+
+                Assert.That(GetSceneInstanceField(GetServerType()).GetValue(null), Is.Not.Null);
+                Assert.That(ResolveNode(GetQueryRoot(), "avatar", "parameters", "Blocked"), Is.Null);
+                Assert.That(ResolveNode(GetQueryRoot(), "avatar", "public", "Blocked"), Is.Null);
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+                DestroySceneInstance();
+            }
+        }
+
+        [Test]
+        public void BasisOsc_OnEnable_InitializesOscAcquisitionServer_WithoutFaceTracking()
+        {
+            DestroySceneInstance();
+            GameObject go = new GameObject("OscShimOnly");
+
+            try
+            {
+                Assert.That(GetSceneInstanceField(GetServerType()).GetValue(null), Is.Null);
+
+                go.AddComponent<BasisOsc>();
+
+                Assert.That(GetSceneInstanceField(GetServerType()).GetValue(null), Is.Not.Null);
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+                DestroySceneInstance();
+            }
+        }
+
+        [Test]
+        public void OSCAcquisition_ReusesExistingOscAcquisitionServer()
+        {
+            DestroySceneInstance();
+            GameObject avatarRoot = new GameObject("AvatarWithOscAcquisition");
+
+            try
+            {
+                BasisOscService.EnsureInitialized();
+
+                System.Type serverType = GetServerType();
+                FieldInfo sceneInstanceField = GetSceneInstanceField(serverType);
+                MonoBehaviour existingServer = (MonoBehaviour)sceneInstanceField.GetValue(null);
+                Assert.That(existingServer, Is.Not.Null);
+
+                BasisAvatar avatar = avatarRoot.AddComponent<BasisAvatar>();
+                avatar.IsOwnedLocally = true;
+                avatarRoot.AddComponent<OSCAcquisition>();
+
+                avatar.NotifyAvatarReady(true);
+
+                MonoBehaviour resolvedServer = (MonoBehaviour)sceneInstanceField.GetValue(null);
+                Assert.That(resolvedServer, Is.SameAs(existingServer));
+
+                Object[] allServers = Resources.FindObjectsOfTypeAll(serverType);
+                Assert.That(allServers.Length, Is.EqualTo(1));
+            }
+            finally
+            {
+                Object.DestroyImmediate(avatarRoot);
+                DestroySceneInstance();
+            }
+        }
+
+        [Test]
+        public void BasisOsc_RemoteAvatarSubscriptions_OnlyReceiveAvatarPublic()
+        {
+            GameObject go = new GameObject("RemoteAvatarSubscriber");
+            MethodInfo publish = typeof(BasisOscService).GetMethod("Publish", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.That(publish, Is.Not.Null);
+
+            try
+            {
+                BasisAvatar avatar = go.AddComponent<BasisAvatar>();
+                avatar.IsOwnedLocally = false;
+
+                BasisOsc shim = go.AddComponent<BasisOsc>();
+                int callCount = 0;
+
+                shim.OnMessage = (message, arguments) => callCount++;
+                shim.Subscribe("/avatar/parameters/Blocked", (message, arguments) => { });
+
+                Assert.That(shim.IsSubscribed("/avatar/public/Blocked"), Is.True);
+                Assert.That(shim.IsSubscribed("/avatar/parameters/Blocked"), Is.True);
+
+                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/avatar/parameters/Blocked", arguments = new object[0] }) });
+                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/avatar/public/Blocked", arguments = new object[0] }) });
+
+                Assert.That(callCount, Is.EqualTo(1));
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+
+        [Test]
+        public void BasisOsc_RemoteAvatarPrefixSubscriptions_OnlyReceiveAvatarPublic()
+        {
+            GameObject go = new GameObject("RemoteAvatarPrefixSubscriber");
+            MethodInfo publish = typeof(BasisOscService).GetMethod("Publish", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.That(publish, Is.Not.Null);
+
+            try
+            {
+                BasisAvatar avatar = go.AddComponent<BasisAvatar>();
+                avatar.IsOwnedLocally = false;
+
+                BasisOsc shim = go.AddComponent<BasisOsc>();
+                int callCount = 0;
+
+                shim.OnMessage = (message, arguments) => callCount++;
+                shim.SubscribePrefix("/avatar/parameters/", (message, arguments) => { });
+
+                Assert.That(shim.IsPrefixSubscribed("/avatar/public/"), Is.True);
+                Assert.That(shim.IsPrefixSubscribed("/avatar/parameters/"), Is.True);
+
+                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/avatar/parameters/FT/v2/JawOpen", arguments = new object[0] }) });
+                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/avatar/public/FT/v2/JawOpen", arguments = new object[0] }) });
+
+                Assert.That(callCount, Is.EqualTo(1));
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+
+        [Test]
+        public void BasisOsc_ReceiveAll_LocalAvatar_IsScopedToAvatarParameters()
+        {
+            GameObject go = new GameObject("ReceiveAllLocalAvatar");
+            MethodInfo publish = typeof(BasisOscService).GetMethod("Publish", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.That(publish, Is.Not.Null);
+
+            try
+            {
+                BasisAvatar avatar = go.AddComponent<BasisAvatar>();
+                avatar.IsOwnedLocally = true;
+
+                BasisOsc shim = go.AddComponent<BasisOsc>();
+                int callCount = 0;
+
+                shim.OnMessage = (message, arguments) => callCount++;
+                shim.ReceiveAll = true;
+
+                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/avatar/parameters/Allowed", arguments = Array.Empty<object>() }) });
+                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/avatar/public/Blocked", arguments = Array.Empty<object>() }) });
+                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/scene/test/parameters/Blocked", arguments = Array.Empty<object>() }) });
+
+                Assert.That(callCount, Is.EqualTo(1));
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+
+        [Test]
+        public void BasisOsc_ReceiveAll_RemoteAvatar_IsScopedToAvatarPublic()
+        {
+            GameObject go = new GameObject("ReceiveAllRemoteAvatar");
+            MethodInfo publish = typeof(BasisOscService).GetMethod("Publish", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.That(publish, Is.Not.Null);
+
+            try
+            {
+                BasisAvatar avatar = go.AddComponent<BasisAvatar>();
+                avatar.IsOwnedLocally = false;
+
+                BasisOsc shim = go.AddComponent<BasisOsc>();
+                int callCount = 0;
+
+                shim.OnMessage = (message, arguments) => callCount++;
+                shim.ReceiveAll = true;
+
+                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/avatar/public/Allowed", arguments = Array.Empty<object>() }) });
+                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/avatar/parameters/Blocked", arguments = Array.Empty<object>() }) });
+                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/prop/test/parameters/Blocked", arguments = Array.Empty<object>() }) });
+
+                Assert.That(callCount, Is.EqualTo(1));
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+
+        [Test]
+        public void BasisOsc_PrefixSubscriptions_RequireSegmentBoundary()
+        {
+            GameObject go = new GameObject("PrefixBoundarySubscriber");
+            MethodInfo publish = typeof(BasisOscService).GetMethod("Publish", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.That(publish, Is.Not.Null);
+
+            try
+            {
+                BasisOsc shim = go.AddComponent<BasisOsc>();
+                int callCount = 0;
+
+                shim.OnMessage = (message, arguments) => callCount++;
+                shim.SubscribePrefix("/avatar/parameters", (message, arguments) => { });
+
+                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/avatar/parametersExtra", arguments = Array.Empty<object>() }) });
+                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/avatar/parameters/Face/Smile", arguments = Array.Empty<object>() }) });
+
+                Assert.That(callCount, Is.EqualTo(1));
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+
+        [Test]
+        public void BasisOsc_PropPublishesWithInstanceScopedPath()
+        {
+            DestroySceneInstance();
+            GameObject goA = new GameObject("Prop");
+            GameObject goB = new GameObject("Prop");
+
+            try
+            {
+                BasisProp propA = goA.AddComponent<BasisProp>();
+                propA.AssignNetworkGUIDIdentifier("prop-one");
+                BasisOsc shimA = goA.AddComponent<BasisOsc>();
+
+                BasisProp propB = goB.AddComponent<BasisProp>();
+                propB.AssignNetworkGUIDIdentifier("prop-two");
+                BasisOsc shimB = goB.AddComponent<BasisOsc>();
+
+                shimA.PublishValue("Status", OscData.String("alpha"));
+                shimB.PublishValue("Status", OscData.String("beta"));
+
+                object leafA = ResolveNode(GetQueryRoot(), "prop", "prop-one", "parameters", "Status");
+                object leafB = ResolveNode(GetQueryRoot(), "prop", "prop-two", "parameters", "Status");
+
+                Assert.That(leafA, Is.Not.Null);
+                Assert.That(leafB, Is.Not.Null);
+                Assert.That(leafA, Is.Not.SameAs(leafB));
+            }
+            finally
+            {
+                Object.DestroyImmediate(goA);
+                Object.DestroyImmediate(goB);
+                DestroySceneInstance();
+            }
+        }
+
+        [Test]
+        public void BasisOsc_PropUnderRemoteAvatar_PublishesToPropNamespace()
+        {
+            DestroySceneInstance();
+            GameObject avatarRoot = new GameObject("RemoteAvatarRoot");
+            GameObject propChild = new GameObject("PropChild");
+            propChild.transform.SetParent(avatarRoot.transform, false);
+
+            try
+            {
+                BasisAvatar avatar = avatarRoot.AddComponent<BasisAvatar>();
+                avatar.IsOwnedLocally = false;
+
+                BasisProp prop = propChild.AddComponent<BasisProp>();
+                prop.AssignNetworkGUIDIdentifier("prop-under-remote-avatar");
+
+                BasisOsc shim = propChild.AddComponent<BasisOsc>();
+                shim.PublishValue("Status", OscData.String("held"));
+
+                object propLeaf = ResolveNode(GetQueryRoot(), "prop", "prop-under-remote-avatar", "parameters", "Status");
+                Assert.That(propLeaf, Is.Not.Null);
+
+                object avatarLeaf = ResolveNode(GetQueryRoot(), "avatar", "parameters", "Status");
+                Assert.That(avatarLeaf, Is.Null);
+            }
+            finally
+            {
+                Object.DestroyImmediate(avatarRoot);
+                DestroySceneInstance();
+            }
+        }
+
+        [Test]
+        public void BasisOsc_PropSubscriptions_OnlyReceiveAvatarPublic()
+        {
+            GameObject go = new GameObject("PropSubscriber");
+            MethodInfo publish = typeof(BasisOscService).GetMethod("Publish", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.That(publish, Is.Not.Null);
+
+            try
+            {
+                go.AddComponent<BasisProp>();
+                BasisOsc shim = go.AddComponent<BasisOsc>();
+                int callCount = 0;
+
+                shim.OnMessage = (message, arguments) => callCount++;
+                shim.Subscribe("Face/Smile", (message, arguments) => { });
+                shim.Subscribe("/avatar/parameters/Blocked", (message, arguments) => { });
+
+                Assert.That(shim.IsSubscribed("/avatar/public/Face/Smile"), Is.True);
+                Assert.That(shim.IsSubscribed("/avatar/parameters/Face/Smile"), Is.False);
+                Assert.That(shim.IsSubscribed("/avatar/parameters/Blocked"), Is.False);
+
+                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/avatar/parameters/Face/Smile", arguments = new object[0] }) });
+                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/avatar/public/Face/Smile", arguments = new object[0] }) });
+
+                Assert.That(callCount, Is.EqualTo(1));
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+
+        [Test]
+        public void BasisOsc_SceneSubscriptions_OnlyReceiveAvatarPublic()
+        {
+            GameObject go = new GameObject("SceneSubscriber");
+            MethodInfo publish = typeof(BasisOscService).GetMethod("Publish", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.That(publish, Is.Not.Null);
+
+            try
+            {
+                go.AddComponent<BasisScene>();
+                BasisOsc shim = go.AddComponent<BasisOsc>();
+                int callCount = 0;
+
+                shim.OnMessage = (message, arguments) => callCount++;
+                shim.SubscribePrefix("FT/", (message, arguments) => { });
+                shim.SubscribePrefix("/avatar/parameters/", (message, arguments) => { });
+
+                Assert.That(shim.IsPrefixSubscribed("/avatar/public/FT/"), Is.True);
+                Assert.That(shim.IsPrefixSubscribed("/avatar/parameters/"), Is.False);
+
+                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/avatar/parameters/FT/v2/JawOpen", arguments = new object[0] }) });
+                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/avatar/public/FT/v2/JawOpen", arguments = new object[0] }) });
+
+                Assert.That(callCount, Is.EqualTo(1));
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+                DestroySceneInstance();
+            }
+        }
+
+        [Test]
+        public void BasisOsc_ResolvePublishAddress_RequiresSegmentBoundary()
+        {
+            GameObject go = new GameObject("PropPublisher");
+
+            try
+            {
+                BasisProp prop = go.AddComponent<BasisProp>();
+                prop.AssignNetworkGUIDIdentifier("prop-one");
+
+                BasisOsc shim = go.AddComponent<BasisOsc>();
+                MethodInfo resolvePublishAddress = typeof(BasisOsc).GetMethod("ResolvePublishAddress", BindingFlags.NonPublic | BindingFlags.Instance);
+                Assert.That(resolvePublishAddress, Is.Not.Null);
+
+                // Absolute-looking paths that miss the scoped prefix on a segment boundary are intentionally treated as relative containment.
+                string resolved = (string)resolvePublishAddress.Invoke(shim, new object[] { "/prop/prop-one/parametersExtra" });
+                Assert.That(resolved, Is.EqualTo("/prop/prop-one/parameters/prop/prop-one/parametersExtra"));
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+            }
+        }
+
+        [Test]
+        public void BasisOsc_ScenePublishesWithScopedPath_AndQueryBranchResolves()
+        {
+            DestroySceneInstance();
+            GameObject go = new GameObject("ScenePublisher");
+
+            try
+            {
+                BasisScene scene = go.AddComponent<BasisScene>();
+                scene.AssignNetworkGUIDIdentifier("scene-one");
+                BasisOsc shim = go.AddComponent<BasisOsc>();
+
+                shim.PublishValue("Environment/Ambient", OscData.String("night"));
+
+                object leaf = ResolveNode(GetQueryRoot(), "scene", "scene-one", "parameters", "Environment", "Ambient");
+                Assert.That(leaf, Is.Not.Null);
+
+                object sceneInstance = GetSceneInstanceField(GetServerType()).GetValue(null);
+                MethodInfo responseResolver = GetServerType().GetMethod("GetOscQueryResponse", BindingFlags.NonPublic | BindingFlags.Instance);
+                Assert.That(responseResolver, Is.Not.Null);
+
+                string json = (string)responseResolver.Invoke(sceneInstance, new object[] { "/scene/scene-one" });
+                StringAssert.Contains("\"FULL_PATH\": \"/scene/scene-one\"", json);
+                StringAssert.Contains("\"Ambient\"", json);
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+                DestroySceneInstance();
+            }
+        }
+
+        [Test]
+        public void BasisOsc_LocalAvatarCanPublishToAvatarPublicNamespace()
+        {
+            DestroySceneInstance();
+            GameObject go = new GameObject("AvatarPublicPublisher");
+
+            try
+            {
+                BasisAvatar avatar = go.AddComponent<BasisAvatar>();
+                avatar.IsOwnedLocally = true;
+
+                BasisOsc shim = go.AddComponent<BasisOsc>();
+                shim.PublishValue("/avatar/public/Status", OscData.String("shareable"));
+
+                object leaf = ResolveNode(GetQueryRoot(), "avatar", "public", "Status");
+                Assert.That(leaf, Is.Not.Null);
+                Assert.That((string)leaf.GetType().GetField("FULL_PATH").GetValue(leaf), Is.EqualTo("/avatar/public/Status"));
+            }
+            finally
+            {
+                Object.DestroyImmediate(go);
+                DestroySceneInstance();
+            }
+        }
+
+        [Test]
+        public void PublishValues_BuildsSimpleOscCompatibleArguments()
+        {
+            System.Type serverType = typeof(BasisOscService).Assembly.GetType("HVR.Basis.Comms.OSCAcquisitionServer");
+            Assert.That(serverType, Is.Not.Null);
+
+            MethodInfo buildOscArguments = serverType.GetMethod("BuildOscArguments", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.That(buildOscArguments, Is.Not.Null);
+
+            object[] arguments = (object[])buildOscArguments.Invoke(null, new object[]
+            {
+                new[]
+                {
+                    OscData.Float32(1.25f),
+                    OscData.Symbol("sym"),
+                    OscData.Midi(1, 2, 3, 4),
+                    OscData.ArrayValue(OscData.Int32(7), OscData.String("nested")),
+                    OscData.Impulse(),
+                    OscData.Nil(),
+                }
+            });
+
+            byte[] buffer = new byte[1024];
+            int offset = 0;
+            SimpleOSC.OSCMessage outbound = new SimpleOSC.OSCMessage
+            {
+                path = "/publish/test",
+                arguments = arguments,
+            };
+
+            SimpleOSC.EncodeOSCInto(buffer, ref offset, outbound);
+
+            ConcurrentQueue<SimpleOSC.OSCMessage> queue = new ConcurrentQueue<SimpleOSC.OSCMessage>();
+            SimpleOSC.DecodeOSCInto(queue, buffer, 0, offset);
+
+            Assert.That(queue.TryDequeue(out SimpleOSC.OSCMessage inbound), Is.True);
+            Assert.That(inbound.typeTag, Is.EqualTo(",fSm[is]IN"));
+            Assert.That(((SimpleOSC.OSCSymbol)inbound.arguments[1]).value, Is.EqualTo("sym"));
+            Assert.That(((object[])inbound.arguments[3]).Length, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void BasisChatSanitizer_ClampsUtf8WithoutBreakingScalars()
+        {
+            string original = new string('a', 300) + "\U0001F600" + new string('b', 300);
+            string sanitized = BasisChatSanitizer.Sanitize(original);
+
+            Assert.That(sanitized.Length, Is.LessThanOrEqualTo(BasisChatSanitizer.MaxMessageCharacters));
+            Assert.That(System.Text.Encoding.UTF8.GetByteCount(sanitized), Is.LessThanOrEqualTo(BasisChatSanitizer.MaxMessageBytes));
+            Assert.That(sanitized.IndexOf('\uD800'), Is.EqualTo(-1));
+        }
+
+        [Test]
+        public void OscQuery_ExposesChatboxInputMetadata()
+        {
+            DestroySceneInstance();
+            BasisOscService.EnsureInitialized();
+
+            object leaf = ResolveNode(GetQueryRoot(), "chatbox", "input");
+            Assert.That(leaf, Is.Not.Null);
+
+            FieldInfo accessField = leaf.GetType().GetField("ACCESS");
+            FieldInfo descriptionField = leaf.GetType().GetField("DESCRIPTION");
+            Assert.That((int)accessField.GetValue(leaf), Is.EqualTo(2));
+
+            string description = (string)descriptionField.GetValue(leaf);
+            Assert.That(description, Does.Contain("string"));
+            Assert.That(description, Does.Contain("bool typing"));
+        }
+
+        [Test]
+        public void ChatboxInput_WithOpenKeyboard_PrefillsSettingsComposer()
+        {
+            System.Type bridgeType = typeof(BasisOscService).Assembly.GetType("HVR.Basis.Comms.BasisOscChatBoxBridge");
+            Assert.That(bridgeType, Is.Not.Null);
+
+            MethodInfo onOscMessageReceived = bridgeType.GetMethod("OnOscMessageReceived", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.That(onOscMessageReceived, Is.Not.Null);
+
+            ClearPendingChatComposerState();
+
+            onOscMessageReceived.Invoke(null, new object[]
+            {
+                OscMessage.FromRaw(new SimpleOSC.OSCMessage
+                {
+                    path = "/chatbox/input",
+                    arguments = new object[] { "hello from osc", true, false }
+                })
+            });
+
+            FieldInfo pendingTextField = typeof(SettingsProvider).GetField("_pendingChatComposerText", BindingFlags.NonPublic | BindingFlags.Static);
+            FieldInfo pendingFocusField = typeof(SettingsProvider).GetField("_pendingChatComposerFocus", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.That((string)pendingTextField.GetValue(null), Is.EqualTo("hello from osc"));
+            Assert.That((bool)pendingFocusField.GetValue(null), Is.True);
+
+            ClearPendingChatComposerState();
+        }
+
+        private static object ResolveNode(object rootNode, params string[] path)
+        {
+            object current = rootNode;
+            for (int i = 0; i < path.Length; i++)
+            {
+                IDictionary contents = (IDictionary)current.GetType().GetField("CONTENTS").GetValue(current);
+                current = contents[path[i]];
+                if (current == null)
+                {
+                    return null;
+                }
+            }
+
+            return current;
+        }
+
+        private static System.Type GetServerType()
+        {
+            return typeof(BasisOscService).Assembly.GetType("HVR.Basis.Comms.OSCAcquisitionServer");
+        }
+
+        private static FieldInfo GetSceneInstanceField(System.Type serverType)
+        {
+            return serverType.GetField("_sceneInstance", BindingFlags.NonPublic | BindingFlags.Static);
+        }
+
+        private static object GetQueryRoot()
+        {
+            System.Type serverType = GetServerType();
+            MonoBehaviour sceneInstance = (MonoBehaviour)GetSceneInstanceField(serverType).GetValue(null);
+            Assert.That(sceneInstance, Is.Not.Null);
+
+            FieldInfo rootField = serverType.GetField("_oscQueryRoot", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.That(rootField, Is.Not.Null);
+            return rootField.GetValue(sceneInstance);
+        }
+
+        private static void DestroySceneInstance()
+        {
+            System.Type serverType = GetServerType();
+            if (serverType == null)
+            {
+                return;
+            }
+
+            FieldInfo sceneInstanceField = GetSceneInstanceField(serverType);
+            if (sceneInstanceField == null)
+            {
+                return;
+            }
+
+            MonoBehaviour sceneInstance = (MonoBehaviour)sceneInstanceField.GetValue(null);
+            if (sceneInstance != null)
+            {
+                Object.DestroyImmediate(sceneInstance.gameObject);
+                sceneInstanceField.SetValue(null, null);
+            }
+        }
+
+        private static void ClearPendingChatComposerState()
+        {
+            typeof(SettingsProvider).GetField("_pendingChatComposerText", BindingFlags.NonPublic | BindingFlags.Static)?.SetValue(null, null);
+            typeof(SettingsProvider).GetField("_pendingChatComposerFocus", BindingFlags.NonPublic | BindingFlags.Static)?.SetValue(null, false);
+            typeof(SettingsProvider).GetField("_pendingChatComposerPlaySound", BindingFlags.NonPublic | BindingFlags.Static)?.SetValue(null, false);
+        }
+    }
+}

--- a/Basis/Packages/dev.hai-vr.basis.comms/Tests/Runtime/OscBridgeTests.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Tests/Runtime/OscBridgeTests.cs
@@ -124,14 +124,14 @@ namespace HVR.Basis.Comms.Tests
                 shim.Subscribe("/exact", (message, arguments) => { });
                 shim.SubscribePrefix("/prefix/", (message, arguments) => { });
 
-                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/nope", arguments = new object[0] }) });
-                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/exact", arguments = new object[0] }) });
-                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/prefix/value", arguments = new object[0] }) });
+                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/nope", arguments = Array.Empty<object>() }) });
+                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/exact", arguments = Array.Empty<object>() }) });
+                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/prefix/value", arguments = Array.Empty<object>() }) });
 
                 Assert.That(callCount, Is.EqualTo(2));
 
                 shim.enabled = false;
-                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/exact", arguments = new object[0] }) });
+                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/exact", arguments = Array.Empty<object>() }) });
 
                 Assert.That(callCount, Is.EqualTo(2));
             }
@@ -160,8 +160,8 @@ namespace HVR.Basis.Comms.Tests
                 Assert.That(shim.IsSubscribed("/avatar/parameters/Face/Smile"), Is.True);
                 Assert.That(shim.IsPrefixSubscribed("/avatar/parameters/FT/"), Is.True);
 
-                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/avatar/parameters/Face/Smile", arguments = new object[0] }) });
-                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/avatar/parameters/FT/v2/JawOpen", arguments = new object[0] }) });
+                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/avatar/parameters/Face/Smile", arguments = Array.Empty<object>() }) });
+                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/avatar/parameters/FT/v2/JawOpen", arguments = Array.Empty<object>() }) });
 
                 Assert.That(callCount, Is.EqualTo(2));
             }
@@ -757,8 +757,8 @@ namespace HVR.Basis.Comms.Tests
                 Assert.That(shim.IsSubscribed("/avatar/public/Blocked"), Is.True);
                 Assert.That(shim.IsSubscribed("/avatar/parameters/Blocked"), Is.True);
 
-                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/avatar/parameters/Blocked", arguments = new object[0] }) });
-                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/avatar/public/Blocked", arguments = new object[0] }) });
+                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/avatar/parameters/Blocked", arguments = Array.Empty<object>() }) });
+                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/avatar/public/Blocked", arguments = Array.Empty<object>() }) });
 
                 Assert.That(callCount, Is.EqualTo(1));
             }
@@ -789,8 +789,8 @@ namespace HVR.Basis.Comms.Tests
                 Assert.That(shim.IsPrefixSubscribed("/avatar/public/"), Is.True);
                 Assert.That(shim.IsPrefixSubscribed("/avatar/parameters/"), Is.True);
 
-                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/avatar/parameters/FT/v2/JawOpen", arguments = new object[0] }) });
-                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/avatar/public/FT/v2/JawOpen", arguments = new object[0] }) });
+                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/avatar/parameters/FT/v2/JawOpen", arguments = Array.Empty<object>() }) });
+                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/avatar/public/FT/v2/JawOpen", arguments = Array.Empty<object>() }) });
 
                 Assert.That(callCount, Is.EqualTo(1));
             }
@@ -974,8 +974,8 @@ namespace HVR.Basis.Comms.Tests
                 Assert.That(shim.IsSubscribed("/avatar/parameters/Face/Smile"), Is.False);
                 Assert.That(shim.IsSubscribed("/avatar/parameters/Blocked"), Is.False);
 
-                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/avatar/parameters/Face/Smile", arguments = new object[0] }) });
-                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/avatar/public/Face/Smile", arguments = new object[0] }) });
+                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/avatar/parameters/Face/Smile", arguments = Array.Empty<object>() }) });
+                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/avatar/public/Face/Smile", arguments = Array.Empty<object>() }) });
 
                 Assert.That(callCount, Is.EqualTo(1));
             }
@@ -1005,8 +1005,8 @@ namespace HVR.Basis.Comms.Tests
                 Assert.That(shim.IsPrefixSubscribed("/avatar/public/FT/"), Is.True);
                 Assert.That(shim.IsPrefixSubscribed("/avatar/parameters/"), Is.False);
 
-                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/avatar/parameters/FT/v2/JawOpen", arguments = new object[0] }) });
-                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/avatar/public/FT/v2/JawOpen", arguments = new object[0] }) });
+                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/avatar/parameters/FT/v2/JawOpen", arguments = Array.Empty<object>() }) });
+                publish.Invoke(null, new object[] { OscMessage.FromRaw(new SimpleOSC.OSCMessage { path = "/avatar/public/FT/v2/JawOpen", arguments = Array.Empty<object>() }) });
 
                 Assert.That(callCount, Is.EqualTo(1));
             }
@@ -1139,74 +1139,21 @@ namespace HVR.Basis.Comms.Tests
             Assert.That(((object[])inbound.arguments[3]).Length, Is.EqualTo(2));
         }
 
-        [Test]
-        public void BasisChatSanitizer_ClampsUtf8WithoutBreakingScalars()
-        {
-            string original = new string('a', 300) + "\U0001F600" + new string('b', 300);
-            string sanitized = BasisChatSanitizer.Sanitize(original);
-
-            Assert.That(sanitized.Length, Is.LessThanOrEqualTo(BasisChatSanitizer.MaxMessageCharacters));
-            Assert.That(System.Text.Encoding.UTF8.GetByteCount(sanitized), Is.LessThanOrEqualTo(BasisChatSanitizer.MaxMessageBytes));
-            Assert.That(sanitized.IndexOf('\uD800'), Is.EqualTo(-1));
-        }
-
-        [Test]
-        public void OscQuery_ExposesChatboxInputMetadata()
-        {
-            DestroySceneInstance();
-            BasisOscService.EnsureInitialized();
-
-            object leaf = ResolveNode(GetQueryRoot(), "chatbox", "input");
-            Assert.That(leaf, Is.Not.Null);
-
-            FieldInfo accessField = leaf.GetType().GetField("ACCESS");
-            FieldInfo descriptionField = leaf.GetType().GetField("DESCRIPTION");
-            Assert.That((int)accessField.GetValue(leaf), Is.EqualTo(2));
-
-            string description = (string)descriptionField.GetValue(leaf);
-            Assert.That(description, Does.Contain("string"));
-            Assert.That(description, Does.Contain("bool typing"));
-        }
-
-        [Test]
-        public void ChatboxInput_WithOpenKeyboard_PrefillsSettingsComposer()
-        {
-            System.Type bridgeType = typeof(BasisOscService).Assembly.GetType("HVR.Basis.Comms.BasisOscChatBoxBridge");
-            Assert.That(bridgeType, Is.Not.Null);
-
-            MethodInfo onOscMessageReceived = bridgeType.GetMethod("OnOscMessageReceived", BindingFlags.NonPublic | BindingFlags.Static);
-            Assert.That(onOscMessageReceived, Is.Not.Null);
-
-            ClearPendingChatComposerState();
-
-            onOscMessageReceived.Invoke(null, new object[]
-            {
-                OscMessage.FromRaw(new SimpleOSC.OSCMessage
-                {
-                    path = "/chatbox/input",
-                    arguments = new object[] { "hello from osc", true, false }
-                })
-            });
-
-            FieldInfo pendingTextField = typeof(SettingsProvider).GetField("_pendingChatComposerText", BindingFlags.NonPublic | BindingFlags.Static);
-            FieldInfo pendingFocusField = typeof(SettingsProvider).GetField("_pendingChatComposerFocus", BindingFlags.NonPublic | BindingFlags.Static);
-            Assert.That((string)pendingTextField.GetValue(null), Is.EqualTo("hello from osc"));
-            Assert.That((bool)pendingFocusField.GetValue(null), Is.True);
-
-            ClearPendingChatComposerState();
-        }
-
         private static object ResolveNode(object rootNode, params string[] path)
         {
             object current = rootNode;
             for (int i = 0; i < path.Length; i++)
             {
-                IDictionary contents = (IDictionary)current.GetType().GetField("CONTENTS").GetValue(current);
+                FieldInfo contentsField = current.GetType().GetField("CONTENTS");
+                if (contentsField == null)
+                    return null;
+                IDictionary contents = (IDictionary)contentsField.GetValue(current);
+                if (contents == null)
+                    return null;
                 current = contents[path[i]];
                 if (current == null)
-                {
                     return null;
-                }
+
             }
 
             return current;
@@ -1226,10 +1173,16 @@ namespace HVR.Basis.Comms.Tests
         {
             System.Type serverType = GetServerType();
             MonoBehaviour sceneInstance = (MonoBehaviour)GetSceneInstanceField(serverType).GetValue(null);
-            Assert.That(sceneInstance, Is.Not.Null);
+            if (sceneInstance == null)
+            {
+                return null;
+            }
 
             FieldInfo rootField = serverType.GetField("_oscQueryRoot", BindingFlags.NonPublic | BindingFlags.Instance);
-            Assert.That(rootField, Is.Not.Null);
+            if (rootField == null)
+            {
+                return null;
+            }
             return rootField.GetValue(sceneInstance);
         }
 
@@ -1255,11 +1208,5 @@ namespace HVR.Basis.Comms.Tests
             }
         }
 
-        private static void ClearPendingChatComposerState()
-        {
-            typeof(SettingsProvider).GetField("_pendingChatComposerText", BindingFlags.NonPublic | BindingFlags.Static)?.SetValue(null, null);
-            typeof(SettingsProvider).GetField("_pendingChatComposerFocus", BindingFlags.NonPublic | BindingFlags.Static)?.SetValue(null, false);
-            typeof(SettingsProvider).GetField("_pendingChatComposerPlaySound", BindingFlags.NonPublic | BindingFlags.Static)?.SetValue(null, false);
-        }
     }
 }

--- a/Basis/Packages/dev.hai-vr.basis.comms/Tests/Runtime/OscBridgeTests.cs
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Tests/Runtime/OscBridgeTests.cs
@@ -1142,7 +1142,8 @@ namespace HVR.Basis.Comms.Tests
         private static object ResolveNode(object rootNode, params string[] path)
         {
             object current = rootNode;
-            for (int i = 0; i < path.Length; i++)
+            int pathCount = path.Length;
+            for (int i = 0; i < pathCount; i++)
             {
                 FieldInfo contentsField = current.GetType().GetField("CONTENTS");
                 if (contentsField == null)

--- a/Basis/Packages/dev.hai-vr.basis.comms/Tests/Runtime/OscBridgeTests.cs.meta
+++ b/Basis/Packages/dev.hai-vr.basis.comms/Tests/Runtime/OscBridgeTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6bcf2b2b16e84d23b2396c3991a2937f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
Adds a scoped `BasisOsc` bridge for Cilbox scripts with OSC/OSCQuery runtime support and Vixxy variable pipeline integration.

- Added `Basis.Shims.BasisOsc` with exact, prefix, value, receive-all, unsubscribe, and publish APIs for Cilbox content.
- Added public OSC wrapper types (`OscData`, `OscDataKind`, `OscMessage`) and Cilbox whitelist/linker preservation for direct OSC use.
- Added OSC runtime service, OSCQuery node publishing, inbound OSC routing, and scoped publish/subscribe behavior for local avatars, remote avatars, props, and scenes.
- Mirrors numeric-compatible published values into Vixxy after publish address scoping passes, without exposing `HVRVariableStore` directly to Cilbox.
- Routes OSC receive draining through `BasisEventDriver` via `OSCAcquisitionServer.Simulate()` and avoids avoidable allocations in the main-thread dispatch path.
- Added a Cilbox OSC subscription sample and editor/debug visibility for OSC subscriptions.
- Added runtime tests covering subscriptions, scoped publishing, OSC type wrappers, OSCQuery value publishing, Vixxy mirroring, remote publish blocking, and SimpleOSC argument handling.

## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
- [x] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- 1* **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [x] Windows
- [ ] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [ ] Tested in VR (note headset under **Notes**)
- [ ] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [x] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [x] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [ ] N/A — change does not touch any of the above

## Notes
1. As Cilbox is runtime initialized scripts, and many of the networkshims are made at runtime, they don't have the proper references to pass onto, so they need to find their scope. I added caching so it only does it at init of the components.
- Public script callbacks that receive `OscMessage` still allocate wrapper objects by API design; the Vixxy/address dispatch path avoids per-frame owner-match allocations after initialization/warmup.
- Cilboxable sample scripts intentionally use normal `Debug.*` logging because Cilbox handles those logs correctly.
- Jobification was considered, but since most of the data is already on separate thread for SimpleOSC, jobification would not assist.