### PR TITLE
feat: VR camera fly mode (RC Mode 2 twin-stick controls)

### DIFF
--- a/Basis/Packages/com.basis.framework/Camera/BasisHandHeldCameraInteractable.cs
+++ b/Basis/Packages/com.basis.framework/Camera/BasisHandHeldCameraInteractable.cs
@@ -49,6 +49,10 @@ public abstract class BasisHandHeldCameraInteractable : BasisPickupInteractable
     [Range(5f, 25f)]
     public float rotationSmoothing = 15f;
 
+    /// <summary>VR fly-mode yaw turn rate at full pilot-stick deflection (degrees/second). Rate-based:
+    /// the heading holds when the stick re-centres.</summary>
+    public float yawRate = 90f;
+
     [Header("Cinematic Controls")]
     /// <summary>Whether to use momentum/inertia for movement.</summary>
     public bool useMomentum = true;
@@ -125,8 +129,11 @@ public abstract class BasisHandHeldCameraInteractable : BasisPickupInteractable
 
     // VR fly mode state
     private bool isVRFlying = false;
-    private bool vrThumbstickClickPrev = false;
-    private Quaternion vrControllerRotation = Quaternion.identity;
+    private bool vrToggleButtonPrev = false;
+
+    /// <summary>Which hand held the camera at launch — it becomes the RC "Mode 2" pilot stick
+    /// (throttle + yaw); the other hand carries the free stick (pitch + roll).</summary>
+    private bool pilotIsLeftHand = false;
 
     private bool selfieRotationEnabled = false;
     /// <summary>Where to pin the camera transform.</summary>
@@ -483,57 +490,99 @@ public abstract class BasisHandHeldCameraInteractable : BasisPickupInteractable
     }
 
     /// <summary>
-    /// VR fly-mode control: toggles fly mode on thumbstick click (edge-detected)
-    /// and captures controller rotation each frame for camera aiming.
+    /// VR fly-mode control: enter/exit on the B/Y face button (edge-detected). Entering requires the
+    /// camera to be held, so the holding hand becomes the pilot; exiting reads the pilot hand directly
+    /// since the camera has detached and may no longer register as interacting.
     /// </summary>
     private void PollVRControl()
     {
-        if (GetActiveVRInput(out BasisInputWrapper vrInput))
+        string className = nameof(BasisHandHeldCameraInteractable);
+
+        if (!isVRFlying)
         {
-            BasisInputState inputState = vrInput.Source.CurrentInputState;
-            string className = nameof(BasisHandHeldCameraInteractable);
-
-            // Toggle fly mode on thumbstick click (edge detection)
-            bool thumbstickClick = inputState.Primary2DAxisClick;
-            if (thumbstickClick && !vrThumbstickClickPrev)
+            if (!GetActiveVRInput(out BasisInputWrapper vrInput))
             {
-                if (isVRFlying)
-                {
-                    // Exit VR fly mode — return camera to hand
-                    isVRFlying = false;
-                    if (!LookLock.Remove(className)) BasisDebug.LogWarning($"{className} couldn't remove LookLock");
-                    if (!MovementLock.Remove(className)) BasisDebug.LogWarning($"{className} couldn't remove MovementLock");
-                    if (!CrouchingLock.Remove(className)) BasisDebug.LogWarning($"{className} couldn't remove CrouchingLock");
-
-                    PinSpace = CameraPinSpace.HandHeld;
-                    velocityMomentum = Vector3.zero;
-                    rotationMomentum = 0f;
-                }
-                else
-                {
-                    // Enter VR fly mode
-                    isVRFlying = true;
-                    LookLock.Add(className);
-                    MovementLock.Add(className);
-                    CrouchingLock.Add(className);
-
-                    PinSpace = CameraPinSpace.WorldSpace;
-
-                    HHC.captureCamera.transform.GetPositionAndRotation(out smoothedPosition, out smoothedRotation);
-
-                    // Initialize rotation tracking from current camera orientation
-                    Vector3 euler = smoothedRotation.eulerAngles;
-                    currentPitch = targetPitch = NormalizeAngle(euler.x);
-                    currentYaw = targetYaw = NormalizeAngle(euler.y);
-                }
+                vrToggleButtonPrev = false;
+                return;
             }
-            vrThumbstickClickPrev = thumbstickClick;
 
-            if (isVRFlying)
+            bool togglePressed = vrInput.Source.CurrentInputState.SecondaryButtonGetState;
+            if (togglePressed && !vrToggleButtonPrev)
             {
-                // Store VR controller rotation for movement direction and camera aim
-                vrControllerRotation = vrInput.BoneControl.OutgoingWorldData.rotation;
+                pilotIsLeftHand = Inputs.leftHand.GetState() == BasisInteractInputState.Interacting;
+                EnterVRFly(className);
             }
+            vrToggleButtonPrev = togglePressed;
+        }
+        else
+        {
+            var pilot = pilotIsLeftHand ? Inputs.leftHand.Source : Inputs.rightHand.Source;
+            bool togglePressed = pilot != null && pilot.CurrentInputState.SecondaryButtonGetState;
+            if (togglePressed && !vrToggleButtonPrev)
+            {
+                ExitVRFly(className);
+            }
+            vrToggleButtonPrev = togglePressed;
+        }
+    }
+
+    /// <summary>Enters VR fly mode: takes the player locks, detaches the camera to world space,
+    /// and seeds the heading and motion state from the current camera pose.</summary>
+    private void EnterVRFly(string className)
+    {
+        isVRFlying = true;
+        LookLock.Add(className);
+        MovementLock.Add(className);
+        CrouchingLock.Add(className);
+
+        PinSpace = CameraPinSpace.WorldSpace;
+
+        HHC.captureCamera.transform.GetPositionAndRotation(out smoothedPosition, out smoothedRotation);
+        currentYaw = NormalizeAngle(smoothedRotation.eulerAngles.y);
+        currentVelocity = Vector3.zero;
+        targetVelocity = Vector3.zero;
+        velocityMomentum = Vector3.zero;
+    }
+
+    /// <summary>Exits VR fly mode: releases the player locks, returns the camera to the hand,
+    /// and clears momentum.</summary>
+    private void ExitVRFly(string className)
+    {
+        isVRFlying = false;
+        if (!LookLock.Remove(className)) BasisDebug.LogWarning($"{className} couldn't remove LookLock");
+        if (!MovementLock.Remove(className)) BasisDebug.LogWarning($"{className} couldn't remove MovementLock");
+        if (!CrouchingLock.Remove(className)) BasisDebug.LogWarning($"{className} couldn't remove CrouchingLock");
+
+        PinSpace = CameraPinSpace.HandHeld;
+        currentVelocity = Vector3.zero;
+        targetVelocity = Vector3.zero;
+        velocityMomentum = Vector3.zero;
+        rotationMomentum = 0f;
+    }
+
+    /// <summary>
+    /// Reads the two thumbsticks and maps them to RC "Mode 2" flight axes. The pilot hand (held the
+    /// camera at launch) carries throttle (Y) + yaw (X); the free hand carries pitch (Y) + roll (X).
+    /// Uses each stick's built-in radial deadzone.
+    /// </summary>
+    private void ReadVRFlyAxes(out float throttle, out float yaw, out float pitch, out float roll)
+    {
+        throttle = yaw = pitch = roll = 0f;
+
+        var pilot = pilotIsLeftHand ? Inputs.leftHand.Source : Inputs.rightHand.Source;
+        var free = pilotIsLeftHand ? Inputs.rightHand.Source : Inputs.leftHand.Source;
+
+        if (pilot != null)
+        {
+            Vector2 pilotStick = pilot.CurrentInputState.Primary2DAxisDeadZoned;
+            throttle = pilotStick.y;
+            yaw = pilotStick.x;
+        }
+        if (free != null)
+        {
+            Vector2 freeStick = free.CurrentInputState.Primary2DAxisDeadZoned;
+            pitch = freeStick.y;
+            roll = freeStick.x;
         }
     }
 
@@ -588,6 +637,12 @@ public abstract class BasisHandHeldCameraInteractable : BasisPickupInteractable
     {
         float deltaTime = Time.deltaTime;
 
+        if (isVRFlying)
+        {
+            MoveVRFlying(deltaTime);
+            return;
+        }
+
         if (HandleMovementInput(out Vector3 inputMovement, out float speedMultiplier))
         {
             UpdateMovement(inputMovement, speedMultiplier, deltaTime);
@@ -615,62 +670,75 @@ public abstract class BasisHandHeldCameraInteractable : BasisPickupInteractable
         ApplySmoothedPosition(deltaTime);
     }
 
-    /// <summary>Reads fly movement inputs and outputs a normalized movement vector + speed multiplier.</summary>
+    /// <summary>
+    /// VR RC "Mode 2" flight step: maps the twin sticks to throttle (world-up) / yaw (rate-based heading)
+    /// / pitch (forward-back) / roll (strafe), integrates velocity with the shared acceleration and
+    /// momentum, and keeps the camera level toward the current heading. No controller-aim, no lean.
+    /// </summary>
+    private void MoveVRFlying(float deltaTime)
+    {
+        ReadVRFlyAxes(out float throttle, out float yaw, out float pitch, out float roll);
+
+        // Rate-based yaw: the heading holds when the stick re-centres.
+        currentYaw = NormalizeAngle(currentYaw + yaw * yawRate * deltaTime);
+
+        // Planar movement is relative to the heading; throttle is always world-up.
+        Vector3 planar = Quaternion.Euler(0f, currentYaw, 0f) * new Vector3(roll, 0f, pitch);
+        Vector3 targetWorldVelocity = (planar + Vector3.up * throttle) * flySpeed;
+
+        bool hasTranslation = throttle != 0f || pitch != 0f || roll != 0f;
+        if (hasTranslation)
+        {
+            targetVelocity = targetWorldVelocity;
+            currentVelocity = Vector3.Lerp(currentVelocity, targetVelocity, flyAcceleration * deltaTime);
+            if (useMomentum)
+                velocityMomentum = Vector3.Lerp(velocityMomentum, currentVelocity * 0.1f, deltaTime * 2f);
+        }
+        else if (useMomentum)
+        {
+            ApplyInertia(deltaTime);
+        }
+        else
+        {
+            currentVelocity = Vector3.zero;
+            targetVelocity = Vector3.zero;
+        }
+
+        Vector3 finalVelocity = currentVelocity + (useMomentum ? velocityMomentum : Vector3.zero);
+        smoothedPosition += finalVelocity * deltaTime;
+
+        Quaternion targetRotation = Quaternion.Euler(0f, currentYaw, 0f);
+        smoothedRotation = Quaternion.Slerp(smoothedRotation, targetRotation, rotationSmoothing * deltaTime);
+    }
+
+    /// <summary>Reads desktop fly movement inputs and outputs a normalized movement vector + speed multiplier.</summary>
     private bool HandleMovementInput(out Vector3 movement, out float speedMultiplier)
     {
         movement = Vector3.zero;
         speedMultiplier = 1f;
 
-        if (isVRFlying)
-        {
-            // VR path: read thumbstick from the interacting controller
-            if (!GetActiveVRInput(out BasisInputWrapper vrInput))
-                return false;
+        var horizontalInput = flyCamera.horizontalMoveInput;
+        var verticalInput = flyCamera.verticalMoveInput;
+        var isFastMovement = flyCamera.isFastMovement;
 
-            BasisInputState state = vrInput.Source.CurrentInputState;
-            Vector2 thumbstick = state.Primary2DAxisDeadZoned;
+        movement = new Vector3(horizontalInput.x, verticalInput, horizontalInput.y);
 
-            // Thumbstick X = strafe, thumbstick Y = forward/back
-            // Vertical movement comes from controller pitch (point up + push forward = fly up)
-            movement = new Vector3(thumbstick.x, 0f, thumbstick.y);
+        if (movement.magnitude < 0.01f)
+            return false;
 
-            if (movement.magnitude < 0.01f)
-                return false;
+        // prevent faster diagonal movement
+        if (movement.magnitude > 1f)
+            movement.Normalize();
 
-            if (movement.magnitude > 1f)
-                movement.Normalize();
-
-            // Grip = speed boost
-            speedMultiplier = state.GripButton ? flyFastMultiplier : 1f;
-            return true;
-        }
-        else
-        {
-            // Desktop path: read keyboard input
-            var horizontalInput = flyCamera.horizontalMoveInput;
-            var verticalInput = flyCamera.verticalMoveInput;
-            var isFastMovement = flyCamera.isFastMovement;
-
-            movement = new Vector3(horizontalInput.x, verticalInput, horizontalInput.y);
-
-            if (movement.magnitude < 0.01f)
-                return false;
-
-            // prevent faster diagonal movement
-            if (movement.magnitude > 1f)
-                movement.Normalize();
-
-            speedMultiplier = isFastMovement ? flyFastMultiplier : 1f;
-            return true;
-        }
+        speedMultiplier = isFastMovement ? flyFastMultiplier : 1f;
+        return true;
     }
 
     /// <summary>Converts input to world velocity and applies acceleration and momentum.</summary>
     private void UpdateMovement(Vector3 inputMovement, float speedMultiplier, float deltaTime)
     {
-        // In VR, move relative to controller orientation (point where you want to fly).
-        // In desktop, move relative to the camera's current orientation.
-        Quaternion orientationRef = isVRFlying ? vrControllerRotation : HHC.captureCamera.transform.rotation;
+        // Desktop: move relative to the camera's current orientation.
+        Quaternion orientationRef = HHC.captureCamera.transform.rotation;
         Vector3 worldMovement = orientationRef * inputMovement;
         targetVelocity = worldMovement * flySpeed * speedMultiplier;
         currentVelocity = Vector3.Lerp(currentVelocity, targetVelocity, flyAcceleration * deltaTime);
@@ -696,20 +764,10 @@ public abstract class BasisHandHeldCameraInteractable : BasisPickupInteractable
         }
     }
 
-    /// <summary>Reads fly rotation input (mouse delta) and outputs the delta if significant.</summary>
+    /// <summary>Reads desktop fly rotation input (mouse delta) and outputs the delta if significant.</summary>
     private bool HandleRotationInput(out Vector2 rotationDelta)
     {
         rotationDelta = Vector2.zero;
-
-        if (isVRFlying)
-        {
-            // VR: drive target rotation directly from controller orientation.
-            // The actual rotation is applied in ApplySmoothedPosition (1:1 mapping).
-            Vector3 euler = vrControllerRotation.eulerAngles;
-            targetPitch = NormalizeAngle(euler.x);
-            targetYaw = NormalizeAngle(euler.y);
-            return false;
-        }
 
         // Desktop: mouse delta
         var mouseInput = flyCamera.mouseInput;
@@ -750,31 +808,22 @@ public abstract class BasisHandHeldCameraInteractable : BasisPickupInteractable
 
     /// <summary>
     /// Integrates velocity into <see cref="smoothedPosition"/> and applies smoothed rotation
-    /// with momentum-influenced smoothing.
+    /// with momentum-influenced smoothing. Desktop fly path only; the VR path is handled in
+    /// <see cref="MoveVRFlying"/>.
     /// </summary>
     private void ApplySmoothedPosition(float deltaTime)
     {
         Vector3 finalVelocity = currentVelocity + (useMomentum ? velocityMomentum : Vector3.zero);
         smoothedPosition += finalVelocity * deltaTime;
 
-        if (isVRFlying)
-        {
-            // VR: 1:1 controller-to-camera rotation for responsive aiming
-            currentPitch = targetPitch;
-            currentYaw = targetYaw;
-            smoothedRotation = vrControllerRotation;
-        }
-        else
-        {
-            // Desktop: smoothed rotation with momentum
-            float enhancedRotationSmoothness = rotationSmoothing + rotationMomentum;
+        // Desktop: smoothed rotation with momentum
+        float enhancedRotationSmoothness = rotationSmoothing + rotationMomentum;
 
-            currentPitch = Mathf.LerpAngle(currentPitch, targetPitch, enhancedRotationSmoothness * deltaTime);
-            currentYaw = Mathf.LerpAngle(currentYaw, targetYaw, enhancedRotationSmoothness * deltaTime);
+        currentPitch = Mathf.LerpAngle(currentPitch, targetPitch, enhancedRotationSmoothness * deltaTime);
+        currentYaw = Mathf.LerpAngle(currentYaw, targetYaw, enhancedRotationSmoothness * deltaTime);
 
-            Quaternion targetRotationQuat = Quaternion.Euler(currentPitch, currentYaw, 0f);
-            smoothedRotation = Quaternion.Slerp(smoothedRotation, targetRotationQuat, rotationSmoothing * deltaTime);
-        }
+        Quaternion targetRotationQuat = Quaternion.Euler(currentPitch, currentYaw, 0f);
+        smoothedRotation = Quaternion.Slerp(smoothedRotation, targetRotationQuat, rotationSmoothing * deltaTime);
     }
 
     /// <summary>Normalizes an angle to the range [-180, 180].</summary>

--- a/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalCharacterDriver.cs
+++ b/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalCharacterDriver.cs
@@ -155,6 +155,7 @@ namespace Basis.Scripts.BasisCharacterController
 
         public BasisLocks.LockContext MovementLock = BasisLocks.GetContext(BasisLocks.Movement);
         public BasisLocks.LockContext CrouchingLock = BasisLocks.GetContext(BasisLocks.Crouching);
+        public BasisLocks.LockContext LookRotationLock = BasisLocks.GetContext(BasisLocks.LookRotation);
         public Transform BasisLocalPlayerTransform;
         private bool isEnabled = true;
         public float CurrentSpeed;
@@ -245,7 +246,12 @@ namespace Basis.Scripts.BasisCharacterController
 
             // Calculate the rotation amount for this frame
             float rotationAmount;
-            if (SMModuleControllerSettings.UsingSnapTurnAngle && BasisDeviceManagement.IsCurrentModeVR())
+            if (LookRotationLock)
+            {
+                rotationAmount = 0f;
+                isSnapTurning = false;
+            }
+            else if (SMModuleControllerSettings.UsingSnapTurnAngle && BasisDeviceManagement.IsCurrentModeVR())
             {
                 var isAboveThreshold = math.abs(Rotation.x) > SnapTurnAbsoluteThreshold;
                 if (isAboveThreshold != isSnapTurning)


### PR DESCRIPTION
## Summary

Adds a VR "fly mode" to the handheld capture camera in to  provide a  much greater degree of freedom for film-making, streaming and taking photos, using **RC "Mode 2"** twin-stick controls.

Fly Mode activate and recall is on the **B/Y button**, replacing the old thumbstick-*click* toggle. The thumbstick toggle was one motivation: repeated stick-clicks wears the thumbstick over time and presents a negative user association.

Proposal: Hold the camera, quick press B/Y → it detaches to world space and both hands pilot. quick press B/Y again → it returns to hand.

**Twin-stick mapping (RC Mode 2):**

| Axis | Stick | Effect |
| --- | --- | --- |
| Throttle | pilot Y | Altitude — straight world-up/down, heading-independent |
| Yaw | pilot X | Rate-based turn; heading **holds** when the stick re-centres |
| Pitch | free Y | Forward / back, relative to heading |
| Roll | free X | Strafe, relative to heading |

While flying, the avatar is pinned in place via look / movement / crouch locks.

Built on the existing fly infrastructure (`CameraPinSpace.WorldSpace`, the pin constraint, and the existing fly-speed / acceleration / momentum fields) rather than new scaffolding — only a `yawRate` tunable is added. 

Desktop fly mode is unchanged.

### Two commits

- **`fix: gate VR turn on the LookRotation lock`** — the snap/smooth-turn block applied controller turn input unconditionally, so a held `LookRotation` lock suppressed *desktop* look but not *VR* stick-turn. Added a lock guard mirroring the existing `MovementLock` guard. Without this, the pilot stick's yaw would also rotate the avatar while flying. This is a small change to a shared control path (`BasisLocalCharacterDriver`), so it is called out separately.
- **`feat: VR camera fly mode with RC Mode 2 twin-stick controls`** — the fly mode itself, entirely within `BasisHandHeldCameraInteractable`.

## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [ ] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — `BasisEventDriver` runs the single per-frame tick that drives the whole framework (network apply, local player sim, blendshapes, JigglePhysics, nameplates, and more) as one sequential chain. An unhandled exception anywhere in that chain aborts the rest of the tick, so every step after the throwing one is silently skipped for that frame. New work added to the driver must either be guaranteed not to throw, or be wrapped in a `try`/`catch` that contains the failure and surfaces it through `BasisDebug` — logged once / rate-limited, never every frame (see the existing `HVRBasisBuiltInAddresses.Simulate()` guard for the pattern). Expect this to be scrutinized closely in review.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [x] Windows
- [ ] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [x] Tested in VR (note headset under **Notes**)
- [x] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [ ] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [ ] N/A — change does not touch any of the above

## Notes

**Draft — not merge-ready yet.** open items:

1. **Not yet built locally**

2. **Known interaction: left-hand B/Y also opens the hamburger menu.** The hamburger menu is bound to the left-hand secondary button (`BasisActionDriver`), so launching/recalling with the *left* hand as pilot also toggles the menu. Right-hand piloting is clean. This is intentionally **not** fixed here — the fix is tracked in https://github.com/BasisVR/Basis/pull/838

**Checklist context:**
- **Jobification** — N/A. Single-camera flight integration on the local player only; a handful of vector ops per frame, not job-worthy.
- **Camera access** — operates on the handheld camera's own `captureCamera` (the prop's capture camera), not the local player camera, so `BasisLocalCameraDriver` discovery does not apply.
- **BasisEventDriver** — per-frame work runs via the existing `BasisLocalPlayer.AfterSimulateOnLate` registration; no new `Update`/standalone tick added.
- **Hot path** — `MoveVRFlying` runs per frame; it allocates nothing (`Vector3`/`Quaternion` are value types) and logs nothing. The only `BasisDebug` calls are on the launch/recall edges.