### PR TITLE
feat: add Sequence speed multiplier to BasisAuthoredMotion

### DIFF
--- a/Basis/Packages/com.basis.framework/Drivers/AuthoredMotion/BasisAuthoredMotionSystem.cs
+++ b/Basis/Packages/com.basis.framework/Drivers/AuthoredMotion/BasisAuthoredMotionSystem.cs
@@ -147,8 +147,17 @@ public struct AuthoredMotionJob : IJobParallelForTransform
                 float fr = m.frameRate > 1e-4f ? m.frameRate : 30f;
                 float length = m.frameCount / fr;
                 float st = t * m.sequenceSpeed;
-                float pt = m.loop != 0 ? math.fmod(st, length) : math.min(math.max(st, 0f), length);
-                if (pt < 0f) pt += length; // fmod can return negative for negative t
+                float pt;
+                if (m.loop != 0)
+                {
+                    pt = math.fmod(st, length);
+                    if (pt < 0f) pt += length; // fmod can return negative for negative t
+                }
+                else
+                {
+                    // Reverse one-shot walks the playhead down from the end; forward holds at 0..length.
+                    pt = math.clamp(m.sequenceSpeed < 0f ? length + st : st, 0f, length);
+                }
 
                 float frameF = pt * fr;
                 int f0 = (int)math.floor(frameF);

--- a/Basis/Packages/com.basis.framework/Drivers/AuthoredMotion/BasisAuthoredMotionSystem.cs
+++ b/Basis/Packages/com.basis.framework/Drivers/AuthoredMotion/BasisAuthoredMotionSystem.cs
@@ -47,6 +47,7 @@ public struct AuthoredMovementData
     public int frameCount;       // frames for this slot's transform
     public float frameRate;      // samples per second
     public int loop;             // 0 = one-shot, 1 = loop
+    public float sequenceSpeed;  // playback rate multiplier (negative reverses)
 
     // Captured rest pose (local space); motion composes as a delta from this.
     public quaternion restRotation;
@@ -145,7 +146,8 @@ public struct AuthoredMotionJob : IJobParallelForTransform
                 if (m.frameCount <= 0) break;
                 float fr = m.frameRate > 1e-4f ? m.frameRate : 30f;
                 float length = m.frameCount / fr;
-                float pt = m.loop != 0 ? math.fmod(t, length) : math.min(math.max(t, 0f), length);
+                float st = t * m.sequenceSpeed;
+                float pt = m.loop != 0 ? math.fmod(st, length) : math.min(math.max(st, 0f), length);
                 if (pt < 0f) pt += length; // fmod can return negative for negative t
 
                 float frameF = pt * fr;
@@ -501,6 +503,7 @@ public static class BasisAuthoredMotionSystem
                         d.frameCount = fc;
                         d.frameRate = clip.frameRate;
                         d.loop = mv.loop ? 1 : 0;
+                        d.sequenceSpeed = mv.sequenceSpeed;
                         AddSlot(data, targets, movementEnabled, d, tf, mv.enabled);
                     }
                     break;

--- a/Basis/Packages/com.basis.sdk/Localization/Languages/en.json
+++ b/Basis/Packages/com.basis.sdk/Localization/Languages/en.json
@@ -261,6 +261,8 @@
     { "key": "sdk.authoredMotion.field.keyframes.tooltip", "value": "Inline pose-delta timeline for short motion. Ignored when a Baked Clip is assigned." },
     { "key": "sdk.authoredMotion.field.loop.label", "value": "Loop" },
     { "key": "sdk.authoredMotion.field.loop.tooltip", "value": "Loop the sequence, or play it once." },
+    { "key": "sdk.authoredMotion.field.sequenceSpeed.label", "value": "Speed" },
+    { "key": "sdk.authoredMotion.field.sequenceSpeed.tooltip", "value": "Playback rate multiplier for the baked clip. 1 plays at authored speed, 2 plays twice as fast, 0.5 half speed; negative values play in reverse." },
 
     { "key": "sdk.buildReport.window.title", "value": "Basis Build Report Viewer" },
     { "key": "sdk.buildReport.window.tabTitle", "value": "Basis Bundle Report" },

--- a/Basis/Packages/com.basis.sdk/Scripts/BasisAuthoredMotion.cs
+++ b/Basis/Packages/com.basis.sdk/Scripts/BasisAuthoredMotion.cs
@@ -78,6 +78,7 @@ public class BasisAuthoredMotion : MonoBehaviour
         public Keyframe[] keyframes = Array.Empty<Keyframe>();
         public BasisMotionClip bakedClip; // shared baked curves; null when using inline keyframes
         public bool loop = true;
+        public float sequenceSpeed = 1f; // playback rate multiplier (1 = authored speed); negative plays in reverse
 
         // Noise — simplex drift on `channel` about `axis`; reuses amplitude / chain / chainFalloff / seed; `noiseSpeed` = sample rate.
         public float noiseSpeed = 0.5f;

--- a/Basis/Packages/com.basis.sdk/Scripts/Editor/BasisAuthoredMotionEditor.cs
+++ b/Basis/Packages/com.basis.sdk/Scripts/Editor/BasisAuthoredMotionEditor.cs
@@ -131,6 +131,7 @@ public class BasisAuthoredMotionEditor : Editor
                     Field(mv, "bakedClip", "bakedClip");
                     Field(mv, "sequenceRoot", "sequenceRoot");
                     Field(mv, "loop", "loop");
+                    Field(mv, "sequenceSpeed", "sequenceSpeed");
                     break;
             }
 


### PR DESCRIPTION
## Summary
The `Sequence` movement kind in `BasisAuthoredMotion` plays a baked clip at its authored speed only. This adds a per-movement **Speed** multiplier so a clip can be slowed down or sped up without re-baking.

`AuthoredMotionJob` scales the sequence playhead by the multiplier before the loop/clamp step, so it applies to both looping and one-shot clips: `1` = authored speed, `2` = double, `0.5` = half. Negative values play in reverse — the existing `fmod` negative-wrap already handles that, so no extra branch was needed.

The field defaults to `1`, which Unity preserves as the migration default for already-serialized components, so existing avatars play at authored speed exactly as before.

https://github.com/user-attachments/assets/162f74a8-257d-40b4-9135-2e5dda2a4c0e

Touched files:
- `BasisAuthoredMotion.cs` — new `sequenceSpeed` field on `Movement` (Sequence section).
- `BasisAuthoredMotionSystem.cs` — `sequenceSpeed` added to the blittable `AuthoredMovementData`, populated during the Sequence build, applied in the Burst job (`t * sequenceSpeed`).
- `BasisAuthoredMotionEditor.cs` — exposes the field in the Sequence inspector card.
- `en.json` — label/tooltip for the new field.

## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [x] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — `BasisEventDriver` runs the single per-frame tick that drives the whole framework (network apply, local player sim, blendshapes, JigglePhysics, nameplates, and more) as one sequential chain. An unhandled exception anywhere in that chain aborts the rest of the tick, so every step after the throwing one is silently skipped for that frame. New work added to the driver must either be guaranteed not to throw, or be wrapped in a `try`/`catch` that contains the failure and surfaces it through `BasisDebug` — logged once / rate-limited, never every frame (see the existing `HVRBasisBuiltInAddresses.Simulate()` guard for the pattern). Expect this to be scrutinized closely in review.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [x] Windows
- [ ] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [ ] Tested in VR (note headset under **Notes**)
- [ ] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [x] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [x] N/A — change does not touch any of the above

## Notes
- **Tested:** compiled in the Unity editor on Windows; the new **Speed** field shows in the Sequence inspector card. The runtime change is a single scalar multiply (`t * sequenceSpeed`) inside the already-exercised `AuthoredMotionJob` Sequence branch.
- **Jobification:** already jobified — the multiplier is applied inside the existing Burst-compiled `AuthoredMotionJob`, not on the main thread.
- **N/A boxes:** this is a data field plus a one-line change inside an existing batched job. It adds no asset loading (Addressables), no `GetComponent`/`AddComponent`, no new `Update`/`LateUpdate` or `BasisEventDriver` work, no camera access, no logging, no scene-wide discovery, and no allocations or new hot-path loops — so those checks are vacuously satisfied.
- **Default/back-compat:** `sequenceSpeed` defaults to `1f`; Unity keeps the field initializer as the migration default for components serialized before this field existed, so existing baked sequences play unchanged.
