### PR TITLE
feat: add third-party licenses tab in-app

### DIFF
--- a/Basis/Assets/AddressableAssetsData/AssetGroups/Basis Foundation Assets.asset
+++ b/Basis/Assets/AddressableAssetsData/AssetGroups/Basis Foundation Assets.asset
@@ -56,6 +56,11 @@ MonoBehaviour:
     m_ReadOnly: 0
     m_SerializedLabels: []
     FlaggedDuringContentUpdateRestriction: 0
+  - m_GUID: 27c7383e2606aaa4986e5ef070459a46
+    m_Address: BasisFrameworkLicenseManifest
+    m_ReadOnly: 0
+    m_SerializedLabels: []
+    FlaggedDuringContentUpdateRestriction: 0
   - m_GUID: 2a27b24eacd47d84ba39d6ee782dd1e8
     m_Address: Packages/com.basis.sdk/Prefabs/UI/Loading Bar.prefab
     m_ReadOnly: 0

--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/en.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/en.json
@@ -333,6 +333,7 @@
     { "key": "settings.tab.admin", "value": "Admin" },
     { "key": "settings.tab.moderator", "value": "Moderator" },
     { "key": "settings.tab.uistyle", "value": "UI Style" },
+    { "key": "settings.tab.thirdpartylicenses", "value": "Third-Party Licenses" },
     { "key": "settings.general.avatarRange", "value": "Avatar Visibility Range" },
     { "key": "settings.general.hearingRange", "value": "Hearing Range" },
     { "key": "settings.general.microphoneRange", "value": "Microphone Range" },
@@ -874,6 +875,8 @@
     { "key": "settings.console.clearLogs", "value": "Clear Logs" },
     { "key": "settings.console.openCrashReport", "value": "Open Latest Crash Report" },
     { "key": "settings.console.output", "value": "Output" },
+
+    { "key": "settings.thirdpartylicenses.openlicenseurl", "value": "Open license URL" },
 
     { "key": "settings.uiStyle.title", "value": "UI Style" },
     { "key": "settings.uiStyle.background1", "value": "Background 1" },

--- a/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProvider.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProvider.cs
@@ -46,6 +46,8 @@ namespace Basis.BasisUI
 
         public static Action<RectTransform> AvatarCustomizationBuilder;
 
+        public static Action<RectTransform> LicensesBuilder;
+
         [RuntimeInitializeOnLoadMethod]
         public static void AddToMenu()
         {
@@ -140,6 +142,20 @@ namespace Basis.BasisUI
             AddLazyTab(tabGroup, "settings.tab.downloadsurls", () => SettingsProviderStorage.DownloadsUrlsTab(tabGroup));
           //  AddLazyTab(tabGroup, "settings.tab.uistyle", () => SettingsProviderUIStyle.UIStyleTab(tabGroup));
             AddLazyTab(tabGroup, "settings.tab.developer", () => DeveloperTab(tabGroup));
+            if (SettingsProvider.LicensesBuilder != null)
+            {
+                AddLazyTab(tabGroup, "settings.tab.thirdpartylicenses", () =>
+                {
+                    PanelTabPage tab = PanelTabPage.CreateVertical(tabGroup.Descriptor.ContentParent);
+                    PanelElementDescriptor descriptor = tab.Descriptor;
+                    descriptor.SetIcon(AddressableAssets.Sprites.Settings);
+                    descriptor.SetTitle(BasisLocalization.Get("settings.tab.thirdpartylicenses"));
+                    descriptor.ForceRebuild();
+
+                    SettingsProvider.LicensesBuilder.Invoke(tab.Descriptor.ContentParent);
+                    return tab;
+                });
+            }
 
             // External package tabs (registered via SettingsProvider.ExternalTabs).
             // TabName is treated as a localization key — packages that don't localize

--- a/Basis/Packages/dev.hai-vr.hvr.license-review/BasisFrameworkLicenseManifest.asset
+++ b/Basis/Packages/dev.hai-vr.hvr.license-review/BasisFrameworkLicenseManifest.asset
@@ -1,0 +1,1564 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a395133486a94aa6bc2761a46e80aa8e, type: 3}
+  m_Name: BasisFrameworkLicenseManifest
+  m_EditorClassIdentifier: HVR.Basis.LicenseReview::HVR.Basis.LicenseReview.LicenseManifest
+  trackedPackages:
+  - packageName: com.xiph.rnnoise
+    licenses:
+    - path: LICENSE
+      spdx: MIT
+      overrideProductName:
+  - packageName: com.avionblock.opussharp
+    licenses:
+    - path: Opus_LICENSE_PLEASE_READ.txt
+      spdx: BSD
+      overrideProductName: Opus Codec
+    - path: LICENSE.txt
+      spdx: MIT
+      overrideProductName: OpusSharp
+  - packageName: com.valvesoftware.unity.openvr
+    licenses:
+    - path: LICENSE.md
+      spdx: BSD-3-Clause
+      overrideProductName:
+  - packageName: com.steam.steamvr
+    licenses:
+    - path: LICENSE
+      spdx: BSD-3-Clause
+      overrideProductName:
+  - packageName: com.cqf.urpvolumetricfog
+    licenses:
+    - path: LICENSE.md
+      spdx: MIT
+      overrideProductName:
+  - packageName: dev.hai-vr.basis.comms
+    licenses:
+    - path: LICENSE
+      spdx: MIT
+      overrideProductName:
+  - packageName: nuget.meamod.dns
+    licenses:
+    - path: LICENSE
+      spdx: MIT
+      overrideProductName:
+  - packageName: org.basisvr.newtonsoft.json
+    licenses:
+    - path: LICENSE
+      spdx: MIT
+      overrideProductName:
+  - packageName: org.basisvr.bouncycastle
+    licenses:
+    - path: LICENSE
+      spdx: MIT
+      overrideProductName:
+  - packageName: org.basisvr.base128
+    licenses:
+    - path: LICENSE
+      spdx: MIT
+      overrideProductName:
+  - packageName: org.basisvr.generator.equals
+    licenses:
+    - path: LICENSE
+      spdx: MIT
+      overrideProductName:
+  - packageName: org.basisvr.simplebase
+    licenses:
+    - path: LICENSE
+      spdx: MIT
+      overrideProductName:
+  - packageName: com.steam.steamaudio
+    licenses:
+    - path: LICENSE.md
+      spdx: Apache-2.0
+      overrideProductName:
+  - packageName: com.basis.openlipsync
+    licenses:
+    - path: LICENSE
+      spdx: Apache-2.0
+      overrideProductName:
+  - packageName: org.basisvr.k4os.compression.lz4
+    licenses:
+    - path: LICENSE
+      spdx: MIT
+      overrideProductName:
+  - packageName: com.llealloo.audiolink
+    licenses:
+    - path: LICENSE
+      spdx: MIT
+      overrideProductName:
+  - packageName: com.cnlohr.cilbox
+    licenses:
+    - path: LICENSE
+      spdx: MIT
+      overrideProductName:
+  - packageName: com.gator-dragon-games.jigglephysics
+    licenses:
+    - path: LICENSE
+      spdx: MIT
+      overrideProductName:
+  - packageName: com.basis.framework
+    licenses:
+    - path: LICENSE
+      spdx: MIT
+      overrideProductName:
+  excludedPackageNames:
+  - com.singularitygroup.hotreload
+  - dev.hai-vr.basis.ndmf
+  - dev.hai-vr.hvr.license-review
+  - com.basis.bundlemanagement
+  - com.basis.common
+  - com.basis.eventdriver
+  - com.basis.examples
+  - com.basis.framework.editor
+  - com.basis.gizmos
+  - com.basis.openvr
+  - com.basis.openxr
+  - com.basis.sdk
+  - com.basis.profilerintergration
+  - com.basis.server
+  - com.basis.settings
+  - com.basis.shim
+  - com.basis.vehicles
+  - com.basis.visualtrackers
+  baked:
+  - productName: AudioLink
+    packageName: com.llealloo.audiolink
+    licensePath: LICENSE
+    spdx: MIT
+    fullLicenseName: MIT License
+    fullLicenseText: 'MIT License
+
+
+
+      Copyright (c) 2021 llealloo
+
+
+
+      Permission
+      is hereby granted, free of charge, to any person obtaining a copy
+
+      of
+      this software and associated documentation files (the "Software"), to deal
+
+      in
+      the Software without restriction, including without limitation the rights
+
+      to
+      use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+
+      copies
+      of the Software, and to permit persons to whom the Software is
+
+      furnished
+      to do so, subject to the following conditions:
+
+
+
+      The above copyright
+      notice and this permission notice shall be included in all
+
+      copies or
+      substantial portions of the Software.
+
+
+
+      THE SOFTWARE IS PROVIDED
+      "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+
+      IMPLIED, INCLUDING
+      BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+
+      FITNESS FOR A
+      PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+
+      AUTHORS
+      OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+
+      LIABILITY,
+      WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+
+      OUT
+      OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+
+      SOFTWARE.
+
+'
+    licenseUrl: https://github.com/BasisVR/Basis/tree/developer/Basis/Packages/com.llealloo.audiolink/LICENSE
+  - productName: Base128
+    packageName: org.basisvr.base128
+    licensePath: LICENSE
+    spdx: MIT
+    fullLicenseName: MIT License
+    fullLicenseText: 'MIT License
+
+
+
+      Copyright (c) Wojmik
+
+
+
+      Permission
+      is hereby granted, free of charge, to any person obtaining a copy
+
+      of
+      this software and associated documentation files (the "Software"), to deal
+
+      in
+      the Software without restriction, including without limitation the rights
+
+      to
+      use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+
+      copies
+      of the Software, and to permit persons to whom the Software is
+
+      furnished
+      to do so, subject to the following conditions:
+
+
+
+      The above copyright
+      notice and this permission notice shall be included in all
+
+      copies or
+      substantial portions of the Software.
+
+
+
+      THE SOFTWARE IS PROVIDED
+      "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+
+      IMPLIED, INCLUDING
+      BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+
+      FITNESS FOR A
+      PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+
+      AUTHORS
+      OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+
+      LIABILITY,
+      WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+
+      OUT
+      OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+
+      SOFTWARE.
+
+
+
+      ---
+
+      Upstream:
+      https://github.com/Wojmik/Base128
+
+      Repackaged for Unity by BasisVR via
+      https://github.com/BasisVR/UpmBuilds
+
+'
+    licenseUrl: https://github.com/BasisVR/Basis/tree/developer/Basis/Packages/org.basisvr.base128/LICENSE
+  - productName: Basis OpenLipSync
+    packageName: com.basis.openlipsync
+    licensePath: LICENSE
+    spdx: Apache-2.0
+    fullLicenseName: Apache License 2.0
+    fullLicenseText: "                                 Apache License\r\n
+      Version 2.0, January 2004\r\n                        http://www.apache.org/licenses/\r\n\r\n
+      TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\r\n\r\n   1. Definitions.\r\n\r\n
+      \"License\" shall mean the terms and conditions for use, reproduction,\r\n
+      and distribution as defined by Sections 1 through 9 of this document.\r\n\r\n
+      \"Licensor\" shall mean the copyright owner or entity authorized by\r\n
+      the copyright owner that is granting the License.\r\n\r\n      \"Legal Entity\"
+      shall mean the union of the acting entity and all\r\n      other entities that
+      control, are controlled by, or are under common\r\n      control with that
+      entity. For the purposes of this definition,\r\n      \"control\" means (i)
+      the power, direct or indirect, to cause the\r\n      direction or management
+      of such entity, whether by contract or\r\n      otherwise, or (ii) ownership
+      of fifty percent (50%) or more of the\r\n      outstanding shares, or (iii)
+      beneficial ownership of such entity.\r\n\r\n      \"You\" (or \"Your\") shall
+      mean an individual or Legal Entity\r\n      exercising permissions granted
+      by this License.\r\n\r\n      \"Source\" form shall mean the preferred form
+      for making modifications,\r\n      including but not limited to software source
+      code, documentation\r\n      source, and configuration files.\r\n\r\n
+      \"Object\" form shall mean any form resulting from mechanical\r\n      transformation
+      or translation of a Source form, including but\r\n      not limited to compiled
+      object code, generated documentation,\r\n      and conversions to other media
+      types.\r\n\r\n      \"Work\" shall mean the work of authorship, whether in
+      Source or\r\n      Object form, made available under the License, as indicated
+      by a\r\n      copyright notice that is included in or attached to the work\r\n
+      (an example is provided in the Appendix below).\r\n\r\n      \"Derivative Works\"
+      shall mean any work, whether in Source or Object\r\n      form, that is based
+      on (or derived from) the Work and for which the\r\n      editorial revisions,
+      annotations, elaborations, or other modifications\r\n      represent, as a
+      whole, an original work of authorship. For the purposes\r\n      of this License,
+      Derivative Works shall not include works that remain\r\n      separable from,
+      or merely link (or bind by name) to the interfaces of,\r\n      the Work and
+      Derivative Works thereof.\r\n\r\n      \"Contribution\" shall mean any work
+      of authorship, including\r\n      the original version of the Work and any
+      modifications or additions\r\n      to that Work or Derivative Works thereof,
+      that is intentionally\r\n      submitted to the Licensor for inclusion in the
+      Work by the copyright owner\r\n      or by an individual or Legal Entity authorized
+      to submit on behalf of\r\n      the copyright owner. For the purposes of this
+      definition, \"submitted\"\r\n      means any form of electronic, verbal, or
+      written communication sent\r\n      to the Licensor or its representatives,
+      including but not limited to\r\n      communication on electronic mailing lists,
+      source code control systems,\r\n      and issue tracking systems that are managed
+      by, or on behalf of, the\r\n      Licensor for the purpose of discussing and
+      improving the Work, but\r\n      excluding communication that is conspicuously
+      marked or otherwise\r\n      designated in writing by the copyright owner as
+      \"Not a Contribution.\"\r\n\r\n      \"Contributor\" shall mean Licensor and
+      any individual or Legal Entity\r\n      on behalf of whom a Contribution has
+      been received by the Licensor and\r\n      subsequently incorporated within
+      the Work.\r\n\r\n   2. Grant of Copyright License. Subject to the terms and
+      conditions of\r\n      this License, each Contributor hereby grants to You
+      a perpetual,\r\n      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\r\n
+      copyright license to reproduce, prepare Derivative Works of,\r\n      publicly
+      display, publicly perform, sublicense, and distribute the\r\n      Work and
+      such Derivative Works in Source or Object form.\r\n\r\n   3. Grant of Patent
+      License. Subject to the terms and conditions of\r\n      this License, each
+      Contributor hereby grants to You a perpetual,\r\n      worldwide, non-exclusive,
+      no-charge, royalty-free, irrevocable\r\n      (except as stated in this section)
+      patent license to make, have made,\r\n      use, offer to sell, sell, import,
+      and otherwise transfer the Work,\r\n      where such license applies only to
+      those patent claims licensable\r\n      by such Contributor that are necessarily
+      infringed by their\r\n      Contribution(s) alone or by combination of their
+      Contribution(s)\r\n      with the Work to which such Contribution(s) was submitted.
+      If You\r\n      institute patent litigation against any entity (including a\r\n
+      cross-claim or counterclaim in a lawsuit) alleging that the Work\r\n      or
+      a Contribution incorporated within the Work constitutes direct\r\n      or
+      contributory patent infringement, then any patent licenses\r\n      granted
+      to You under this License for that Work shall terminate\r\n      as of the
+      date such litigation is filed.\r\n\r\n   4. Redistribution. You may reproduce
+      and distribute copies of the\r\n      Work or Derivative Works thereof in any
+      medium, with or without\r\n      modifications, and in Source or Object form,
+      provided that You\r\n      meet the following conditions:\r\n\r\n      (a)
+      You must give any other recipients of the Work or\r\n          Derivative Works
+      a copy of this License; and\r\n\r\n      (b) You must cause any modified files
+      to carry prominent notices\r\n          stating that You changed the files;
+      and\r\n\r\n      (c) You must retain, in the Source form of any Derivative
+      Works\r\n          that You distribute, all copyright, patent, trademark, and\r\n
+      attribution notices from the Source form of the Work,\r\n          excluding
+      those notices that do not pertain to any part of\r\n          the Derivative
+      Works; and\r\n\r\n      (d) If the Work includes a \"NOTICE\" text file as
+      part of its\r\n          distribution, then any Derivative Works that You distribute
+      must\r\n          include a readable copy of the attribution notices contained\r\n
+      within such NOTICE file, excluding any notices that do not\r\n          pertain
+      to any part of the Derivative Works, in at least one\r\n          of the following
+      places: within a NOTICE text file distributed\r\n          as part of the Derivative
+      Works; within the Source form or\r\n          documentation, if provided along
+      with the Derivative Works; or,\r\n          within a display generated by the
+      Derivative Works, if and\r\n          wherever such third-party notices normally
+      appear. The contents\r\n          of the NOTICE file are for informational
+      purposes only and\r\n          do not modify the License. You may add Your
+      own attribution\r\n          notices within Derivative Works that You distribute,
+      alongside\r\n          or as an addendum to the NOTICE text from the Work,
+      provided\r\n          that such additional attribution notices cannot be construed\r\n
+      as modifying the License.\r\n\r\n      You may add Your own copyright statement
+      to Your modifications and\r\n      may provide additional or different license
+      terms and conditions\r\n      for use, reproduction, or distribution of Your
+      modifications, or\r\n      for any such Derivative Works as a whole, provided
+      Your use,\r\n      reproduction, and distribution of the Work otherwise complies
+      with\r\n      the conditions stated in this License.\r\n\r\n   5. Submission
+      of Contributions. Unless You explicitly state otherwise,\r\n      any Contribution
+      intentionally submitted for inclusion in the Work\r\n      by You to the Licensor
+      shall be under the terms and conditions of\r\n      this License, without any
+      additional terms or conditions.\r\n      Notwithstanding the above, nothing
+      herein shall supersede or modify\r\n      the terms of any separate license
+      agreement you may have executed\r\n      with Licensor regarding such Contributions.\r\n\r\n
+      6. Trademarks. This License does not grant permission to use the trade\r\n
+      names, trademarks, service marks, or product names of the Licensor,\r\n
+      except as required for reasonable and customary use in describing the\r\n
+      origin of the Work and reproducing the content of the NOTICE file.\r\n\r\n
+      7. Disclaimer of Warranty. Unless required by applicable law or\r\n      agreed
+      to in writing, Licensor provides the Work (and each\r\n      Contributor provides
+      its Contributions) on an \"AS IS\" BASIS,\r\n      WITHOUT WARRANTIES OR CONDITIONS
+      OF ANY KIND, either express or\r\n      implied, including, without limitation,
+      any warranties or conditions\r\n      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY,
+      or FITNESS FOR A\r\n      PARTICULAR PURPOSE. You are solely responsible for
+      determining the\r\n      appropriateness of using or redistributing the Work
+      and assume any\r\n      risks associated with Your exercise of permissions
+      under this License.\r\n\r\n   8. Limitation of Liability. In no event and under
+      no legal theory,\r\n      whether in tort (including negligence), contract,
+      or otherwise,\r\n      unless required by applicable law (such as deliberate
+      and grossly\r\n      negligent acts) or agreed to in writing, shall any Contributor
+      be\r\n      liable to You for damages, including any direct, indirect, special,\r\n
+      incidental, or consequential damages of any character arising as a\r\n
+      result of this License or out of the use or inability to use the\r\n      Work
+      (including but not limited to damages for loss of goodwill,\r\n      work stoppage,
+      computer failure or malfunction, or any and all\r\n      other commercial damages
+      or losses), even if such Contributor\r\n      has been advised of the possibility
+      of such damages.\r\n\r\n   9. Accepting Warranty or Additional Liability. While
+      redistributing\r\n      the Work or Derivative Works thereof, You may choose
+      to offer,\r\n      and charge a fee for, acceptance of support, warranty, indemnity,\r\n
+      or other liability obligations and/or rights consistent with this\r\n
+      License. However, in accepting such obligations, You may act only\r\n
+      on Your own behalf and on Your sole responsibility, not on behalf\r\n
+      of any other Contributor, and only if You agree to indemnify,\r\n      defend,
+      and hold each Contributor harmless for any liability\r\n      incurred by,
+      or claims asserted against, such Contributor by reason\r\n      of your accepting
+      any such warranty or additional liability.\r\n\r\n   END OF TERMS AND CONDITIONS\r\n\r\n
+      Copyright 2024 BasisVR\r\n\r\n   Licensed under the Apache License, Version
+      2.0 (the \"License\");\r\n   you may not use this file except in compliance
+      with the License.\r\n   You may obtain a copy of the License at\r\n\r\n
+      http://www.apache.org/licenses/LICENSE-2.0\r\n\r\n   Unless required by applicable
+      law or agreed to in writing, software\r\n   distributed under the License is
+      distributed on an \"AS IS\" BASIS,\r\n   WITHOUT WARRANTIES OR CONDITIONS OF
+      ANY KIND, either express or implied.\r\n   See the License for the specific
+      language governing permissions and\r\n   limitations under the License.\r\n"
+    licenseUrl: https://github.com/BasisVR/Basis/tree/developer/Basis/Packages/com.basis.openlipsync/LICENSE
+  - productName: BouncyCastle.Cryptography
+    packageName: org.basisvr.bouncycastle
+    licensePath: LICENSE
+    spdx: MIT
+    fullLicenseName: MIT License
+    fullLicenseText: 'MIT License
+
+
+
+      Copyright (c) 2000-2024 The Legion
+      of the Bouncy Castle Inc.
+
+
+
+      Permission is hereby granted, free
+      of charge, to any person obtaining a copy
+
+      of this software and associated
+      documentation files (the "Software"), to deal
+
+      in the Software without
+      restriction, including without limitation the rights
+
+      to use, copy,
+      modify, merge, publish, distribute, sublicense, and/or sell
+
+      copies
+      of the Software, and to permit persons to whom the Software is
+
+      furnished
+      to do so, subject to the following conditions:
+
+
+
+      The above copyright
+      notice and this permission notice shall be included in all
+
+      copies or
+      substantial portions of the Software.
+
+
+
+      THE SOFTWARE IS PROVIDED
+      "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+
+      IMPLIED, INCLUDING
+      BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+
+      FITNESS FOR A
+      PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+
+      AUTHORS
+      OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+
+      LIABILITY,
+      WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+
+      OUT
+      OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+
+      SOFTWARE.
+
+
+
+      ---
+
+      Upstream:
+      https://github.com/bcgit/bc-csharp
+
+      Repackaged for Unity by BasisVR
+      via https://github.com/BasisVR/UpmBuilds
+
+'
+    licenseUrl: https://github.com/BasisVR/Basis/tree/developer/Basis/Packages/org.basisvr.bouncycastle/LICENSE
+  - productName: Cilbox
+    packageName: com.cnlohr.cilbox
+    licensePath: LICENSE
+    spdx: MIT
+    fullLicenseName: MIT License
+    fullLicenseText: 'MIT License
+
+
+
+      Copyright (c) 2025 cnlohr
+
+      Copyright
+      (c) 2008 - 2015 Jb Evain (jbevain@gmail.com) (opcodes)
+
+      Copyright (c)
+      2008 - 2011 Novell, Inc. (For original CIL code from cecil)
+
+
+
+      Permission
+      is hereby granted, free of charge, to any person obtaining a copy
+
+      of
+      this software and associated documentation files (the "Software"), to deal
+
+      in
+      the Software without restriction, including without limitation the rights
+
+      to
+      use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+
+      copies
+      of the Software, and to permit persons to whom the Software is
+
+      furnished
+      to do so, subject to the following conditions:
+
+
+
+      The above copyright
+      notice and this permission notice shall be included in all
+
+      copies or
+      substantial portions of the Software.
+
+
+
+      THE SOFTWARE IS PROVIDED
+      "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+
+      IMPLIED, INCLUDING
+      BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+
+      FITNESS FOR A
+      PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+
+      AUTHORS
+      OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+
+      LIABILITY,
+      WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+
+      OUT
+      OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+
+      SOFTWARE.
+
+'
+    licenseUrl: https://github.com/BasisVR/Basis/tree/developer/Basis/Packages/com.cnlohr.cilbox/LICENSE
+  - productName: Generator.Equals
+    packageName: org.basisvr.generator.equals
+    licensePath: LICENSE
+    spdx: MIT
+    fullLicenseName: MIT License
+    fullLicenseText: 'MIT License
+
+
+
+      Copyright (c) Diego Frata
+
+
+
+      Permission
+      is hereby granted, free of charge, to any person obtaining a copy
+
+      of
+      this software and associated documentation files (the "Software"), to deal
+
+      in
+      the Software without restriction, including without limitation the rights
+
+      to
+      use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+
+      copies
+      of the Software, and to permit persons to whom the Software is
+
+      furnished
+      to do so, subject to the following conditions:
+
+
+
+      The above copyright
+      notice and this permission notice shall be included in all
+
+      copies or
+      substantial portions of the Software.
+
+
+
+      THE SOFTWARE IS PROVIDED
+      "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+
+      IMPLIED, INCLUDING
+      BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+
+      FITNESS FOR A
+      PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+
+      AUTHORS
+      OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+
+      LIABILITY,
+      WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+
+      OUT
+      OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+
+      SOFTWARE.
+
+
+
+      ---
+
+      Upstream:
+      https://github.com/diegofrata/Generator.Equals
+
+      Repackaged for Unity
+      by BasisVR via https://github.com/BasisVR/UpmBuilds
+
+'
+    licenseUrl: https://github.com/BasisVR/Basis/tree/developer/Basis/Packages/org.basisvr.generator.equals/LICENSE
+  - productName: HVR Basis Comms
+    packageName: dev.hai-vr.basis.comms
+    licensePath: LICENSE
+    spdx: MIT
+    fullLicenseName: MIT License
+    fullLicenseText: "MIT License\r\n\r\nCopyright (c) 2025 Ha\xEF~ (@vr_hai github.com/hai-vr)\r\nCopyright
+      (c) 2025 MR LUKE B DOOLAN\r\n\r\nPermission is hereby granted, free of charge,
+      to any person obtaining a copy\r\nof this software and associated documentation
+      files (the \"Software\"), to deal\r\nin the Software without restriction, including
+      without limitation the rights\r\nto use, copy, modify, merge, publish, distribute,
+      sublicense, and/or sell\r\ncopies of the Software, and to permit persons to
+      whom the Software is\r\nfurnished to do so, subject to the following conditions:\r\n\r\nThe
+      above copyright notice and this permission notice shall be included in all\r\ncopies
+      or substantial portions of the Software.\r\n\r\nTHE SOFTWARE IS PROVIDED \"AS
+      IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\r\nIMPLIED, INCLUDING BUT NOT
+      LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\r\nFITNESS FOR A PARTICULAR PURPOSE
+      AND NONINFRINGEMENT. IN NO EVENT SHALL THE\r\nAUTHORS OR COPYRIGHT HOLDERS
+      BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\r\nLIABILITY, WHETHER IN AN ACTION
+      OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\r\nOUT OF OR IN CONNECTION WITH
+      THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\r\nSOFTWARE.\r\n"
+    licenseUrl: https://github.com/BasisVR/Basis/tree/developer/Basis/Packages/dev.hai-vr.basis.comms/LICENSE
+  - productName: Jiggle Physics
+    packageName: com.gator-dragon-games.jigglephysics
+    licensePath: LICENSE
+    spdx: MIT
+    fullLicenseName: MIT License
+    fullLicenseText: 'MIT License
+
+
+
+      Copyright (c) naelstrof
+
+
+
+      Permission
+      is hereby granted, free of charge, to any person obtaining a copy
+
+      of
+      this software and associated documentation files (the "Software"), to deal
+
+      in
+      the Software without restriction, including without limitation the rights
+
+      to
+      use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+
+      copies
+      of the Software, and to permit persons to whom the Software is
+
+      furnished
+      to do so, subject to the following conditions:
+
+
+
+      The above copyright
+      notice and this permission notice shall be included in all
+
+      copies or
+      substantial portions of the Software.
+
+
+
+      THE SOFTWARE IS PROVIDED
+      "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+
+      IMPLIED, INCLUDING
+      BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+
+      FITNESS FOR A
+      PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+
+      AUTHORS
+      OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+
+      LIABILITY,
+      WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+
+      OUT
+      OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+
+      SOFTWARE.
+
+'
+    licenseUrl: https://github.com/BasisVR/Basis/tree/developer/Basis/Packages/com.gator-dragon-games.jigglephysics/LICENSE
+  - productName: K4os.Compression.LZ4
+    packageName: org.basisvr.k4os.compression.lz4
+    licensePath: LICENSE
+    spdx: MIT
+    fullLicenseName: MIT License
+    fullLicenseText: 'MIT License
+
+
+
+      Copyright (c) 2017 Milosz Krajewski
+
+
+
+      Permission
+      is hereby granted, free of charge, to any person obtaining a copy
+
+      of
+      this software and associated documentation files (the "Software"), to deal
+
+      in
+      the Software without restriction, including without limitation the rights
+
+      to
+      use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+
+      copies
+      of the Software, and to permit persons to whom the Software is
+
+      furnished
+      to do so, subject to the following conditions:
+
+
+
+      The above copyright
+      notice and this permission notice shall be included in all
+
+      copies or
+      substantial portions of the Software.
+
+
+
+      THE SOFTWARE IS PROVIDED
+      "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+
+      IMPLIED, INCLUDING
+      BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+
+      FITNESS FOR A
+      PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+
+      AUTHORS
+      OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+
+      LIABILITY,
+      WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+
+      OUT
+      OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+
+      SOFTWARE.
+
+
+
+      ---
+
+      Upstream:
+      https://github.com/MiloszKrajewski/K4os.Compression.LZ4
+
+      Repackaged
+      for Unity by BasisVR via https://github.com/BasisVR/UpmBuilds
+
+'
+    licenseUrl: https://github.com/BasisVR/Basis/tree/developer/Basis/Packages/org.basisvr.k4os.compression.lz4/LICENSE
+  - productName: MeaMod.DNS
+    packageName: nuget.meamod.dns
+    licensePath: LICENSE
+    spdx: MIT
+    fullLicenseName: MIT License
+    fullLicenseText: 'MIT License
+
+
+
+      Copyright (c) 2021 James Weston
+
+
+
+      Permission
+      is hereby granted, free of charge, to any person obtaining a copy
+
+      of
+      this software and associated documentation files (the "Software"), to deal
+
+      in
+      the Software without restriction, including without limitation the rights
+
+      to
+      use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+
+      copies
+      of the Software, and to permit persons to whom the Software is
+
+      furnished
+      to do so, subject to the following conditions:
+
+
+
+      The above copyright
+      notice and this permission notice shall be included in all
+
+      copies or
+      substantial portions of the Software.
+
+
+
+      THE SOFTWARE IS PROVIDED
+      "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+
+      IMPLIED, INCLUDING
+      BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+
+      FITNESS FOR A
+      PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+
+      AUTHORS
+      OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+
+      LIABILITY,
+      WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+
+      OUT
+      OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+
+      SOFTWARE.
+
+'
+    licenseUrl: https://github.com/BasisVR/Basis/tree/developer/Basis/Packages/nuget.meamod.dns/LICENSE
+  - productName: Newtonsoft.Json
+    packageName: org.basisvr.newtonsoft.json
+    licensePath: LICENSE
+    spdx: MIT
+    fullLicenseName: MIT License
+    fullLicenseText: 'MIT License
+
+
+
+      Copyright (c) 2007 James Newton-King
+
+
+
+      Permission
+      is hereby granted, free of charge, to any person obtaining a copy
+
+      of
+      this software and associated documentation files (the "Software"), to deal
+
+      in
+      the Software without restriction, including without limitation the rights
+
+      to
+      use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+
+      copies
+      of the Software, and to permit persons to whom the Software is
+
+      furnished
+      to do so, subject to the following conditions:
+
+
+
+      The above copyright
+      notice and this permission notice shall be included in all
+
+      copies or
+      substantial portions of the Software.
+
+
+
+      THE SOFTWARE IS PROVIDED
+      "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+
+      IMPLIED, INCLUDING
+      BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+
+      FITNESS FOR A
+      PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+
+      AUTHORS
+      OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+
+      LIABILITY,
+      WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+
+      OUT
+      OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+
+      SOFTWARE.
+
+
+
+      ---
+
+      Upstream:
+      https://github.com/JamesNK/Newtonsoft.Json
+
+      Repackaged for Unity by
+      BasisVR via https://github.com/BasisVR/UpmBuilds
+
+'
+    licenseUrl: https://github.com/BasisVR/Basis/tree/developer/Basis/Packages/org.basisvr.newtonsoft.json/LICENSE
+  - productName: OpenVR XR Plugin
+    packageName: com.valvesoftware.unity.openvr
+    licensePath: LICENSE.md
+    spdx: BSD-3-Clause
+    fullLicenseName: BSD 3-Clause License
+    fullLicenseText: 'Copyright (c) Valve Corporation
+
+      All rights reserved.
+
+
+
+      Redistribution
+      and use in source and binary forms, with or without modification,
+
+      are
+      permitted provided that the following conditions are met
+
+
+
+      1.
+      Redistributions of source code must retain the above copyright notice, this
+
+      list
+      of conditions and the following disclaimer.
+
+
+
+      2. Redistributions
+      in binary form must reproduce the above copyright notice,
+
+      this list
+      of conditions and the following disclaimer in the documentation andor
+
+      other
+      materials provided with the distribution.
+
+
+
+      3. Neither the name
+      of the copyright holder nor the names of its contributors
+
+      may be used
+      to endorse or promote products derived from this software without
+
+      specific
+      prior written permission.
+
+
+
+      THIS SOFTWARE IS PROVIDED BY THE
+      COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND
+
+      ANY EXPRESS OR IMPLIED
+      WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+
+      WARRANTIES OF
+      MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+
+      DISCLAIMED.
+      IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+
+      ANY
+      DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+
+      (INCLUDING,
+      BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+
+      LOSS
+      OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+
+      ANY
+      THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+
+      (INCLUDING
+      NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+
+      SOFTWARE,
+      EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.'
+    licenseUrl: https://github.com/BasisVR/Basis/tree/developer/Basis/Packages/com.valvesoftware.unity.openvr/LICENSE.md
+  - productName: Opus Codec
+    packageName: com.avionblock.opussharp
+    licensePath: Opus_LICENSE_PLEASE_READ.txt
+    spdx:
+    fullLicenseName:
+    fullLicenseText: 'Contributions to the collaboration shall not be considered
+      confidential.
+
+
+
+      Each contributor represents and warrants that
+      it has the right and
+
+      authority to license copyright in its contributions
+      to the collaboration.
+
+
+
+      Each contributor agrees to license the
+      copyright in the contributions
+
+      under the Modified (2-clause or 3-clause)
+      BSD License or the Clear BSD License.
+
+
+
+      Please see the IPR statements
+      submitted to the IETF for the complete
+
+      patent licensing details:
+
+
+
+      Xiph.Org
+      Foundation:
+
+      https://datatracker.ietf.org/ipr/1524/
+
+
+
+      Microsoft
+      Corporation:
+
+      https://datatracker.ietf.org/ipr/1914/
+
+
+
+      Skype
+      Limited:
+
+      https://datatracker.ietf.org/ipr/1602/
+
+
+
+      Broadcom
+      Corporation:
+
+      https://datatracker.ietf.org/ipr/1526/'
+    licenseUrl: https://github.com/BasisVR/Basis/tree/developer/Basis/Packages/com.avionblock.opussharp/Opus_LICENSE_PLEASE_READ.txt
+  - productName: OpusSharp
+    packageName: com.avionblock.opussharp
+    licensePath: LICENSE.txt
+    spdx: MIT
+    fullLicenseName: MIT License
+    fullLicenseText: 'MIT License
+
+
+
+      Copyright (c) 2026 AvionBlock
+
+
+
+      Permission
+      is hereby granted, free of charge, to any person obtaining a copy
+
+      of
+      this software and associated documentation files (the "Software"), to deal
+
+      in
+      the Software without restriction, including without limitation the rights
+
+      to
+      use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+
+      copies
+      of the Software, and to permit persons to whom the Software is
+
+      furnished
+      to do so, subject to the following conditions:
+
+
+
+      The above copyright
+      notice and this permission notice shall be included in all
+
+      copies or
+      substantial portions of the Software.
+
+
+
+      THE SOFTWARE IS PROVIDED
+      "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+
+      IMPLIED, INCLUDING
+      BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+
+      FITNESS FOR A
+      PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+
+      AUTHORS
+      OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+
+      LIABILITY,
+      WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+
+      OUT
+      OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+
+      SOFTWARE.
+
+'
+    licenseUrl: https://github.com/BasisVR/Basis/tree/developer/Basis/Packages/com.avionblock.opussharp/LICENSE.txt
+  - productName: RNNoise
+    packageName: com.xiph.rnnoise
+    licensePath: LICENSE
+    spdx: MIT
+    fullLicenseName: MIT License
+    fullLicenseText: 'MIT License
+
+
+
+      Copyright (c) 2023 Yellow Dog
+      Man Studios
+
+
+
+      Permission is hereby granted, free of charge,
+      to any person obtaining a copy
+
+      of this software and associated documentation
+      files (the "Software"), to deal
+
+      in the Software without restriction,
+      including without limitation the rights
+
+      to use, copy, modify, merge,
+      publish, distribute, sublicense, and/or sell
+
+      copies of the Software,
+      and to permit persons to whom the Software is
+
+      furnished to do so, subject
+      to the following conditions:
+
+
+
+      The above copyright notice and
+      this permission notice shall be included in all
+
+      copies or substantial
+      portions of the Software.
+
+
+
+      THE SOFTWARE IS PROVIDED "AS IS",
+      WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+
+      IMPLIED, INCLUDING BUT NOT
+      LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+
+      FITNESS FOR A PARTICULAR
+      PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+
+      AUTHORS OR COPYRIGHT
+      HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+
+      LIABILITY, WHETHER
+      IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+
+      OUT OF OR
+      IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+
+      SOFTWARE.
+
+'
+    licenseUrl: https://github.com/BasisVR/Basis/tree/developer/Basis/Packages/com.xiph.rnnoise/LICENSE
+  - productName: SimpleBase
+    packageName: org.basisvr.simplebase
+    licensePath: LICENSE
+    spdx: MIT
+    fullLicenseName: MIT License
+    fullLicenseText: 'MIT License
+
+
+
+      Copyright (c) Sedat Kapanoglu
+
+
+
+      Permission
+      is hereby granted, free of charge, to any person obtaining a copy
+
+      of
+      this software and associated documentation files (the "Software"), to deal
+
+      in
+      the Software without restriction, including without limitation the rights
+
+      to
+      use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+
+      copies
+      of the Software, and to permit persons to whom the Software is
+
+      furnished
+      to do so, subject to the following conditions:
+
+
+
+      The above copyright
+      notice and this permission notice shall be included in all
+
+      copies or
+      substantial portions of the Software.
+
+
+
+      THE SOFTWARE IS PROVIDED
+      "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+
+      IMPLIED, INCLUDING
+      BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+
+      FITNESS FOR A
+      PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+
+      AUTHORS
+      OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+
+      LIABILITY,
+      WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+
+      OUT
+      OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+
+      SOFTWARE.
+
+
+
+      ---
+
+      Upstream:
+      https://github.com/ssg/SimpleBase
+
+      Repackaged for Unity by BasisVR via
+      https://github.com/BasisVR/UpmBuilds
+
+'
+    licenseUrl: https://github.com/BasisVR/Basis/tree/developer/Basis/Packages/org.basisvr.simplebase/LICENSE
+  - productName: Steam Audio
+    packageName: com.steam.steamaudio
+    licensePath: LICENSE.md
+    spdx: Apache-2.0
+    fullLicenseName: Apache License 2.0
+    fullLicenseText: "\r\n                                 Apache License\r\n
+      Version 2.0, January 2004\r\n                        http://www.apache.org/licenses/\r\n\r\n
+      TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\r\n\r\n   1. Definitions.\r\n\r\n
+      \"License\" shall mean the terms and conditions for use, reproduction,\r\n
+      and distribution as defined by Sections 1 through 9 of this document.\r\n\r\n
+      \"Licensor\" shall mean the copyright owner or entity authorized by\r\n
+      the copyright owner that is granting the License.\r\n\r\n      \"Legal Entity\"
+      shall mean the union of the acting entity and all\r\n      other entities that
+      control, are controlled by, or are under common\r\n      control with that
+      entity. For the purposes of this definition,\r\n      \"control\" means (i)
+      the power, direct or indirect, to cause the\r\n      direction or management
+      of such entity, whether by contract or\r\n      otherwise, or (ii) ownership
+      of fifty percent (50%) or more of the\r\n      outstanding shares, or (iii)
+      beneficial ownership of such entity.\r\n\r\n      \"You\" (or \"Your\") shall
+      mean an individual or Legal Entity\r\n      exercising permissions granted
+      by this License.\r\n\r\n      \"Source\" form shall mean the preferred form
+      for making modifications,\r\n      including but not limited to software source
+      code, documentation\r\n      source, and configuration files.\r\n\r\n
+      \"Object\" form shall mean any form resulting from mechanical\r\n      transformation
+      or translation of a Source form, including but\r\n      not limited to compiled
+      object code, generated documentation,\r\n      and conversions to other media
+      types.\r\n\r\n      \"Work\" shall mean the work of authorship, whether in
+      Source or\r\n      Object form, made available under the License, as indicated
+      by a\r\n      copyright notice that is included in or attached to the work\r\n
+      (an example is provided in the Appendix below).\r\n\r\n      \"Derivative Works\"
+      shall mean any work, whether in Source or Object\r\n      form, that is based
+      on (or derived from) the Work and for which the\r\n      editorial revisions,
+      annotations, elaborations, or other modifications\r\n      represent, as a
+      whole, an original work of authorship. For the purposes\r\n      of this License,
+      Derivative Works shall not include works that remain\r\n      separable from,
+      or merely link (or bind by name) to the interfaces of,\r\n      the Work and
+      Derivative Works thereof.\r\n\r\n      \"Contribution\" shall mean any work
+      of authorship, including\r\n      the original version of the Work and any
+      modifications or additions\r\n      to that Work or Derivative Works thereof,
+      that is intentionally\r\n      submitted to Licensor for inclusion in the Work
+      by the copyright owner\r\n      or by an individual or Legal Entity authorized
+      to submit on behalf of\r\n      the copyright owner. For the purposes of this
+      definition, \"submitted\"\r\n      means any form of electronic, verbal, or
+      written communication sent\r\n      to the Licensor or its representatives,
+      including but not limited to\r\n      communication on electronic mailing lists,
+      source code control systems,\r\n      and issue tracking systems that are managed
+      by, or on behalf of, the\r\n      Licensor for the purpose of discussing and
+      improving the Work, but\r\n      excluding communication that is conspicuously
+      marked or otherwise\r\n      designated in writing by the copyright owner as
+      \"Not a Contribution.\"\r\n\r\n      \"Contributor\" shall mean Licensor and
+      any individual or Legal Entity\r\n      on behalf of whom a Contribution has
+      been received by Licensor and\r\n      subsequently incorporated within the
+      Work.\r\n\r\n   2. Grant of Copyright License. Subject to the terms and conditions
+      of\r\n      this License, each Contributor hereby grants to You a perpetual,\r\n
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\r\n      copyright
+      license to reproduce, prepare Derivative Works of,\r\n      publicly display,
+      publicly perform, sublicense, and distribute the\r\n      Work and such Derivative
+      Works in Source or Object form.\r\n\r\n   3. Grant of Patent License. Subject
+      to the terms and conditions of\r\n      this License, each Contributor hereby
+      grants to You a perpetual,\r\n      worldwide, non-exclusive, no-charge, royalty-free,
+      irrevocable\r\n      (except as stated in this section) patent license to make,
+      have made,\r\n      use, offer to sell, sell, import, and otherwise transfer
+      the Work,\r\n      where such license applies only to those patent claims licensable\r\n
+      by such Contributor that are necessarily infringed by their\r\n      Contribution(s)
+      alone or by combination of their Contribution(s)\r\n      with the Work to
+      which such Contribution(s) was submitted. If You\r\n      institute patent
+      litigation against any entity (including a\r\n      cross-claim or counterclaim
+      in a lawsuit) alleging that the Work\r\n      or a Contribution incorporated
+      within the Work constitutes direct\r\n      or contributory patent infringement,
+      then any patent licenses\r\n      granted to You under this License for that
+      Work shall terminate\r\n      as of the date such litigation is filed.\r\n\r\n
+      4. Redistribution. You may reproduce and distribute copies of the\r\n
+      Work or Derivative Works thereof in any medium, with or without\r\n      modifications,
+      and in Source or Object form, provided that You\r\n      meet the following
+      conditions:\r\n\r\n      (a) You must give any other recipients of the Work
+      or\r\n          Derivative Works a copy of this License; and\r\n\r\n      (b)
+      You must cause any modified files to carry prominent notices\r\n          stating
+      that You changed the files; and\r\n\r\n      (c) You must retain, in the Source
+      form of any Derivative Works\r\n          that You distribute, all copyright,
+      patent, trademark, and\r\n          attribution notices from the Source form
+      of the Work,\r\n          excluding those notices that do not pertain to any
+      part of\r\n          the Derivative Works; and\r\n\r\n      (d) If the Work
+      includes a \"NOTICE\" text file as part of its\r\n          distribution, then
+      any Derivative Works that You distribute must\r\n          include a readable
+      copy of the attribution notices contained\r\n          within such NOTICE file,
+      excluding those notices that do not\r\n          pertain to any part of the
+      Derivative Works, in at least one\r\n          of the following places: within
+      a NOTICE text file distributed\r\n          as part of the Derivative Works;
+      within the Source form or\r\n          documentation, if provided along with
+      the Derivative Works; or,\r\n          within a display generated by the Derivative
+      Works, if and\r\n          wherever such third-party notices normally appear.
+      The contents\r\n          of the NOTICE file are for informational purposes
+      only and\r\n          do not modify the License. You may add Your own attribution\r\n
+      notices within Derivative Works that You distribute, alongside\r\n
+      or as an addendum to the NOTICE text from the Work, provided\r\n          that
+      such additional attribution notices cannot be construed\r\n          as modifying
+      the License.\r\n\r\n      You may add Your own copyright statement to Your
+      modifications and\r\n      may provide additional or different license terms
+      and conditions\r\n      for use, reproduction, or distribution of Your modifications,
+      or\r\n      for any such Derivative Works as a whole, provided Your use,\r\n
+      reproduction, and distribution of the Work otherwise complies with\r\n
+      the conditions stated in this License.\r\n\r\n   5. Submission of Contributions.
+      Unless You explicitly state otherwise,\r\n      any Contribution intentionally
+      submitted for inclusion in the Work\r\n      by You to the Licensor shall be
+      under the terms and conditions of\r\n      this License, without any additional
+      terms or conditions.\r\n      Notwithstanding the above, nothing herein shall
+      supersede or modify\r\n      the terms of any separate license agreement you
+      may have executed\r\n      with Licensor regarding such Contributions.\r\n\r\n
+      6. Trademarks. This License does not grant permission to use the trade\r\n
+      names, trademarks, service marks, or product names of the Licensor,\r\n
+      except as required for reasonable and customary use in describing the\r\n
+      origin of the Work and reproducing the content of the NOTICE file.\r\n\r\n
+      7. Disclaimer of Warranty. Unless required by applicable law or\r\n      agreed
+      to in writing, Licensor provides the Work (and each\r\n      Contributor provides
+      its Contributions) on an \"AS IS\" BASIS,\r\n      WITHOUT WARRANTIES OR CONDITIONS
+      OF ANY KIND, either express or\r\n      implied, including, without limitation,
+      any warranties or conditions\r\n      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY,
+      or FITNESS FOR A\r\n      PARTICULAR PURPOSE. You are solely responsible for
+      determining the\r\n      appropriateness of using or redistributing the Work
+      and assume any\r\n      risks associated with Your exercise of permissions
+      under this License.\r\n\r\n   8. Limitation of Liability. In no event and under
+      no legal theory,\r\n      whether in tort (including negligence), contract,
+      or otherwise,\r\n      unless required by applicable law (such as deliberate
+      and grossly\r\n      negligent acts) or agreed to in writing, shall any Contributor
+      be\r\n      liable to You for damages, including any direct, indirect, special,\r\n
+      incidental, or consequential damages of any character arising as a\r\n
+      result of this License or out of the use or inability to use the\r\n      Work
+      (including but not limited to damages for loss of goodwill,\r\n      work stoppage,
+      computer failure or malfunction, or any and all\r\n      other commercial damages
+      or losses), even if such Contributor\r\n      has been advised of the possibility
+      of such damages.\r\n\r\n   9. Accepting Warranty or Additional Liability. While
+      redistributing\r\n      the Work or Derivative Works thereof, You may choose
+      to offer,\r\n      and charge a fee for, acceptance of support, warranty, indemnity,\r\n
+      or other liability obligations and/or rights consistent with this\r\n
+      License. However, in accepting such obligations, You may act only\r\n
+      on Your own behalf and on Your sole responsibility, not on behalf\r\n
+      of any other Contributor, and only if You agree to indemnify,\r\n      defend,
+      and hold each Contributor harmless for any liability\r\n      incurred by,
+      or claims asserted against, such Contributor by reason\r\n      of your accepting
+      any such warranty or additional liability.\r\n\r\n   END OF TERMS AND CONDITIONS\r\n\r\n
+      APPENDIX: How to apply the Apache License to your work.\r\n\r\n      To apply
+      the Apache License to your work, attach the following\r\n      boilerplate
+      notice, with the fields enclosed by brackets \"[]\"\r\n      replaced with
+      your own identifying information. (Don't include\r\n      the brackets!)  The
+      text should be enclosed in the appropriate\r\n      comment syntax for the
+      file format. We also recommend that a\r\n      file or class name and description
+      of purpose be included on the\r\n      same \"printed page\" as the copyright
+      notice for easier\r\n      identification within third-party archives.\r\n\r\n
+      Copyright [yyyy] [name of copyright owner]\r\n\r\n   Licensed under the Apache
+      License, Version 2.0 (the \"License\");\r\n   you may not use this file except
+      in compliance with the License.\r\n   You may obtain a copy of the License
+      at\r\n\r\n       http://www.apache.org/licenses/LICENSE-2.0\r\n\r\n   Unless
+      required by applicable law or agreed to in writing, software\r\n   distributed
+      under the License is distributed on an \"AS IS\" BASIS,\r\n   WITHOUT WARRANTIES
+      OR CONDITIONS OF ANY KIND, either express or implied.\r\n   See the License
+      for the specific language governing permissions and\r\n   limitations under
+      the License.\r\n"
+    licenseUrl: https://github.com/BasisVR/Basis/tree/developer/Basis/Packages/com.steam.steamaudio/LICENSE.md
+  - productName: SteamVR
+    packageName: com.steam.steamvr
+    licensePath: LICENSE
+    spdx: BSD-3-Clause
+    fullLicenseName: BSD 3-Clause License
+    fullLicenseText: 'Copyright (c) Valve Corporation
+
+      All rights reserved.
+
+
+
+      Redistribution
+      and use in source and binary forms, with or without modification,
+
+      are
+      permitted provided that the following conditions are met
+
+
+
+      1.
+      Redistributions of source code must retain the above copyright notice, this
+
+      list
+      of conditions and the following disclaimer.
+
+
+
+      2. Redistributions
+      in binary form must reproduce the above copyright notice,
+
+      this list
+      of conditions and the following disclaimer in the documentation andor
+
+      other
+      materials provided with the distribution.
+
+
+
+      3. Neither the name
+      of the copyright holder nor the names of its contributors
+
+      may be used
+      to endorse or promote products derived from this software without
+
+      specific
+      prior written permission.
+
+
+
+      THIS SOFTWARE IS PROVIDED BY THE
+      COPYRIGHT HOLDERS AND CONTRIBUTORS AS IS AND
+
+      ANY EXPRESS OR IMPLIED
+      WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+
+      WARRANTIES OF
+      MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+
+      DISCLAIMED.
+      IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+
+      ANY
+      DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+
+      (INCLUDING,
+      BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+
+      LOSS
+      OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+
+      ANY
+      THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+
+      (INCLUDING
+      NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+
+      SOFTWARE,
+      EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.'
+    licenseUrl: https://github.com/BasisVR/Basis/tree/developer/Basis/Packages/com.steam.steamvr/LICENSE
+  - productName: URP Volumetric Fog
+    packageName: com.cqf.urpvolumetricfog
+    licensePath: LICENSE.md
+    spdx: MIT
+    fullLicenseName: MIT License
+    fullLicenseText: 'MIT License
+
+
+
+      Copyright (c) 2025 Cristian Qiu
+
+
+
+      Permission
+      is hereby granted, free of charge, to any person obtaining a copy
+
+      of
+      this software and associated documentation files (the "Software"), to deal
+
+      in
+      the Software without restriction, including without limitation the rights
+
+      to
+      use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+
+      copies
+      of the Software, and to permit persons to whom the Software is
+
+      furnished
+      to do so, subject to the following conditions:
+
+
+
+      The above copyright
+      notice and this permission notice shall be included in all
+
+      copies or
+      substantial portions of the Software.
+
+
+
+      THE SOFTWARE IS PROVIDED
+      "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+
+      IMPLIED, INCLUDING
+      BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+
+      FITNESS FOR A
+      PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+
+      AUTHORS
+      OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+
+      LIABILITY,
+      WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+
+      OUT
+      OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+
+      SOFTWARE.'
+    licenseUrl: https://github.com/BasisVR/Basis/tree/developer/Basis/Packages/com.cqf.urpvolumetricfog/LICENSE.md
+  urlPrefix: https://github.com/BasisVR/Basis/tree/developer/Basis/Packages/

--- a/Basis/Packages/dev.hai-vr.hvr.license-review/BasisFrameworkLicenseManifest.asset.meta
+++ b/Basis/Packages/dev.hai-vr.hvr.license-review/BasisFrameworkLicenseManifest.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 27c7383e2606aaa4986e5ef070459a46
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Basis/Packages/dev.hai-vr.hvr.license-review/LICENSE
+++ b/Basis/Packages/dev.hai-vr.hvr.license-review/LICENSE
@@ -1,0 +1,21 @@
+﻿MIT License
+
+Copyright (c) 2026 Haï~ (@vr_hai github.com/hai-vr)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Basis/Packages/dev.hai-vr.hvr.license-review/LICENSE.meta
+++ b/Basis/Packages/dev.hai-vr.hvr.license-review/LICENSE.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e43e934eef824bf3aeeea9598472f8fb
+timeCreated: 1778152421

--- a/Basis/Packages/dev.hai-vr.hvr.license-review/Scripts.meta
+++ b/Basis/Packages/dev.hai-vr.hvr.license-review/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d658925898865c04c8f61f987322e439
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Basis/Packages/dev.hai-vr.hvr.license-review/Scripts/Editor.meta
+++ b/Basis/Packages/dev.hai-vr.hvr.license-review/Scripts/Editor.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 59e9ce950d8549259966f7df830e0327
+timeCreated: 1778148656

--- a/Basis/Packages/dev.hai-vr.hvr.license-review/Scripts/Editor/HVR.LicenseReview.Editor.asmdef
+++ b/Basis/Packages/dev.hai-vr.hvr.license-review/Scripts/Editor/HVR.LicenseReview.Editor.asmdef
@@ -1,0 +1,19 @@
+{
+    "name": "HVR.LicenseReview.Editor",
+    "rootNamespace": "",
+    "references": [
+        "HVR.LicenseReview"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [
+    ],
+    "noEngineReferences": false
+}

--- a/Basis/Packages/dev.hai-vr.hvr.license-review/Scripts/Editor/HVR.LicenseReview.Editor.asmdef.meta
+++ b/Basis/Packages/dev.hai-vr.hvr.license-review/Scripts/Editor/HVR.LicenseReview.Editor.asmdef.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c5563ff2829f48d99d2f4b2cd03e265d
+timeCreated: 1778148659

--- a/Basis/Packages/dev.hai-vr.hvr.license-review/Scripts/Editor/LicenseBaker.cs
+++ b/Basis/Packages/dev.hai-vr.hvr.license-review/Scripts/Editor/LicenseBaker.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using UnityEditor.PackageManager;
+
+namespace HVR.LicenseReview.Editor
+{
+    public static class LicenseBaker
+    {
+        public static void BakeManifest(LicenseManifest manifest, Func<(string, string), string> urlFn)
+        {
+            var packagesInProject = PackageInfo.GetAllRegisteredPackages().ToDictionary(info => info.name, info => info);
+
+            manifest.baked = manifest.trackedPackages
+                .Where(package => packagesInProject.ContainsKey(package.packageName))
+                .SelectMany(package =>
+                {
+                    var packageInProject = packagesInProject[package.packageName];
+
+                    return package.licenses.Select(license => new LicenseBaked
+                    {
+                        productName = !string.IsNullOrWhiteSpace(license.overrideProductName) ? license.overrideProductName : packageInProject.displayName,
+                        packageName = package.packageName,
+                        licensePath = license.path,
+                        spdx = license.spdx,
+                        fullLicenseName = FromSpdxToFullLicenseName(license.spdx),
+                        licenseUrl = urlFn.Invoke((package.packageName, license.path)),
+                        fullLicenseText = File.ReadAllText(Path.Combine(packageInProject.resolvedPath, license.path), Encoding.UTF8)
+                    });
+                })
+                .OrderBy(baked => baked.productName)
+                .ThenBy(baked => baked.licensePath)
+                .ToArray();
+        }
+
+        private static string FromSpdxToFullLicenseName(string licenseSpdx)
+        {
+            return licenseSpdx switch
+            {
+                "MIT" => "MIT License",
+                "Apache-2.0" => "Apache License 2.0",
+                "BSD-3-Clause" => "BSD 3-Clause License",
+                "BSD-2-Clause" => "BSD 2-Clause License",
+                "Unlicense" => "The Unlicense",
+                _ => licenseSpdx
+            };
+        }
+    }
+}

--- a/Basis/Packages/dev.hai-vr.hvr.license-review/Scripts/Editor/LicenseBaker.cs.meta
+++ b/Basis/Packages/dev.hai-vr.hvr.license-review/Scripts/Editor/LicenseBaker.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 005790ec4df745eea34e87573fd4a4d4
+timeCreated: 1778160767

--- a/Basis/Packages/dev.hai-vr.hvr.license-review/Scripts/Editor/LicenseManifestEditor.cs
+++ b/Basis/Packages/dev.hai-vr.hvr.license-review/Scripts/Editor/LicenseManifestEditor.cs
@@ -1,0 +1,466 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using UnityEditor;
+using UnityEngine;
+using PackageInfo = UnityEditor.PackageManager.PackageInfo;
+
+namespace HVR.LicenseReview.Editor
+{
+    [CustomEditor(typeof(LicenseManifest))]
+    public class LicenseManifestEditor : UnityEditor.Editor
+    {
+        private const string ChangeLicenseTrackingStatusLabel = "Change license tracking status";
+        private const string UnknownLicense = "Unknown";
+        private string _rootFullPath;
+        private List<PPackage> _allPackages;
+        private LicenseManifest my;
+        private HashSet<string> _allPackageNames;
+
+        private static bool editLicenses;
+        private static bool displayLicenses;
+
+        private void OnEnable()
+        {
+            my = (LicenseManifest)target;
+            _rootFullPath = Path.GetFullPath(".").Replace("\\", "/") + "/";
+            _allPackages = FindPackageInformation();
+            _allPackageNames = _allPackages.Select(package => package.package.name).ToHashSet();
+        }
+
+        private List<PPackage> FindPackageInformation()
+        {
+            var results = new List<PPackage>();
+
+            var packageList = PackageInfo.GetAllRegisteredPackages();
+            foreach (PackageInfo package in packageList)
+            {
+                if (package.resolvedPath != null && Directory.Exists(package.resolvedPath))
+                {
+                    var allFiles = Directory.GetFiles(package.resolvedPath, "*", SearchOption.AllDirectories);
+
+                    var foundLicenseFiles = allFiles
+                        .Where(file =>
+                        {
+                            var filename = Path.GetFileName(file).ToLowerInvariant();
+                            return filename.Equals("license")
+                                || filename.Equals("license.txt")
+                                || filename.Equals("license.md")
+                                || filename.Equals("copying")
+                                || filename.Equals("copying.txt")
+                                || filename.Equals("copying.md")
+                                || (filename.Contains("_license_") && !filename.EndsWith(".meta"))
+                                   ;
+                        })
+                        .Select(s => s.Replace("\\", "/"))
+                        .ToList();
+                    var foundTrademarkFiles = allFiles
+                        .Where(file =>
+                        {
+                            var filename = Path.GetFileName(file).ToLowerInvariant();
+                            return filename.Contains("trademark") && !filename.EndsWith(".meta");
+                        })
+                        .Select(s => s.Replace("\\", "/"))
+                        .ToList();
+
+                    results.Add(new PPackage
+                    {
+                        package = package,
+                        resolvedPath = package.resolvedPath.Replace("\\", "/"),
+                        foundLicenseFiles = foundLicenseFiles.Select(licensePath =>
+                        {
+                            return Guess(package, licensePath);
+                        }).ToList(),
+                        foundTrademarkFiles = foundTrademarkFiles.Select(trademarkPath => new PTrademark
+                        {
+                            trademarkPath = trademarkPath,
+                            trademarkContents = File.ReadAllText(trademarkPath, Encoding.UTF8)
+                        }).ToList()
+                    });
+                }
+            }
+
+            return results
+                .OrderBy(package => package.package.name.StartsWith("com.basis.") ? 0 : 1)
+                .ThenBy(package => package.package.name.StartsWith("org.basisvr.") ? 0 : 1)
+                .ThenBy(package => package.package.displayName)
+                .ToList();
+        }
+
+        private PLicense Guess(PackageInfo package, string licensePath)
+        {
+            var my = (LicenseManifest)target;
+
+            var subPath = licensePath.Substring(package.resolvedPath.Length + 1);
+
+            var contents = File.ReadAllText(licensePath, Encoding.UTF8);
+            return new PLicense
+            {
+                licensePath = licensePath,
+                licenseContents = contents,
+                licenseGuess = GuessLicense(contents),
+
+                licenseSubPath = subPath,
+                isTrackedInManifest = my.IsTracked(package.name, subPath)
+            };
+        }
+
+        public override void OnInspectorGUI()
+        {
+            my = (LicenseManifest)target;
+
+            if (GUILayout.Button("Bake"))
+            {
+                Undo.RecordObject(my, "Bake licenses");
+                LicenseBaker.BakeManifest(my, tuple => $"{my.urlPrefix}{tuple.Item1}/{tuple.Item2}");
+                return;
+            }
+
+            EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(LicenseManifest.urlPrefix)));
+            EditorGUILayout.Separator();
+
+            editLicenses = EditorGUILayout.ToggleLeft("Edit Licenses", editLicenses);
+            displayLicenses = EditorGUILayout.ToggleLeft("Display Full License Text", displayLicenses);
+
+            var packagesNotFound = my.trackedPackages.Where(package => !_allPackageNames.Contains(package.packageName)).ToList();
+
+            if (packagesNotFound.Count > 0)
+            {
+                EditorGUILayout.HelpBox("The manifest contains references to packages that don't exist in this project.", MessageType.Error);
+                foreach (var package in packagesNotFound)
+                {
+                    EditorGUILayout.LabelField($"- {package.packageName} not found in project");
+                }
+                EditorGUILayout.Separator();
+            }
+
+            var partitonByIsNotUnity = Partition(_allPackages, package => !package.package.name.StartsWith("com.unity."));
+
+            var partitionByHasAnyLicense = Partition(partitonByIsNotUnity.matches, package => package.foundLicenseFiles.Count > 0);
+
+            EditorGUILayout.LabelField($"Found license files across {partitionByHasAnyLicense.matches.Count} packages.");
+            EditorGUILayout.LabelField($"Found {partitionByHasAnyLicense.rest.Count} packages with no license file.");
+            EditorGUILayout.Separator();
+
+            var guesses = partitionByHasAnyLicense.matches.GroupBy(package =>
+                {
+                    if (package.foundLicenseFiles.Count == 0) return "Missing";
+                    if (package.foundLicenseFiles.Count == 1) return package.foundLicenseFiles[0].licenseGuess;
+                    if (package.foundLicenseFiles.Select(license => license.licenseGuess).Distinct().Count() > 1) return "Multiple license types found";
+                    return package.foundLicenseFiles[0].licenseGuess;
+                })
+                .OrderBy(packages => packages.Key != "Missing" ? 0 : 1)
+                .ThenBy(packages => packages.Key != UnknownLicense ? 0 : 1)
+                .ThenBy(packages => packages.Key != "Multiple license types found" ? 0 : 1);
+            foreach (var groups in guesses)
+            {
+                EditorGUILayout.BeginVertical("GroupBox");
+                EditorGUILayout.LabelField(groups.Key + "?", EditorStyles.boldLabel);
+
+                EditorGUILayout.Separator();
+                foreach (var package in groups)
+                {
+                    var hasMoreThanOneLicenseInIt = package.foundLicenseFiles.Count > 1;
+
+                    LayoutPackageName(package);
+
+                    var isExcluded = my.IsExcluded(package.package.name);
+                    if (isExcluded) EditorGUI.BeginDisabledGroup(true);
+
+                    if (!isExcluded && (hasMoreThanOneLicenseInIt || package.foundLicenseFiles[0].isTrackedInManifest && editLicenses))
+                    {
+                        foreach (var licenseFile in package.foundLicenseFiles)
+                        {
+                            EditorGUILayout.BeginHorizontal();
+                            EditorGUILayout.LabelField("", GUILayout.Width(20));
+                            var isTracked = licenseFile.isTrackedInManifest;
+                            var newTracked = EditorGUILayout.Toggle(isTracked, GUILayout.Width(20));
+                            if (newTracked != isTracked)
+                            {
+                                Undo.RecordObject(my, ChangeLicenseTrackingStatusLabel);
+                                if (newTracked)
+                                {
+                                    my.Track(package.package.name, new [] { licenseFile.licenseSubPath });
+                                }
+                                else
+                                {
+                                    my.Untrack(package.package.name, new [] { licenseFile.licenseSubPath });
+                                }
+                                licenseFile.isTrackedInManifest = newTracked;
+                                serializedObject.Update();
+                            }
+                            EditorGUILayout.LabelField(licenseFile.licenseGuess + "?", GUILayout.Width(100));
+                            EditorGUILayout.LabelField(licenseFile.licenseSubPath);
+                            EditorGUILayout.EndHorizontal();
+
+                            if (isTracked && editLicenses)
+                            {
+                                var trackedPackagesSp = serializedObject.FindProperty(nameof(LicenseManifest.trackedPackages));
+                                for (var i = 0; i < trackedPackagesSp.arraySize; i++)
+                                {
+                                    var packageElt = trackedPackagesSp.GetArrayElementAtIndex(i);
+                                    var packageNameSp = packageElt.FindPropertyRelative(nameof(LicenseTrackedPackage.packageName));
+                                    if (packageNameSp.stringValue == package.package.name)
+                                    {
+                                        var licensesProperty = packageElt.FindPropertyRelative(nameof(LicenseTrackedPackage.licenses));
+                                        for (var j = 0; j < licensesProperty.arraySize; j++)
+                                        {
+                                            var licenseSp = licensesProperty.GetArrayElementAtIndex(j);
+                                            var pathSo = licenseSp.FindPropertyRelative(nameof(LicenseTrackedLicense.path));
+                                            if (pathSo.stringValue == licenseFile.licenseSubPath)
+                                            {
+                                                EditorGUILayout.BeginVertical("GroupBox");
+                                                EditorGUILayout.LabelField($"{package.package.displayName} ({package.package.name})", EditorStyles.boldLabel);
+                                                EditorGUILayout.BeginHorizontal();
+                                                EditorGUILayout.LabelField(licenseFile.licensePath);
+                                                if (GUILayout.Button("Open package.json", GUILayout.Width(150)))
+                                                {
+                                                    Application.OpenURL($"file://{package.package.resolvedPath}/package.json");
+                                                }
+                                                if (GUILayout.Button("Open license", GUILayout.Width(100)))
+                                                {
+                                                    Application.OpenURL($"file://{licenseFile.licensePath}");
+                                                }
+                                                EditorGUILayout.EndHorizontal();
+                                                EditorGUILayout.Separator();
+
+                                                var spdxSp = licenseSp.FindPropertyRelative(nameof(LicenseTrackedLicense.spdx));
+                                                EditorGUILayout.PropertyField(spdxSp, new GUIContent("SPDX"));
+                                                if (licenseFile.licenseGuess != UnknownLicense && spdxSp.stringValue != licenseFile.licenseGuess)
+                                                {
+                                                    EditorGUILayout.HelpBox($"The SPDX identifier does not match our guess: {licenseFile.licenseGuess}. Please review.", MessageType.Warning);
+                                                }
+                                                else if (licenseFile.licenseGuess == UnknownLicense)
+                                                {
+                                                    if (string.IsNullOrWhiteSpace(spdxSp.stringValue))
+                                                    {
+                                                        EditorGUILayout.HelpBox($"We were unable to guess the license for this. Please find and specify the license.", MessageType.Error);
+                                                    }
+                                                    else
+                                                    {
+                                                        EditorGUILayout.HelpBox($"We were unable to guess the license for this. Make sure the license is correct.", MessageType.Info);
+                                                    }
+                                                }
+
+                                                EditorGUILayout.Separator();
+                                                EditorGUILayout.LabelField($"Overrides", EditorStyles.boldLabel);
+                                                EditorGUILayout.PropertyField(licenseSp.FindPropertyRelative(nameof(LicenseTrackedLicense.overrideProductName)));
+
+                                                if (displayLicenses)
+                                                {
+                                                    EditorGUILayout.Separator();
+                                                    EditorGUILayout.TextArea(licenseFile.licenseContents, GUILayout.Height(100));
+                                                }
+                                                EditorGUILayout.EndVertical();
+                                                break;
+                                            }
+                                        }
+                                        break;
+                                    }
+                                }
+                            }
+
+                            // EditorGUILayout.TextArea(licenseFile.licenseContents, GUILayout.Height(100));
+                        }
+                    }
+
+                    if (!isExcluded)
+                    {
+                        LayoutTrademarks(package);
+                    }
+                    if (isExcluded) EditorGUI.EndDisabledGroup();
+                }
+                EditorGUILayout.EndVertical();
+            }
+
+            EditorGUILayout.Separator();
+            EditorGUILayout.LabelField("No license found", EditorStyles.boldLabel);
+
+            EditorGUILayout.BeginVertical("GroupBox");
+            foreach (var package in partitionByHasAnyLicense.rest)
+            {
+                LayoutPackageName(package);
+                LayoutTrademarks(package);
+            }
+            EditorGUILayout.EndVertical();
+
+            EditorGUILayout.Separator();
+            EditorGUILayout.LabelField("Unity packages that have a LICENSE in them", EditorStyles.boldLabel);
+            EditorGUILayout.BeginVertical("GroupBox");
+            foreach (var package in partitonByIsNotUnity.rest.Where(package => package.foundLicenseFiles.Count > 0))
+            {
+                LayoutPackageName(package, true);
+            }
+            EditorGUILayout.EndVertical();
+
+            serializedObject.ApplyModifiedProperties();
+        }
+
+        private void LayoutPackageName(PPackage package, bool forceDoNotShowLicenses = false)
+        {
+            EditorGUILayout.BeginHorizontal();
+
+            var isAlreadyTracked = package.foundLicenseFiles.Any(license => license.isTrackedInManifest);
+            var isExcluded = my.IsExcluded(package.package.name);
+
+            if (isExcluded) EditorGUI.BeginDisabledGroup(true);
+
+            if (!forceDoNotShowLicenses && package.foundLicenseFiles.Count > 0)
+            {
+                var isTracked = package.foundLicenseFiles.All(license => license.isTrackedInManifest);
+                var newTracked = EditorGUILayout.Toggle(isTracked, GUILayout.Width(20));
+                if (isTracked != newTracked)
+                {
+                    Undo.RecordObject(my, ChangeLicenseTrackingStatusLabel);
+                    if (newTracked)
+                    {
+                        my.Track(package.package.name, package.foundLicenseFiles.Select(license => license.licenseSubPath).ToArray());
+                    }
+                    else
+                    {
+                        my.Untrack(package.package.name, package.foundLicenseFiles.Select(license => license.licenseSubPath).ToArray());
+                    }
+                    foreach (var license in package.foundLicenseFiles)
+                    {
+                        license.isTrackedInManifest = newTracked;
+                    }
+                    serializedObject.Update();
+                }
+            }
+
+            EditorGUILayout.LabelField(package.package.displayName, EditorStyles.boldLabel, GUILayout.Width(300));
+            EditorGUILayout.LabelField($"→ {package.package.name} ({SimplifyPath(package.resolvedPath)})", EditorStyles.boldLabel);
+            if (!isAlreadyTracked && !isExcluded && !forceDoNotShowLicenses)
+            {
+                if (GUILayout.Button("Exclude"))
+                {
+                    my.Exclude(package.package.name);
+                }
+            }
+
+            if (isExcluded)
+            {
+                EditorGUILayout.LabelField("Excluded", EditorStyles.boldLabel, GUILayout.Width(100));
+            }
+
+            if (isExcluded) EditorGUI.EndDisabledGroup();
+
+            EditorGUILayout.EndHorizontal();
+        }
+
+        private void LayoutTrademarks(PPackage package)
+        {
+            if (package.foundTrademarkFiles.Count > 0)
+            {
+                EditorGUILayout.BeginVertical("GroupBox");
+                EditorGUILayout.LabelField("Trademarks", EditorStyles.boldLabel);
+                foreach (var trademarkFile in package.foundTrademarkFiles)
+                {
+                    EditorGUILayout.LabelField(SimplifyPath(trademarkFile.trademarkPath));
+                    EditorGUILayout.TextArea(trademarkFile.trademarkContents, GUILayout.Height(100));
+                }
+                EditorGUILayout.EndVertical();
+            }
+        }
+
+        private string SimplifyPath(string path)
+        {
+            return path.StartsWith(_rootFullPath) ? path.Substring(_rootFullPath.Length) : path;
+        }
+
+        private static (List<T> matches, List<T> rest) Partition<T>(IEnumerable<T> source, Func<T, bool> predicate)
+        {
+            var matches = new List<T>();
+            var rest = new List<T>();
+            foreach (var item in source)
+            {
+                if (predicate(item)) matches.Add(item);
+                else rest.Add(item);
+            }
+            return (matches, rest);
+        }
+
+        private string GuessLicense(string licenseContents)
+        {
+            // This function only provides a guess, it may be incorrect. Only display this string for aid purposes.
+            // The developer using the tool should be responsible for checking
+            // before writing or serializing the result into a data table.
+
+            if (string.IsNullOrWhiteSpace(licenseContents))
+                return UnknownLicense;
+
+            var normalizedContents = licenseContents.ToLowerInvariant().Replace("\r\n", "\n");
+
+            if (normalizedContents.Contains("unity companion license"))
+                return "Unity Companion License";
+
+            if (normalizedContents.Contains("permission is hereby granted, free of charge") &&
+                normalizedContents.Contains("mit license"))
+                return "MIT";
+
+            if (normalizedContents.Contains("permission is hereby granted, free of charge") &&
+                normalizedContents.Contains("without restriction") &&
+                normalizedContents.Contains("use, copy, modify, merge, publish, distribute, sublicense"))
+                return "MIT";
+
+            if (normalizedContents.Contains("apache license") && normalizedContents.Contains("version 2.0"))
+                return "Apache-2.0";
+
+            if (normalizedContents.Contains("redistribution and use in source and binary forms"))
+            {
+                if (normalizedContents.Contains("3-clause"))
+                    return "BSD-3-Clause";
+                if (normalizedContents.Contains("2-clause"))
+                    return "BSD-2-Clause";
+
+                var clauseCount = 0;
+                if (normalizedContents.Contains("redistributions of source code must retain"))
+                    clauseCount++;
+                if (normalizedContents.Contains("redistributions in binary form must reproduce"))
+                    clauseCount++;
+                if (normalizedContents.Contains("neither the name of"))
+                    clauseCount++;
+
+                if (clauseCount == 3)
+                    return "BSD-3-Clause";
+                if (clauseCount == 2)
+                    return "BSD-2-Clause";
+
+                return "BSD";
+            }
+
+            if (normalizedContents.Contains("this is free and unencumbered software released into the public domain"))
+                return "Unlicense";
+
+            if (normalizedContents.Contains("creative commons") && normalizedContents.Contains("cc0"))
+                return "CC0-1.0";
+
+            return UnknownLicense;
+        }
+
+        private class PPackage
+        {
+            public PackageInfo package;
+            public string resolvedPath;
+            public List<PLicense> foundLicenseFiles;
+            public List<PTrademark> foundTrademarkFiles;
+        }
+
+        private class PLicense
+        {
+            public string licensePath;
+            public string licenseContents;
+            public string licenseGuess;
+            public string licenseSubPath;
+            public bool isTrackedInManifest;
+        }
+
+        private class PTrademark
+        {
+            public string trademarkPath;
+            public string trademarkContents;
+        }
+    }
+}

--- a/Basis/Packages/dev.hai-vr.hvr.license-review/Scripts/Editor/LicenseManifestEditor.cs.meta
+++ b/Basis/Packages/dev.hai-vr.hvr.license-review/Scripts/Editor/LicenseManifestEditor.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 46acd0fa92f14a19afae037476c90a0f
+timeCreated: 1778148754

--- a/Basis/Packages/dev.hai-vr.hvr.license-review/Scripts/Runtime.meta
+++ b/Basis/Packages/dev.hai-vr.hvr.license-review/Scripts/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6386bf6422acc494a98ac1878a34a528
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Basis/Packages/dev.hai-vr.hvr.license-review/Scripts/Runtime/HVR.LicenseReview.asmdef
+++ b/Basis/Packages/dev.hai-vr.hvr.license-review/Scripts/Runtime/HVR.LicenseReview.asmdef
@@ -1,0 +1,19 @@
+{
+    "name": "HVR.LicenseReview",
+    "rootNamespace": "",
+    "references": [
+        "Basis Framework",
+        "Unity.Addressables",
+        "Unity.ResourceManager"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [
+    ],
+    "noEngineReferences": false
+}

--- a/Basis/Packages/dev.hai-vr.hvr.license-review/Scripts/Runtime/HVR.LicenseReview.asmdef.meta
+++ b/Basis/Packages/dev.hai-vr.hvr.license-review/Scripts/Runtime/HVR.LicenseReview.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: cc6f8188151995d489a30e46c3f2811a
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Basis/Packages/dev.hai-vr.hvr.license-review/Scripts/Runtime/LicenseManifest.cs
+++ b/Basis/Packages/dev.hai-vr.hvr.license-review/Scripts/Runtime/LicenseManifest.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Linq;
+using UnityEngine;
+
+namespace HVR.LicenseReview
+{
+    [CreateAssetMenu(fileName = "LicenseManifest", menuName = "HVR.Basis/License Manifest")]
+    public class LicenseManifest : ScriptableObject
+    {
+        /// Packages that are part of this manifest.
+        public LicenseTrackedPackage[] trackedPackages = Array.Empty<LicenseTrackedPackage>();
+
+        // Packages that are excluded, usually because they are added to the project by users after the fact
+        // (e.g. work tools that are not part of the project and never committed).
+        public string[] excludedPackageNames = Array.Empty<string>();
+
+        public LicenseBaked[] baked = Array.Empty<LicenseBaked>();
+        public string urlPrefix;
+
+        public bool IsTracked(string packageName, string subPath)
+        {
+            return trackedPackages.Any(package => package.packageName == packageName && package.licenses.Any(license => license.path == subPath));
+        }
+
+        public void Track(string packageName, string[] newPathsToTrack)
+        {
+            for (var index = 0; index < trackedPackages.Length; index++)
+            {
+                var trackedPackage = trackedPackages[index];
+
+                if (trackedPackage.packageName == packageName)
+                {
+                    var existingPaths = trackedPackage.licenses.Select(license => license.path).ToHashSet();
+                    var newLicenses = newPathsToTrack.Except(existingPaths)
+                        .Select(path => new LicenseTrackedLicense
+                        {
+                            path = path
+                        })
+                        .ToList();
+
+                    var newTrackedPackage = trackedPackage;
+                    newTrackedPackage.licenses = newTrackedPackage.licenses.Concat(newLicenses).ToArray();
+                    trackedPackages[index] = newTrackedPackage;
+                    return;
+                }
+            }
+
+            trackedPackages = trackedPackages
+                .Append(new LicenseTrackedPackage
+                {
+                    packageName = packageName,
+                    licenses = newPathsToTrack.Select(path => new LicenseTrackedLicense
+                    {
+                        path = path
+                    }).ToArray()
+                })
+                .ToArray();
+        }
+
+        public void Untrack(string packageName, string[] toUntrack)
+        {
+            var toUntrackHashSet = toUntrack.ToHashSet();
+
+            for (var index = 0; index < trackedPackages.Length; index++)
+            {
+                var trackedPackage = trackedPackages[index];
+
+                if (trackedPackage.packageName == packageName)
+                {
+                    var newTrackedPackage = trackedPackage;
+                    newTrackedPackage.licenses = newTrackedPackage.licenses.Where(license => !toUntrackHashSet.Contains(license.path)).ToArray();
+
+                    if (newTrackedPackage.licenses.Length == 0)
+                    {
+                        trackedPackages = trackedPackages.Where((_, i) => i != index).ToArray();
+                    }
+                    else
+                    {
+                        trackedPackages[index] = newTrackedPackage;
+                    }
+                    return;
+                }
+            }
+        }
+
+        public bool IsExcluded(string packageName)
+        {
+            return excludedPackageNames.Contains(packageName);
+        }
+
+        public void Exclude(string packageName)
+        {
+            if (trackedPackages.Any(package => package.packageName == packageName)) return;
+            if (excludedPackageNames.Contains(packageName)) return;
+
+            excludedPackageNames = excludedPackageNames.Append(packageName).ToArray();
+        }
+    }
+
+    [Serializable]
+    public struct LicenseTrackedPackage
+    {
+        public string packageName;
+        public LicenseTrackedLicense[] licenses;
+    }
+
+    [Serializable]
+    public struct LicenseTrackedLicense
+    {
+        public string path;
+
+        public string spdx;
+
+        public string overrideProductName;
+    }
+
+    [Serializable]
+    public struct LicenseBaked
+    {
+        public string productName;
+
+        public string packageName;
+        public string licensePath;
+
+        public string spdx;
+        public string fullLicenseName;
+        public string fullLicenseText;
+
+        public string licenseUrl;
+    }
+}

--- a/Basis/Packages/dev.hai-vr.hvr.license-review/Scripts/Runtime/LicenseManifest.cs.meta
+++ b/Basis/Packages/dev.hai-vr.hvr.license-review/Scripts/Runtime/LicenseManifest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a395133486a94aa6bc2761a46e80aa8e
+timeCreated: 1778148573

--- a/Basis/Packages/dev.hai-vr.hvr.license-review/Scripts/Runtime/SettingsProviderThirdPartyLicenses.cs
+++ b/Basis/Packages/dev.hai-vr.hvr.license-review/Scripts/Runtime/SettingsProviderThirdPartyLicenses.cs
@@ -1,0 +1,49 @@
+using Basis.BasisUI;
+using UnityEngine;
+using UnityEngine.AddressableAssets;
+
+namespace HVR.LicenseReview
+{
+    public static class SettingsProviderLicenses
+    {
+        [RuntimeInitializeOnLoadMethod]
+        static void Register()
+        {
+            SettingsProvider.LicensesBuilder = BuildSection;
+        }
+
+        static void BuildSection(RectTransform container)
+        {
+            var licenseManifest = Addressables.LoadAssetAsync<LicenseManifest>("BasisFrameworkLicenseManifest")
+                .WaitForCompletion();
+
+            foreach (var license in licenseManifest.baked)
+            {
+                var toggle = PanelToggle.CreateNew(container);
+                toggle.Descriptor.SetTitle(license.productName);
+                toggle.Descriptor.SetDescription(license.fullLicenseName);
+                toggle.SetValueWithoutNotify(false);
+
+                var licenseText = PanelElementDescriptor.CreateNew(PanelElementDescriptor.ElementStyles.Group, container);
+                licenseText.SetTitle($"{license.packageName}/{license.licensePath}");
+                licenseText.SetDescription(license.fullLicenseText);
+
+                var openUrl = PanelButton.CreateNew(PanelButton.ButtonStyles.Default, licenseText);
+                openUrl.Descriptor.SetTitle(BasisLocalization.Get("settings.thirdpartylicenses.openlicenseurl"));
+                openUrl.OnClicked += () =>
+                {
+                    if (license.licenseUrl.StartsWith("https://"))
+                    {
+                        Application.OpenURL(license.licenseUrl);
+                    }
+                };
+
+                licenseText.SetActive(false);
+                toggle.OnValueChanged += value =>
+                {
+                    licenseText.SetActive(value);
+                };
+            }
+        }
+    }
+}

--- a/Basis/Packages/dev.hai-vr.hvr.license-review/Scripts/Runtime/SettingsProviderThirdPartyLicenses.cs.meta
+++ b/Basis/Packages/dev.hai-vr.hvr.license-review/Scripts/Runtime/SettingsProviderThirdPartyLicenses.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 2d570092d3884e969c331904a3b88deb
+timeCreated: 1778161984

--- a/Basis/Packages/dev.hai-vr.hvr.license-review/package.json
+++ b/Basis/Packages/dev.hai-vr.hvr.license-review/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dev.hai-vr.hvr.license-review",
+  "displayName": "HVR License Review",
+  "version": "0.0.1",
+  "description": "HVR License Review"
+}

--- a/Basis/Packages/dev.hai-vr.hvr.license-review/package.json.meta
+++ b/Basis/Packages/dev.hai-vr.hvr.license-review/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5a78a34f9bb368c49ba46e7096402aa4
+PackageManifestImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary

Adds a new "Third-Party Licenses" tab in the Settings menu. This ensures that the built app may comply with some licenses where the text needs to be visible in-application.

A new ScriptableObject with a custom editor is provided which enumerates a variety of LICENSE text files found inside packages of the project. This enables a developer to verify and select the licenses that will be displayed in-app.

<img width="2533" height="1268" alt="Unity_T0ON1YRXTq" src="https://github.com/user-attachments/assets/f206b1d5-77a6-4e16-b7fa-508a00dd26d9" />


<img width="938" height="1302" alt="Unity_ZU8Vx2pVPs" src="https://github.com/user-attachments/assets/d4ca87f4-530f-49df-8407-d17d1f3d53dc" />

## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
- [x] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [x] Windows
- [ ] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [ ] Tested in VR (note headset under **Notes**)
- [ ] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [x] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [x] N/A — change does not touch any of the above

## Notes
<!-- Optional context for reviewers. Headset model, why a required box is N/A, anything else worth knowing. -->
