### PR TITLE
fix: Network Object ownership state machine

### DIFF
--- a/Basis/Packages/com.basis.framework/Interactions/BasisPlayerInteract.cs
+++ b/Basis/Packages/com.basis.framework/Interactions/BasisPlayerInteract.cs
@@ -717,26 +717,6 @@ namespace Basis.Scripts.BasisSdk.Interactions
             }
         }
 
-        public bool ForceSetInteracting(BasisInteractableObject interactableObject, BasisInput input)
-        {
-            if (input.TryGetRole(out BasisBoneTrackedRole role) && interactableObject.Inputs.ChangeStateByRole(role, BasisInteractInputState.Hovering))
-            {
-                for (int i = 0; i < InteractInputs.Length; i++)
-                {
-                    if (InteractInputs[i].IsInput(input))
-                    {
-                        BasisDebug.Log("Stole ownership, starting interact", BasisDebug.LogTag.Networking);
-                        interactableObject.OnInteractStart(input);
-                        InteractInputs[i].lastTarget = interactableObject;
-                    }
-                }
-
-                return true;
-            }
-
-            return false;
-        }
-
         public static bool IsDesktopCenterEye(BasisInput input)
         {
             return BasisDeviceManagement.IsUserInDesktop() &&

--- a/Basis/Packages/com.basis.framework/Networking/BasisNetworkBehaviour/BasisNetworkBehaviour.cs
+++ b/Basis/Packages/com.basis.framework/Networking/BasisNetworkBehaviour/BasisNetworkBehaviour.cs
@@ -5,9 +5,35 @@ using Basis.Network.Core;
 using System;
 using System.Collections;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using UnityEngine;
 using static BasisNetworkCommon;
+
+public enum NetworkOwnershipState
+{
+    /// <summary>
+    /// Ownership state is unknown/uninitialized or server-owned.
+    /// </summary>
+    Unknown,
+    /// <summary>
+    /// Owned by a remote source.
+    /// </summary>
+    Remote,
+    /// <summary>
+    /// Ownership request sent, awaiting confirmation.
+    /// </summary>
+    PendingClaim,
+    /// <summary>
+    /// Owned locally.
+    /// </summary>
+    Local,
+    /// <summary>
+    /// Ownership release requested, awaiting confirmation.
+    /// </summary>
+    PendingRelease,
+}
+
 namespace Basis
 {
     public abstract class BasisNetworkBehaviour : BasisNetworkContentBase
@@ -19,16 +45,25 @@ namespace Basis
             get => networkID;
             private set => networkID = value;
         }
+        public NetworkOwnershipState OwnershipState = NetworkOwnershipState.Unknown;
         /// <summary>
-        /// only set true when the server approves our ownership
+        /// True after server has confirmed ownership.
+        /// Equivalent to OwnershipState == Local.
         /// </summary>
-        public bool IsOwnedLocallyOnServer = false;
+        public bool IsOwnedLocallyOnServer => OwnershipState == NetworkOwnershipState.Local;
         /// <summary>
-        /// this is instantly set when we request ownership.
+        /// True from claim ownership start (PendingClaim) and
+        /// while the server agrees (Local).
         /// </summary>
-        public bool IsOwnedLocallyOnClient = false;
+        public bool IsOwnedLocallyOnClient =>
+            OwnershipState == NetworkOwnershipState.Local
+            || OwnershipState == NetworkOwnershipState.PendingClaim;
+        
         public ushort CurrentOwnerId;
         public BasisNetworkPlayer currentOwnedPlayer;
+        private Task<BasisOwnershipResult> _pendingClaim;
+        private Task<BasisOwnershipResult> _pendingRelease;
+        private readonly CancellationTokenSource _destroyCts = new();
 
         /// <summary>
         /// the reason its start instead of awake is to make sure progation occurs to everything no matter the net connect
@@ -48,6 +83,7 @@ namespace Basis
         }
         public virtual void OnDestroy()
         {
+            _destroyCts.Cancel();
             if (HasNetworkID)
             {
                 BasisNetworkGenericMessages.UnregisterHandler(NetworkID);
@@ -127,25 +163,35 @@ namespace Basis
         }
         private void LowLevelOwnershipTransfer(string uniqueEntityID, ushort NetIdNewOwner, bool isOwner)
         {
-
-            if (uniqueEntityID == clientIdentifier)
+            if (uniqueEntityID != clientIdentifier) return;
+            Transition(isOwner ? NetworkOwnershipState.Local : NetworkOwnershipState.Remote);
+            CurrentOwnerId = NetIdNewOwner;
+            if (BasisNetworkPlayers.GetPlayerById(CurrentOwnerId, out currentOwnedPlayer))
             {
-                IsOwnedLocallyOnServer = isOwner;
-                IsOwnedLocallyOnClient = isOwner;
-                CurrentOwnerId = NetIdNewOwner;
-                if (BasisNetworkPlayers.GetPlayerById(CurrentOwnerId, out currentOwnedPlayer))
-                {
-                    OnOwnershipTransfer(currentOwnedPlayer);
-                }
-                else
-                {
-                    BasisUnInitalizedPlayer UnInitalizedPlayer = new BasisUnInitalizedPlayer(CurrentOwnerId);
-                    BasisDebug.LogError($"No Owner for Id {CurrentOwnerId} Creating Fake {nameof(BasisUnInitalizedPlayer)} this should only occur rarely");
-                    UnInitalizedPlayer.Initialize();
-                    OnOwnershipTransfer(UnInitalizedPlayer);
-                }
+                OnOwnershipTransfer(currentOwnedPlayer);
+            }
+            else
+            {
+                BasisUnInitalizedPlayer UnInitalizedPlayer = new BasisUnInitalizedPlayer(CurrentOwnerId);
+                BasisDebug.LogError($"No Owner for Id {CurrentOwnerId} Creating Fake {nameof(BasisUnInitalizedPlayer)} this should only occur rarely");
+                UnInitalizedPlayer.Initialize();
+                OnOwnershipTransfer(UnInitalizedPlayer);
             }
         }
+
+        private void Transition(NetworkOwnershipState newState)
+        {
+            if (OwnershipState == newState) return;
+            BasisDebug.Log($"[ownership] {clientIdentifier}: {OwnershipState} -> {newState}", BasisDebug.LogTag.Networking);
+            OwnershipState = newState;
+            OnOwnershipStateChanged();
+        }
+        /// <summary>
+        /// Called whenever <see cref="OwnershipState"/> changes (including optimistic
+        /// transitions and rollbacks on failed requests). Subclasses override to react
+        /// without depending on the server-driven <see cref="OnOwnershipTransfer"/>.
+        /// </summary>
+        protected virtual void OnOwnershipStateChanged() { }
         /// <summary>
         /// this is used for sending Network Messages
         /// very much a data sync that can be used more like a traditional sync method
@@ -276,32 +322,78 @@ namespace Basis
         }
         public async void TakeOwnership()
         {
-            //no need to use await ownership will get back here from lower level.
-            await TakeOwnershipAsync();
+            await ClaimOwnership();
         }
-        /// <summary>
-        /// actively takes ownership from another player
-        /// </summary>
-        /// <param name="Timout"></param>
-        /// <returns></returns>
-        public async Task<BasisOwnershipResult> TakeOwnershipAsync(int Timout = 5000)
+
+        public Task<BasisOwnershipResult> ClaimOwnership(int timeoutMs = 5000)
         {
-            IsOwnedLocallyOnClient = true;
+            if (OwnershipState == NetworkOwnershipState.Local)
+                return Task.FromResult(new BasisOwnershipResult(true, BasisNetworkPlayer.LocalPlayer.playerId));
+            if (_pendingClaim != null)
+                return _pendingClaim;
+            return _pendingClaim = InternalClaim(timeoutMs);
+        }
+
+        private async Task<BasisOwnershipResult> InternalClaim(int timeoutMs)
+        {
+            var prev = OwnershipState;
+            Transition(NetworkOwnershipState.PendingClaim);
             CurrentOwnerId = BasisNetworkPlayer.LocalPlayer.playerId;
             currentOwnedPlayer = BasisNetworkPlayer.LocalPlayer;
-            BasisOwnershipResult Result = await BasisNetworkOwnership.TakeOwnershipAsync(clientIdentifier, BasisNetworkConnection.LocalPlayerPeer.RemoteId, Timout);
-            return Result;
+            try
+            {
+                var result = await BasisNetworkOwnership.TakeOwnershipAsync(
+                    clientIdentifier,
+                    BasisNetworkConnection.LocalPlayerPeer.RemoteId,
+                    timeoutMs,
+                    _destroyCts.Token);
+                // On failure, the server-driven OnOwnershipTransfer never fires, so revert
+                // the optimistic transition. Caller is responsible for any retry.
+                if (!result.Success && OwnershipState == NetworkOwnershipState.PendingClaim)
+                {
+                    Transition(prev);
+                }
+                return result;
+            }
+            finally { _pendingClaim = null; }
         }
-        /// <summary>
-        /// requests who is the owner
-        /// </summary>
-        /// <param name="Timout"></param>
-        /// <returns></returns>
-        public async Task<BasisOwnershipResult> RequestWhoIsOwnershipAsync(int Timout = 5000)
+
+        public Task<BasisOwnershipResult> ReleaseOwnership(int timeoutMs = 5000)
         {
-            BasisOwnershipResult Result = await BasisNetworkOwnership.RequestCurrentOwnershipAsync(clientIdentifier, Timout);
-            return Result;
+            if (OwnershipState == NetworkOwnershipState.Unknown || OwnershipState == NetworkOwnershipState.Remote)
+                return Task.FromResult(new BasisOwnershipResult(true, CurrentOwnerId));
+            if (_pendingRelease != null)
+                return _pendingRelease;
+            return _pendingRelease = InternalRelease(timeoutMs);
         }
+
+        private async Task<BasisOwnershipResult> InternalRelease(int timeoutMs)
+        {
+            var prev = OwnershipState;
+            Transition(NetworkOwnershipState.PendingRelease);
+            try
+            {
+                var result = await BasisNetworkOwnership.RemoveOwnershipAsync(
+                    clientIdentifier,
+                    timeoutMs,
+                    _destroyCts.Token);
+                if (!result.Success && OwnershipState == NetworkOwnershipState.PendingRelease)
+                {
+                    Transition(prev);
+                }
+                return result;
+            }
+            finally { _pendingRelease = null; }
+        }
+
+        /// <summary>
+        /// Polls ownership state from the server. Triggers OnOwnershipTransfer.
+        /// </summary>
+        public async Task<BasisOwnershipResult> PollOwnership(int timeoutMs = 5000)
+        {
+            return await BasisNetworkOwnership.RequestCurrentOwnershipAsync(clientIdentifier, timeoutMs, _destroyCts.Token);
+        }
+
         public virtual void OnNetworkReady()
         {
 

--- a/Basis/Packages/com.basis.framework/Networking/BasisNetworkOwnership.cs
+++ b/Basis/Packages/com.basis.framework/Networking/BasisNetworkOwnership.cs
@@ -10,10 +10,10 @@ using static SerializableBasis;
 
 public static partial class BasisNetworkOwnership
 {
-    public static async Task<BasisOwnershipResult> RemoveOwnershipAsync(string UniqueNetworkId, int timeoutMs = 5000)
+    public static async Task<BasisOwnershipResult> RemoveOwnershipAsync(string UniqueNetworkId, int timeoutMs = 5000, CancellationToken externalToken = default)
     {
         var tcs = new TaskCompletionSource<BasisOwnershipResult>();
-        using var cancellationTokenSource = new CancellationTokenSource();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(externalToken);
 
         void OnOwnershipTransferred(string ownershipID, ushort playerID, bool isLocalOwner)
         {
@@ -24,7 +24,7 @@ public static partial class BasisNetworkOwnership
             }
         }
 
-        cancellationTokenSource.Token.Register(() =>
+        cts.Token.Register(() =>
         {
             BasisNetworkPlayer.OnOwnershipTransfer -= OnOwnershipTransferred;
             tcs.TrySetResult(BasisOwnershipResult.Failed);
@@ -56,17 +56,17 @@ public static partial class BasisNetworkOwnership
             return BasisOwnershipResult.Failed;
         }
 
-        cancellationTokenSource.CancelAfter(timeoutMs);
+        cts.CancelAfter(timeoutMs);
         return await tcs.Task;
     }
-    public static async Task<BasisOwnershipResult> TakeOwnershipAsync(string UniqueNetworkId, int NewOwner, int timeoutMs = 5000)
+    public static async Task<BasisOwnershipResult> TakeOwnershipAsync(string UniqueNetworkId, int NewOwner, int timeoutMs = 5000, CancellationToken externalToken = default)
     {
-        return await TakeOwnershipAsync(UniqueNetworkId, (ushort)NewOwner, timeoutMs);
+        return await TakeOwnershipAsync(UniqueNetworkId, (ushort)NewOwner, timeoutMs, externalToken);
     }
-    public static async Task<BasisOwnershipResult> TakeOwnershipAsync(string UniqueNetworkId, ushort NewOwner, int timeoutMs = 5000)
+    public static async Task<BasisOwnershipResult> TakeOwnershipAsync(string UniqueNetworkId, ushort NewOwner, int timeoutMs = 5000, CancellationToken externalToken = default)
     {
         var tcs = new TaskCompletionSource<BasisOwnershipResult>();
-        using var cancellationTokenSource = new CancellationTokenSource();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(externalToken);
 
         void OnOwnershipTransferred(string ownershipID, ushort playerID, bool isLocalOwner)
         {
@@ -77,7 +77,7 @@ public static partial class BasisNetworkOwnership
             }
         }
 
-        cancellationTokenSource.Token.Register(() =>
+        cts.Token.Register(() =>
         {
             BasisNetworkPlayer.OnOwnershipTransfer -= OnOwnershipTransferred;
             tcs.TrySetResult(BasisOwnershipResult.Failed);
@@ -109,7 +109,7 @@ public static partial class BasisNetworkOwnership
             return BasisOwnershipResult.Failed;
         }
 
-        cancellationTokenSource.CancelAfter(timeoutMs);
+        cts.CancelAfter(timeoutMs);
         return await tcs.Task;
     }
     /// <summary>
@@ -127,7 +127,7 @@ public static partial class BasisNetworkOwnership
         }
         return false;
     }
-    public static async Task<BasisOwnershipResult> RequestCurrentOwnershipAsync(string UniqueNetworkId, int timeoutMs = 5000)
+    public static async Task<BasisOwnershipResult> RequestCurrentOwnershipAsync(string UniqueNetworkId, int timeoutMs = 5000, CancellationToken externalToken = default)
     {
         if (BasisNetworkPlayers.OwnershipPairing.TryGetValue(UniqueNetworkId, out ushort Unique))
         {
@@ -141,7 +141,7 @@ public static partial class BasisNetworkOwnership
         }
 
         var tcs = new TaskCompletionSource<BasisOwnershipResult>();
-        using var cancellationTokenSource = new CancellationTokenSource();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(externalToken);
 
         void OnOwnershipTransferred(string ownershipID, ushort playerID, bool isLocalOwner)
         {
@@ -152,7 +152,7 @@ public static partial class BasisNetworkOwnership
             }
         }
 
-        cancellationTokenSource.Token.Register(() =>
+        cts.Token.Register(() =>
         {
             BasisNetworkPlayer.OnOwnershipTransfer -= OnOwnershipTransferred;
             tcs.TrySetResult(BasisOwnershipResult.Failed);
@@ -184,7 +184,7 @@ public static partial class BasisNetworkOwnership
             return BasisOwnershipResult.Failed;
         }
 
-        cancellationTokenSource.CancelAfter(timeoutMs);
+        cts.CancelAfter(timeoutMs);
         return await tcs.Task;
     }
 }

--- a/Basis/Packages/com.basis.framework/Networking/Object Sync/BasisObjectSyncNetworking.cs
+++ b/Basis/Packages/com.basis.framework/Networking/Object Sync/BasisObjectSyncNetworking.cs
@@ -3,7 +3,6 @@ using Basis.Scripts.BasisSdk.Interactions;
 using Basis.Scripts.Device_Management.Devices;
 using Basis.Scripts.Networking;
 using Basis.Scripts.Networking.Compression;
-using Basis.Scripts.Networking.NetworkedAvatar;
 using Basis.Network.Core;
 using UnityEngine;
 public class BasisObjectSyncNetworking : BasisNetworkBehaviour
@@ -14,7 +13,8 @@ public class BasisObjectSyncNetworking : BasisNetworkBehaviour
     BasisPositionRotationScale LocalLastData = new BasisPositionRotationScale();
     [SerializeField]
     public BasisTranslationUpdate BTU = new BasisTranslationUpdate();
-    public BasisInput pendingStealRequest = null;
+    [SerializeField]
+    private bool ReleaseOwnershipOnDrop = false;
     public float CatchupLerp = 5;
     public byte[] buffer = new byte[BasisPositionRotationScale.Size];
     public Transform SelfTransform;
@@ -30,6 +30,7 @@ public class BasisObjectSyncNetworking : BasisNetworkBehaviour
             BasisPickupInteractable.CanHoverInjected.Add(CanHover);
             BasisPickupInteractable.CanInteractInjected.Add(CanInteract);
             BasisPickupInteractable.OnInteractStartEvent.AddListener(OnInteractStartEvent);
+            BasisPickupInteractable.OnInteractEndEvent.AddListener(OnInteractEndEvent);
         }
         if (BasisPickupInteractable.RigidRef != null)
         {
@@ -47,6 +48,7 @@ public class BasisObjectSyncNetworking : BasisNetworkBehaviour
             BasisPickupInteractable.CanHoverInjected.Remove(CanHover);
             BasisPickupInteractable.CanInteractInjected.Remove(CanInteract);
             BasisPickupInteractable.OnInteractStartEvent.RemoveListener(OnInteractStartEvent);
+            BasisPickupInteractable.OnInteractEndEvent.RemoveListener(OnInteractEndEvent);
         }
     }
     public override void OnDestroy()
@@ -57,7 +59,7 @@ public class BasisObjectSyncNetworking : BasisNetworkBehaviour
     }
     public override void OnNetworkReady()
     {
-        ControlState();
+        ApplyState();
     }
 
     private bool CanHover(BasisInput input)
@@ -71,31 +73,23 @@ public class BasisObjectSyncNetworking : BasisNetworkBehaviour
     }
     private bool CanInteract(BasisInput input)
     {
-        // Allow interact if we arent connected or if we own it locally
-        if (IsOwnedLocallyOnClient)
-        {
-            return true;
-        }
-        // Allow if stealing is enabled and no other input has a steal in progress
-        // NOTE: pendingStealRequest is only set in OnInteractStartEvent to avoid
-        // side effects when this is called speculatively (e.g. via IsInfluencable)
-        return CanNetworkSteal && (pendingStealRequest == null || pendingStealRequest == input);
+        return IsOwnedLocallyOnClient || CanNetworkSteal;
     }
     private void OnInteractStartEvent(BasisInput input)
     {
-        if (!IsOwnedLocallyOnClient)
+        // Remote grabbed pickup sets kinematic during lerp, so preserve locally expected kinematic state 
+        if (BasisPickupInteractable != null && BasisPickupInteractable.KinematicWhileInteracting)
         {
-            pendingStealRequest = input;
+            BasisPickupInteractable._previousKinematicValue = false;
         }
-        CanInteractAsync(); // ControlState handles the ownership transfer logic here
+        _ = ClaimOwnership();
     }
-    private async void CanInteractAsync()
+    private void OnInteractEndEvent(BasisInput input)
     {
-        var result = await TakeOwnershipAsync(5000); // 5 second timeout 
-        if (result.Success == false)
-        {
-            pendingStealRequest = null;
-        }
+        if (!ReleaseOwnershipOnDrop) return;
+        // Only release if no other hand is still interacting with the pickup.
+        if (BasisPickupInteractable != null && BasisPickupInteractable.Inputs.AnyInteracting()) return;
+        _ = ReleaseOwnership();
     }
     public void SetIsKinematicOnPickup(bool state)
     {
@@ -104,11 +98,12 @@ public class BasisObjectSyncNetworking : BasisNetworkBehaviour
             BasisPickupInteractable.RigidRef.isKinematic = state;
         }
     }
-    public override void OnOwnershipTransfer(BasisNetworkPlayer NetIdNewOwner)
-    {
-        ControlState();
-    }
-    public void ControlState()
+    protected override void OnOwnershipStateChanged() => ApplyState();
+    /// <summary>
+    /// Pure state-driven physics + driver-set assignment. Local press already ran
+    /// OnInteractStart end-to-end with CanNetworkSteal=true, so no replay path.
+    /// </summary>
+    public void ApplyState()
     {
         #if UNITY_SERVER
         if (SelfTransform == null)
@@ -121,49 +116,42 @@ public class BasisObjectSyncNetworking : BasisNetworkBehaviour
             }
         }
         #endif
-        //lets always just update the last data so going from here we have some reference of last.
-        if (IsOwnedLocallyOnClient)
+        switch (OwnershipState)
         {
-            BasisObjectSyncDriver.AddLocalOwner(this);
-            BasisObjectSyncDriver.RemoveRemoteOwner(this);
-            if (pendingStealRequest != null)
-            {
-                // Set non-kinematic before ForceSetInteracting so that OnInteractStart
-                // saves the correct _previousKinematicValue (false) for restore on drop
-                SetIsKinematicOnPickup(false);
-                BasisPlayerInteract.Instance.ForceSetInteracting(BasisPickupInteractable, pendingStealRequest);
-                pendingStealRequest = null;
-                // ForceSetInteracting -> OnInteractStart re-applies isKinematic = true
-                // when KinematicWhileInteracting is enabled, so don't override after
-            }
-            else if (BasisPickupInteractable != null
-                && BasisPickupInteractable.KinematicWhileInteracting
-                && BasisPickupInteractable.RequiresUpdateLoop)
-            {
-                // Currently held with KinematicWhileInteracting - preserve kinematic state
-            }
-            else
-            {
-                SetIsKinematicOnPickup(false);
-            }
-        }
-        else
-        {
-            // Initialize BTU from current transform so the lerp job doesn't
-            // snap the object back to origin before the first sync arrives
-            SelfTransform.GetLocalPositionAndRotation(out UnityEngine.Vector3 currentPos, out UnityEngine.Quaternion currentRot);
-            BTU.TargetPosition = currentPos;
-            BTU.TargetRotation = currentRot;
-            BTU.TargetScales = SelfTransform.localScale;
-            BTU.LerpMultipliers = CatchupLerp;
+            case NetworkOwnershipState.PendingClaim:
+            case NetworkOwnershipState.Local:
+                BasisObjectSyncDriver.AddLocalOwner(this);
+                BasisObjectSyncDriver.RemoveRemoteOwner(this);
+                if (BasisPickupInteractable != null
+                    && BasisPickupInteractable.KinematicWhileInteracting
+                    && BasisPickupInteractable.RequiresUpdateLoop)
+                {
+                    // Currently held with KinematicWhileInteracting - preserve kinematic state
+                }
+                else
+                {
+                    SetIsKinematicOnPickup(false);
+                }
+                break;
+            case NetworkOwnershipState.Remote:
+            case NetworkOwnershipState.Unknown:
+            case NetworkOwnershipState.PendingRelease:
+                // Initialize BTU from current transform so the lerp job doesn't
+                // snap the object back to origin before the first sync arrives
+                SelfTransform.GetLocalPositionAndRotation(out UnityEngine.Vector3 currentPos, out UnityEngine.Quaternion currentRot);
+                BTU.TargetPosition = currentPos;
+                BTU.TargetRotation = currentRot;
+                BTU.TargetScales = SelfTransform.localScale;
+                BTU.LerpMultipliers = CatchupLerp;
 
-            BasisObjectSyncDriver.RemoveLocalOwner(this);
-            BasisObjectSyncDriver.AddRemoteOwner(this);
-            if (BasisPickupInteractable != null)
-            {
-                BasisPickupInteractable.Drop();
-            }
-            SetIsKinematicOnPickup(true);
+                BasisObjectSyncDriver.RemoveLocalOwner(this);
+                BasisObjectSyncDriver.AddRemoteOwner(this);
+                if (BasisPickupInteractable != null)
+                {
+                    BasisPickupInteractable.Drop();
+                }
+                SetIsKinematicOnPickup(true);
+                break;
         }
     }
     public override void OnNetworkMessage(ushort PlayerID, byte[] buffer, DeliveryMethod DeliveryMethod)

--- a/Basis/Packages/com.basis.framework/Networking/Object Sync/BasisObjectSyncNetworking.cs
+++ b/Basis/Packages/com.basis.framework/Networking/Object Sync/BasisObjectSyncNetworking.cs
@@ -99,10 +99,7 @@ public class BasisObjectSyncNetworking : BasisNetworkBehaviour
         }
     }
     protected override void OnOwnershipStateChanged() => ApplyState();
-    /// <summary>
-    /// Pure state-driven physics + driver-set assignment. Local press already ran
-    /// OnInteractStart end-to-end with CanNetworkSteal=true, so no replay path.
-    /// </summary>
+
     public void ApplyState()
     {
         #if UNITY_SERVER

--- a/Basis/Packages/com.basis.shim/Shims/BasisNetworkShim.cs
+++ b/Basis/Packages/com.basis.shim/Shims/BasisNetworkShim.cs
@@ -50,7 +50,7 @@ namespace Basis.Shims
 
         public void RequestOwnershipIfNone()
         {
-	        RequestWhoIsOwnershipAsync();
+	        PollOwnership();
         }
 	}
 }


### PR DESCRIPTION
## Summary
Current ownership handling required that we re-trigger OnInteractStart when claiming ownership which would cause a double sfx play (and other bugs). This adds a simple state machine for pending requests so we can gate on state transition a bit more cleanly and still account for this case.

TODO: lots of testing

## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
- [ ] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [x] Windows
- [ ] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [ ] Tested in VR (note headset under **Notes**)
- [ ] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [ ] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [ ] N/A — change does not touch any of the above

## Notes
<!-- Optional context for reviewers. Headset model, why a required box is N/A, anything else worth knowing. -->
this cleans up `ForceSetInteracting` which im quite happy about.