### PR TITLE
feat: gate hamburger/quick menu behind a brief delayed hold gesture

### DIFF
--- a/Basis/Packages/com.basis.framework/Device Management/Devices/Base/BasisActionDriver.cs
+++ b/Basis/Packages/com.basis.framework/Device Management/Devices/Base/BasisActionDriver.cs
@@ -394,18 +394,73 @@ public static class BasisActionDriver
         controller.UpdateMovementSpeed(true);
     }
 
+    /// <summary>Continuous hold (seconds) on the secondary button required to toggle the hamburger menu.</summary>
+    public const float HamburgerHoldSeconds = 1f;
+
+    // VR controllers have very few buttons, so the same button often serves more than one purpose.
+    // A hold gate lets a button's quick tap stay free for another consumer while the hold drives this
+    // action — here the secondary button's tap is left for the VR fly camera launch/recall. To add
+    // another hold-activated action (e.g. a future quick menu on the other hand): add a new ActionId,
+    // give it its OWN HoldGesture field (the action delegates are static, so a shared field would race
+    // across hands), then Bind it to the desired role.
+    private static HoldGesture s_hamburgerHold;
+
     /// <summary>
-    /// Toggles the hamburger menu on secondary button release.
+    /// Toggles the hamburger menu once the secondary button has been held for
+    /// <see cref="HamburgerHoldSeconds"/>. A quick tap does nothing, which leaves the tap free for other
+    /// consumers of the same button (e.g. the VR fly camera launch/recall).
     /// </summary>
     /// <param name="current">Current input snapshot.</param>
     /// <param name="last">Previous input snapshot.</param>
+    // Enum/method name kept as "…OnSecondaryRelease" so saved bindings (BasisActionBindingsV1.json,
+    // which serialises actions by name) keep resolving; the trigger is now a hold, not a release.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void ToggleHamburgerOnSecondaryRelease(ref BasisInputState current, ref BasisInputState last)
     {
-        if (current.SecondaryButtonGetState == false && last.SecondaryButtonGetState)
+        if (s_hamburgerHold.Tick(current.SecondaryButtonGetState, HamburgerHoldSeconds))
         {
-
             Basis.BasisUI.BasisMainMenu.Toggle();
+        }
+    }
+
+    /// <summary>
+    /// Tracks a press-and-hold on a single button. <see cref="Tick"/> returns true on the one frame the
+    /// button has been held continuously for the given duration; releasing early cancels without firing
+    /// and re-arms on the next press. One instance per logical button — do not share across hands.
+    /// </summary>
+    public struct HoldGesture
+    {
+        private double pressStartTime;
+        private bool isPressing;
+        private bool fired;
+
+        /// <summary>Advances the gesture; returns true once per press when the hold threshold is met.</summary>
+        /// <param name="buttonDown">Whether the button is held this frame.</param>
+        /// <param name="holdSeconds">Continuous hold duration required to fire.</param>
+        public bool Tick(bool buttonDown, float holdSeconds)
+        {
+            if (!buttonDown)
+            {
+                isPressing = false;
+                fired = false;
+                return false;
+            }
+
+            if (!isPressing)
+            {
+                isPressing = true;
+                fired = false;
+                pressStartTime = Time.unscaledTimeAsDouble;
+                return false;
+            }
+
+            if (!fired && Time.unscaledTimeAsDouble - pressStartTime >= holdSeconds)
+            {
+                fired = true;
+                return true;
+            }
+
+            return false;
         }
     }
 


### PR DESCRIPTION
## Summary
<!-- What does this PR change and why? Link related issues. -->
VR controllers expose very few buttons, so the same button has to serve more than one purpose. The hamburger menu was bound to the left-hand secondary button on release, which made a quick tap unavailable to anything else and prone to accidental firing.

Introduce a reusable HoldGesture struct and require the secondary button to be held for 1s to toggle the menu. This protects the menu from misfire and, more importantly, frees the button's quick tap.

A future quick menu on the other controller can adopt the same pattern by adding its own ActionId + HoldGesture field and binding it to that hand.

The enum/method name is kept as ToggleHamburgerOnSecondaryRelease so existing saved bindings (serialised by action name) keep resolving.

## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [ ] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [ ] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [ ] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [ ] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [ ] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [ ] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — `BasisEventDriver` runs the single per-frame tick that drives the whole framework (network apply, local player sim, blendshapes, JigglePhysics, nameplates, and more) as one sequential chain. An unhandled exception anywhere in that chain aborts the rest of the tick, so every step after the throwing one is silently skipped for that frame. New work added to the driver must either be guaranteed not to throw, or be wrapped in a `try`/`catch` that contains the failure and surfaces it through `BasisDebug` — logged once / rate-limited, never every frame (see the existing `HVRBasisBuiltInAddresses.Simulate()` guard for the pattern). Expect this to be scrutinized closely in review.
- [ ] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [ ] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [ ] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [ ] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [ ] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [ ] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [ ] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [ ] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [ ] Windows
- [ ] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [ ] Tested in VR (note headset under **Notes**)
- [ ] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [ ] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [ ] N/A — change does not touch any of the above

## Notes
<!-- Optional context for reviewers. Headset model, why a required box is N/A, anything else worth knowing. -->
