### PR TITLE
Fix unitypackage builder

### DIFF
--- a/.github/scripts/unitypackagegen.sh
+++ b/.github/scripts/unitypackagegen.sh
@@ -8,6 +8,7 @@ PACKAGES="Packages/org.basisvr.generator.equals-3.2.0.tgz:
         Packages/org.basisvr.bouncycastle-2.5.0.tgz"
 SUBFOLDERS="Packages/com.basis.sdk:
         Packages/UnityJigglePhysics-upm:
+        Packages/org.basisvr.k4os.compression.lz4:
         Packages/com.basis.bundlemanagement:
         Packages/com.basis.server"
 
@@ -34,7 +35,6 @@ if [[ "$1" == "full" ]]; then
               Packages/com.basis.openlipsync:
               Packages/com.basis.openvr:
               Packages/com.basis.openxr:
-              Packages/com.basis.pooltable:
               Packages/com.basis.profilerintergration:
               Packages/com.basis.settings:
               Packages/com.basis.shim:
@@ -75,6 +75,7 @@ elif [[ "$1" == "sdk" ]]; then
 else
   echo "Only full and sdk targets are specified."
   die
+  exit
 fi
 
 set -e
@@ -129,26 +130,27 @@ done
 
 echo "Adding extra files: " ${MOREFILES}
 
-echo ${MOREFILES} | tr : '\n' | while read FV ; do
-    #printf 'File found: %s\n' "$FV"
-    ASSET=$FV
-    GUID=$(echo "$FV" | md5sum | cut -d' ' -f1 | cut -b-32 )
-    mkdir -p generate_unitypackage/$GUID
-    if [[ -f "$ASSET" ]]; then
-        #echo "$ASSET" TO generate_unitypackage/$GUID/asset
-        #echo ASSET COPY cp "$ASSET" generate_unitypackage/$GUID/asset
-        cp "$ASSET" generate_unitypackage/$GUID/asset
-    fi
+if [[ -n ${MOREFILES} ]]; then
+	echo ${MOREFILES} | tr : '\n' | while read FV ; do
+		#printf 'File found: %s\n' "$FV"
+		ASSET=$FV
+		GUID=$(echo "$FV" | md5sum | cut -d' ' -f1 | cut -b-32 )
+		mkdir -p generate_unitypackage/$GUID
+		if [[ -f "$ASSET" ]]; then
+		    #echo "$ASSET" TO generate_unitypackage/$GUID/asset
+		    #echo ASSET COPY cp "$ASSET" generate_unitypackage/$GUID/asset
+		    cp "$ASSET" generate_unitypackage/$GUID/asset
+		fi
 
-	echo "fileFormatVersion: 2" > generate_unitypackage/$GUID/asset.meta
-	echo "guid: ${GUID}" >> generate_unitypackage/$GUID/asset.meta
+		echo "fileFormatVersion: 2" > generate_unitypackage/$GUID/asset.meta
+		echo "guid: ${GUID}" >> generate_unitypackage/$GUID/asset.meta
 
-    #GPNAME=$(echo ${ddv:0:${#ddv} - 4} | cut -d/ -f3-)
-    FONLY=$(echo $FV | rev | cut -d. -f2- | rev)
-    echo "${ASSET}" "${GUID}"
-    echo "${ASSET}" > generate_unitypackage/$GUID/pathname
-done
-
+		#GPNAME=$(echo ${ddv:0:${#ddv} - 4} | cut -d/ -f3-)
+		FONLY=$(echo $FV | rev | cut -d. -f2- | rev)
+		echo "${ASSET}" "${GUID}"
+		echo "${ASSET}" > generate_unitypackage/$GUID/pathname
+	done
+fi
 
 echo "Now, exporting .tgz's"
 

--- a/Basis/Packages/com.basis.framework/package.json
+++ b/Basis/Packages/com.basis.framework/package.json
@@ -12,7 +12,7 @@
     "com.unity.addressables": "2.9.1",
     "com.unity.animation.rigging": "1.4.1",
     "com.unity.burst": "1.8.29",
-    "com.unity.collections": "6.4.0",
+    "com.unity.collections": "2.6.6",
     "com.unity.inputsystem": "1.19.0",
     "com.unity.mathematics": "1.3.3",
     "com.unity.render-pipelines.core": "17.4.0",

--- a/Basis/Packages/com.basis.sdk/UiStyling/Runtime/Components/UiStyleSettings.cs
+++ b/Basis/Packages/com.basis.sdk/UiStyling/Runtime/Components/UiStyleSettings.cs
@@ -88,7 +88,9 @@ namespace Basis.BasisUI.Styling
         {
             // This works at runtime too (2022+). If you're on older Unity, switch to Object.FindObjectsOfType<BaseUiStyleComponent>()
             BaseUiStyleComponent[] components =
-                Object.FindObjectsByType<BaseUiStyleComponent>(FindObjectsInactive.Include);
+                Object.FindObjectsByType<BaseUiStyleComponent>(
+                    FindObjectsInactive.Include,
+                    FindObjectsSortMode.None);
 
             foreach (BaseUiStyleComponent comp in components)
             {

--- a/Basis/ProjectSettings/ProjectSettings.asset
+++ b/Basis/ProjectSettings/ProjectSettings.asset
@@ -948,11 +948,11 @@ PlayerSettings:
   activeInputHandler: 1
   windowsGamepadBackendHint: 0
   enableDirectStorage: 1
-  cloudProjectId: 119fdfcf-36b9-4c45-a3e2-7da2705a7ef7
+  cloudProjectId: 
   framebufferDepthMemorylessMode: 2
   qualitySettingsNames: []
-  projectName: Basis Unity
-  organizationId: luke-doolan
+  projectName: 
+  organizationId: 
   cloudEnabled: 0
   legacyClampBlendShapeWeights: 0
   hmiLoadingImage: {fileID: 0}


### PR DESCRIPTION
## Summary
Fixes up the build path to build both a full and SDK .unitypackage for the builder.

## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [x] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [ ] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [ ] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [ ] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [ ] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [ ] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [ ] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [ ] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [ ] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [ ] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [ ] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [ ] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [ ] Windows
- [x] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [ ] Tested in VR (note headset under **Notes**)
- [ ] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [x] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [x] N/A — change does not touch any of the above

## Notes
I also noticed some of dooly's specific cloud stuff checked in so I cleared that out.