### PR TITLE
Fix the Github Action CI

### DIFF
--- a/.github/scripts/sanitize_headless_ci.py
+++ b/.github/scripts/sanitize_headless_ci.py
@@ -18,6 +18,7 @@ PACKAGE_DIRS_TO_REMOVE = (
 PACKAGE_DEPENDENCIES_TO_REMOVE = (
     "com.llealloo.audiolink",
     "com.unity.xr.openxr",
+    "com.valvesoftware.openxr.utils",
     "com.valvesoftware.unity.openvr",
 )
 
@@ -39,6 +40,11 @@ XR_ASSET_PATHS_TO_REMOVE = (
 
 LINKER_ASSEMBLIES_TO_REMOVE = (
     "AudioLink",
+)
+
+PACKAGE_LOCK_ENTRIES_TO_REMOVE = PACKAGE_DEPENDENCIES_TO_REMOVE + (
+    "com.basis.openvr",
+    "com.basis.openxr",
 )
 
 
@@ -98,6 +104,35 @@ def remove_manifest_dependencies(project_root: Path) -> list[str]:
         manifest_path.write_text("".join(output), encoding="utf-8")
 
     return removed_dependencies
+
+
+def remove_package_lock_entries(project_root: Path) -> list[str]:
+    lock_path = project_root / "Packages/packages-lock.json"
+    if not lock_path.exists():
+        return []
+
+    import json
+
+    lock_data = json.loads(lock_path.read_text(encoding="utf-8"))
+    dependencies = lock_data.get("dependencies", {})
+    removed_entries: list[str] = []
+
+    for dependency in PACKAGE_LOCK_ENTRIES_TO_REMOVE:
+        if dependencies.pop(dependency, None) is not None:
+            removed_entries.append(dependency)
+
+    for package_info in dependencies.values():
+        package_dependencies = package_info.get("dependencies")
+        if not isinstance(package_dependencies, dict):
+            continue
+
+        for dependency in PACKAGE_LOCK_ENTRIES_TO_REMOVE:
+            package_dependencies.pop(dependency, None)
+
+    if removed_entries:
+        lock_path.write_text(json.dumps(lock_data, indent=2) + "\n", encoding="utf-8")
+
+    return removed_entries
 
 
 def strip_editor_build_settings(project_root: Path) -> list[str]:
@@ -236,6 +271,12 @@ def main() -> int:
     if removed_dependencies:
         print(f"Removed {len(removed_dependencies)} manifest dependencies from {project_root / 'Packages/manifest.json'}")
         for dependency in removed_dependencies:
+            print(f"  - {dependency}")
+
+    removed_lock_entries = remove_package_lock_entries(project_root)
+    if removed_lock_entries:
+        print(f"Removed {len(removed_lock_entries)} package lock entries from {project_root / 'Packages/packages-lock.json'}")
+        for dependency in removed_lock_entries:
             print(f"  - {dependency}")
 
     removed_config_keys = strip_editor_build_settings(project_root)

--- a/.github/scripts/sanitize_linux_client_ci.py
+++ b/.github/scripts/sanitize_linux_client_ci.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+from pathlib import Path
+
+
+PACKAGE_DIRS_TO_REMOVE = (
+    "Packages/com.basis.openxr",
+    "Packages/com.meta.xr.sdk.core",
+)
+
+PACKAGE_DEPENDENCIES_TO_REMOVE = (
+    "com.unity.xr.openxr",
+    "com.valvesoftware.openxr.utils",
+)
+
+PACKAGE_LOCK_ENTRIES_TO_REMOVE = PACKAGE_DEPENDENCIES_TO_REMOVE + (
+    "com.basis.openxr",
+)
+
+
+def remove_manifest_dependencies(project_root: Path) -> list[str]:
+    manifest_path = project_root / "Packages/manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    dependencies = manifest.get("dependencies", {})
+    removed: list[str] = []
+
+    for dependency in PACKAGE_DEPENDENCIES_TO_REMOVE:
+        if dependencies.pop(dependency, None) is not None:
+            removed.append(dependency)
+
+    if removed:
+        manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+
+    return removed
+
+
+def remove_package_lock_entries(project_root: Path) -> list[str]:
+    lock_path = project_root / "Packages/packages-lock.json"
+    if not lock_path.exists():
+        return []
+
+    lock_data = json.loads(lock_path.read_text(encoding="utf-8"))
+    dependencies = lock_data.get("dependencies", {})
+    removed: list[str] = []
+
+    for dependency in PACKAGE_LOCK_ENTRIES_TO_REMOVE:
+        if dependencies.pop(dependency, None) is not None:
+            removed.append(dependency)
+
+    for package_info in dependencies.values():
+        package_dependencies = package_info.get("dependencies")
+        if not isinstance(package_dependencies, dict):
+            continue
+
+        for dependency in PACKAGE_LOCK_ENTRIES_TO_REMOVE:
+            package_dependencies.pop(dependency, None)
+
+    if removed:
+        lock_path.write_text(json.dumps(lock_data, indent=2) + "\n", encoding="utf-8")
+
+    return removed
+
+
+def remove_package_dirs(project_root: Path) -> list[Path]:
+    removed: list[Path] = []
+
+    for relative_dir in PACKAGE_DIRS_TO_REMOVE:
+        package_dir = project_root / relative_dir
+        if package_dir.exists():
+            shutil.rmtree(package_dir)
+            removed.append(package_dir)
+        else:
+            print(f"Package directory already absent: {package_dir}")
+
+    return removed
+
+
+def main() -> int:
+    project_root = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("Basis")
+    project_root = project_root.resolve()
+
+    if not project_root.exists():
+        print(f"Project root not found: {project_root}", file=sys.stderr)
+        return 1
+
+    removed_manifest_dependencies = remove_manifest_dependencies(project_root)
+    for dependency in removed_manifest_dependencies:
+        print(f"Removed manifest dependency: {dependency}")
+
+    removed_lock_entries = remove_package_lock_entries(project_root)
+    for dependency in removed_lock_entries:
+        print(f"Removed package lock entry: {dependency}")
+
+    removed_package_dirs = remove_package_dirs(project_root)
+    for package_dir in removed_package_dirs:
+        print(f"Removed package directory: {package_dir}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -84,13 +84,11 @@ jobs:
       - name: "Create version string"
         id: version
         run: echo "gitversion=$(git describe --tags --always)" >> "$GITHUB_OUTPUT"
-      - name: "Remove OpenXR when building for Linux"
+      - name: "Sanitize Linux client project"
         if: matrix.targetPlatform == 'StandaloneLinux64'
-        run: rm -rf ${projectPath}/Packages/com.basis.openxr
-        # run: jq 'del(.dependencies ["com.unity.xr.openxr"])' < ${projectPath}/Packages/manifest.json > manifest.json.tmp && mv manifest.json.tmp ${projectPath}/Packages/manifest.json
-      - name: "Remove Meta XR Core when building for Linux"
-        if: matrix.targetPlatform == 'StandaloneLinux64'
-        run: rm -rf ${projectPath}/Packages/com.meta.xr.sdk.core
+        shell: bash
+        run: |
+          python3 .github/scripts/sanitize_linux_client_ci.py "${projectPath}"
       # Fix docker not ready on windows
       - name: Ensure Docker service is running
         if: matrix.buildPlatform == 'windows-2022'


### PR DESCRIPTION
## Summary
<!-- What does this PR change and why? Link related issues. -->
Currently all the linux builds on Github were no longer building, decided to go and fix it.
## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [x] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — `BasisEventDriver` runs the single per-frame tick that drives the whole framework (network apply, local player sim, blendshapes, JigglePhysics, nameplates, and more) as one sequential chain. An unhandled exception anywhere in that chain aborts the rest of the tick, so every step after the throwing one is silently skipped for that frame. New work added to the driver must either be guaranteed not to throw, or be wrapped in a `try`/`catch` that contains the failure and surfaces it through `BasisDebug` — logged once / rate-limited, never every frame (see the existing `HVRBasisBuiltInAddresses.Simulate()` guard for the pattern). Expect this to be scrutinized closely in review.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [x] Windows
- [x] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [ ] Tested in VR (note headset under **Notes**)
- [ ] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [x] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [x] N/A — change does not touch any of the above

## Notes
<!-- Optional context for reviewers. Headset model, why a required box is N/A, anything else worth knowing. -->
