### PR TITLE
Camera nameplates

### DIFF
--- a/Basis/Packages/com.basis.eventdriver/BasisEventDriver.cs
+++ b/Basis/Packages/com.basis.eventdriver/BasisEventDriver.cs
@@ -291,6 +291,7 @@ namespace Basis.EventDriver
             // ── Nameplate schedule ──
             ProfileBegin(PROF_NAMEPLATE_SCHEDULE);
             BasisRemoteNamePlateDriver.ScheduleSimulate(TimeAsDouble);
+            BasisCameraNamePlateDriver.UpdateAllPlatePositions();
             ProfileEnd(PROF_NAMEPLATE_SCHEDULE);
 #if STEAMAUDIO_ENABLED
             SteamAudioManager.Schedule();

--- a/Basis/Packages/com.basis.eventdriver/BasisEventDriver.cs
+++ b/Basis/Packages/com.basis.eventdriver/BasisEventDriver.cs
@@ -290,6 +290,7 @@ namespace Basis.EventDriver
 
             // ── Nameplate schedule ──
             ProfileBegin(PROF_NAMEPLATE_SCHEDULE);
+            BasisNamePlateMeshBaker.ProcessBakeQueue();
             BasisRemoteNamePlateDriver.ScheduleSimulate(TimeAsDouble);
             BasisCameraNamePlateDriver.UpdateAllPlatePositions();
             ProfileEnd(PROF_NAMEPLATE_SCHEDULE);

--- a/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/SettingsProviderNamePlate.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/SettingsProviderNamePlate.cs
@@ -97,6 +97,7 @@ namespace Basis.BasisUI
         public static void ApplyNamePlateSettings()
         {
             BasisRemoteNamePlateDriver.ApplyNamePlateSettingsFromUI();
+            BasisCameraNamePlateDriver.ApplyNamePlateSettingsFromUI();
         }
     }
 }

--- a/Basis/Packages/com.basis.framework/Device Management/BasisDeviceManagement.cs
+++ b/Basis/Packages/com.basis.framework/Device Management/BasisDeviceManagement.cs
@@ -798,6 +798,8 @@ namespace Basis.Scripts.Device_Management
         {
             if (FireOffNetwork)
             {
+                BasisNamePlateAssets.Initialize();
+                BasisNamePlateMeshBaker.Initialize();
                 BasisRemoteNamePlateDriver.Initialize();
                 BasisCameraNamePlateDriver.Initialize();
                 BasisNetworkLifeCycle.Initialize();

--- a/Basis/Packages/com.basis.framework/Device Management/BasisDeviceManagement.cs
+++ b/Basis/Packages/com.basis.framework/Device Management/BasisDeviceManagement.cs
@@ -799,6 +799,7 @@ namespace Basis.Scripts.Device_Management
             if (FireOffNetwork)
             {
                 BasisRemoteNamePlateDriver.Initialize();
+                BasisCameraNamePlateDriver.Initialize();
                 BasisNetworkLifeCycle.Initialize();
             }
         }

--- a/Basis/Packages/com.basis.framework/Networking/BasisNetworkLifeCycle.cs
+++ b/Basis/Packages/com.basis.framework/Networking/BasisNetworkLifeCycle.cs
@@ -151,8 +151,8 @@ public static class BasisNetworkLifeCycle
         BasisNetworkHandleTempBlock.Shutdown();
         BasisNetworkHandleChatTyping.Shutdown();
 #if !UNITY_SERVER
-        BasisNetworkPIPCameraDriver.Shutdown();
         BasisCameraNamePlateDriver.Shutdown();
+        BasisNetworkPIPCameraDriver.Shutdown();
 #endif
         BasisNetworkConnection.NetworkClient?.Disconnect();
     }

--- a/Basis/Packages/com.basis.framework/Networking/BasisNetworkLifeCycle.cs
+++ b/Basis/Packages/com.basis.framework/Networking/BasisNetworkLifeCycle.cs
@@ -4,6 +4,7 @@ using Basis.Scripts.Networking;
 using Basis.Scripts.Networking.NetworkedAvatar;
 using Basis.Scripts.Networking.Receivers;
 using Basis.Scripts.UI;
+using Basis.Scripts.UI.NamePlate;
 using Basis.Network.Core;
 using System.Threading;
 using System.Threading.Tasks;
@@ -151,6 +152,7 @@ public static class BasisNetworkLifeCycle
         BasisNetworkHandleChatTyping.Shutdown();
 #if !UNITY_SERVER
         BasisNetworkPIPCameraDriver.Shutdown();
+        BasisCameraNamePlateDriver.Shutdown();
 #endif
         BasisNetworkConnection.NetworkClient?.Disconnect();
     }

--- a/Basis/Packages/com.basis.framework/Networking/BasisNetworkLifeCycle.cs
+++ b/Basis/Packages/com.basis.framework/Networking/BasisNetworkLifeCycle.cs
@@ -78,6 +78,10 @@ public static class BasisNetworkLifeCycle
             }
 
             BasisRemoteNetworkDriver.Apply();//complete in-flight jobs before clearing players
+#if !UNITY_SERVER
+            BasisCameraNamePlateDriver.ClearAll();
+            BasisNetworkPIPCameraDriver.ClearRemotePIPs();
+#endif
             BasisNetworkPlayers.ClearAllRegistries();//remove players
             Basis.Scripts.Networking.Receivers.BasisShoutAudioDriver.DeInitialize();//remove shout audio sources
             await BasisNetworkSpawnItem.Reset();//remove items

--- a/Basis/Packages/com.basis.framework/Networking/BasisNetworkPIPCameraDriver.cs
+++ b/Basis/Packages/com.basis.framework/Networking/BasisNetworkPIPCameraDriver.cs
@@ -115,17 +115,7 @@ public static class BasisNetworkPIPCameraDriver
 
         BasisLocalPlayer.AfterSimulateOnLate.RemoveAction(SimulatePriority, Simulate);
 
-        smoothHandle.Complete();
-
-        // Destroy all spawned PIP instances
-        foreach (var kvp in pipInstances)
-        {
-            if (kvp.Value != null)
-            {
-                UnityEngine.Object.Destroy(kvp.Value);
-            }
-        }
-        pipInstances.Clear();
+        ClearRemotePIPs();
 
         // Release the loaded prefab
         if (prefabHandle.IsValid())
@@ -140,14 +130,37 @@ public static class BasisNetworkPIPCameraDriver
         if (targetRotations.IsCreated) targetRotations.Dispose();
         if (activeFlags.IsCreated) activeFlags.Dispose();
 
+        initialized = false;
+    }
+
+    public static void ClearRemotePIPs()
+    {
+        if (!initialized) return;
+
+        smoothHandle.Complete();
+
+        foreach (var kvp in pipInstances)
+        {
+            if (kvp.Value != null)
+            {
+                UnityEngine.Object.Destroy(kvp.Value);
+            }
+        }
+        pipInstances.Clear();
+        pipTransforms.Clear();
         playerIdToIndex.Clear();
         indexToPlayerId.Clear();
         activeRemotePIPs.Clear();
-        pipTransforms.Clear();
         recycledIndices.Clear();
         nextFreeIndex = 0;
 
-        initialized = false;
+        if (activeFlags.IsCreated)
+        {
+            for (int i = 0; i < activeFlags.Length; i++)
+            {
+                activeFlags[i] = 0;
+            }
+        }
     }
 
     /// <summary>

--- a/Basis/Packages/com.basis.framework/Networking/BasisNetworkPIPCameraDriver.cs
+++ b/Basis/Packages/com.basis.framework/Networking/BasisNetworkPIPCameraDriver.cs
@@ -25,7 +25,7 @@ public static class BasisNetworkPIPCameraDriver
     /// <summary>
     /// Fired when a remote player's PIP camera is created.
     /// </summary>
-    public static event Action<ushort, float3, Quaternion> OnRemotePIPCreated;
+    public static event Action<ushort, float3, quaternion> OnRemotePIPCreated;
 
     /// <summary>
     /// Fired when a remote player's PIP camera is destroyed.

--- a/Basis/Packages/com.basis.framework/Networking/BasisNetworkPIPCameraDriver.cs
+++ b/Basis/Packages/com.basis.framework/Networking/BasisNetworkPIPCameraDriver.cs
@@ -25,7 +25,7 @@ public static class BasisNetworkPIPCameraDriver
     /// <summary>
     /// Fired when a remote player's PIP camera is created.
     /// </summary>
-    public static event Action<ushort, float3, quaternion> OnRemotePIPCreated;
+    public static event Action<ushort, float3, Quaternion> OnRemotePIPCreated;
 
     /// <summary>
     /// Fired when a remote player's PIP camera is destroyed.
@@ -297,6 +297,23 @@ public static class BasisNetworkPIPCameraDriver
             return true;
         }
         position = Vector3.zero;
+        return false;
+    }
+
+    /// <summary>
+    /// Try to get the world pose of a remote PIP camera by player ID.
+    /// </summary>
+    public static bool TryGetPIPPose(ushort playerId, out Vector3 position, out Quaternion rotation)
+    {
+        if (pipTransforms.TryGetValue(playerId, out Transform t) && t != null)
+        {
+            position = t.position;
+            rotation = t.rotation;
+            return true;
+        }
+
+        position = Vector3.zero;
+        rotation = Quaternion.identity;
         return false;
     }
 

--- a/Basis/Packages/com.basis.framework/UI/NamePlate/BasisCameraNamePlate.cs
+++ b/Basis/Packages/com.basis.framework/UI/NamePlate/BasisCameraNamePlate.cs
@@ -1,4 +1,3 @@
-using System.Threading;
 using Basis.Scripts.BasisSdk.Players;
 using UnityEngine;
 
@@ -24,18 +23,15 @@ namespace Basis.Scripts.UI.NamePlate
         /// The player ID this nameplate belongs to.
         /// </summary>
         public ushort PlayerID;
+
         public BasisRemotePlayer RemotePlayer;
 
         /// <summary>
         /// Whether this nameplate is currently active and visible.
         /// </summary>
-        private int _isActive = 1;
+        // Camera nameplate lifecycle is driven from Unity's main thread.
+        public bool IsActive = true;
         private bool _lastAppliedActive = true;
-        public bool IsActive
-        {
-            get => Volatile.Read(ref _isActive) == 1;
-            private set => Volatile.Write(ref _isActive, value ? 1 : 0);
-        }
 
         /// <summary>
         /// The current display name being shown.
@@ -46,14 +42,27 @@ namespace Basis.Scripts.UI.NamePlate
 
         public void Initialize(ushort playerId, string displayName, Transform parentTransform, BasisRemotePlayer remotePlayer = null)
         {
+            if (string.IsNullOrEmpty(displayName))
+            {
+                displayName = $"Player {playerId}";
+            }
+
             PlayerID = playerId;
             RemotePlayer = remotePlayer;
             DisplayName = displayName;
             gameObject.name = $"CameraNamePlate_{playerId}";
             ApplyScale();
 
-            BackgroundFilter = gameObject.AddComponent<MeshFilter>();
-            BackgroundRenderer = gameObject.AddComponent<MeshRenderer>();
+            if (BackgroundFilter == null && !TryGetComponent(out BackgroundFilter))
+            {
+                BackgroundFilter = gameObject.AddComponent<MeshFilter>();
+            }
+
+            if (BackgroundRenderer == null && !TryGetComponent(out BackgroundRenderer))
+            {
+                BackgroundRenderer = gameObject.AddComponent<MeshRenderer>();
+            }
+
             visual = new BasisNamePlateVisual("CameraNamePlateCombinedMesh");
             visual.Attach(BackgroundFilter, BackgroundRenderer);
             visual.SetDisplayName(displayName);
@@ -73,6 +82,11 @@ namespace Basis.Scripts.UI.NamePlate
 
         public void UpdateDisplayName(string newName)
         {
+            if (string.IsNullOrEmpty(newName))
+            {
+                newName = $"Player {PlayerID}";
+            }
+
             if (DisplayName == newName) return;
             DisplayName = newName;
             visual?.SetDisplayName(newName);

--- a/Basis/Packages/com.basis.framework/UI/NamePlate/BasisCameraNamePlate.cs
+++ b/Basis/Packages/com.basis.framework/UI/NamePlate/BasisCameraNamePlate.cs
@@ -1,0 +1,156 @@
+using System.Threading;
+using Basis.Scripts.BasisSdk.Players;
+using UnityEngine;
+
+namespace Basis.Scripts.UI.NamePlate
+{
+    /// <summary>
+    /// Nameplate displayed above a remote PIP camera feed.
+    /// Shows the player's display name using the same font and visual style as avatar nameplates.
+    /// </summary>
+    public class BasisCameraNamePlate : MonoBehaviour
+    {
+        /// <summary>
+        /// The MeshFilter for the baked nameplate mesh.
+        /// </summary>
+        public MeshFilter BackgroundFilter;
+
+        /// <summary>
+        /// The MeshRenderer for the baked nameplate mesh.
+        /// </summary>
+        public MeshRenderer BackgroundRenderer;
+
+        /// <summary>
+        /// The player ID this nameplate belongs to.
+        /// </summary>
+        public ushort PlayerID;
+        public BasisRemotePlayer RemotePlayer;
+
+        /// <summary>
+        /// Whether this nameplate is currently active and visible.
+        /// </summary>
+        private int _isActive = 1;
+        private bool _lastAppliedActive = true;
+        public bool IsActive
+        {
+            get => Volatile.Read(ref _isActive) == 1;
+            private set => Volatile.Write(ref _isActive, value ? 1 : 0);
+        }
+
+        /// <summary>
+        /// The current display name being shown.
+        /// </summary>
+        public string DisplayName;
+
+        private Mesh _backgroundMesh;
+
+        /// <summary>
+        /// Whether the mesh needs to be regenerated (name changed).
+        /// </summary>
+        private bool _needsMeshUpdate;
+
+        public void Initialize(ushort playerId, string displayName, Transform parentTransform, BasisRemotePlayer remotePlayer = null)
+        {
+            PlayerID = playerId;
+            RemotePlayer = remotePlayer;
+            DisplayName = displayName;
+            gameObject.name = $"CameraNamePlate_{playerId}";
+            ApplyScale();
+
+            BackgroundFilter = gameObject.AddComponent<MeshFilter>();
+            BackgroundRenderer = gameObject.AddComponent<MeshRenderer>();
+
+            // Use the same material as avatar nameplates
+            if (BasisRemoteNamePlateDriver.SelectedNamePlateMaterial != null)
+            {
+                BackgroundRenderer.sharedMaterial = BasisRemoteNamePlateDriver.SelectedNamePlateMaterial;
+                BackgroundRenderer.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+                BackgroundRenderer.receiveShadows = false;
+                BackgroundRenderer.lightProbeUsage = UnityEngine.Rendering.LightProbeUsage.Off;
+            }
+
+            // Parent under BasisDeviceManagement for lifetime management
+            if (parentTransform != null)
+            {
+                transform.SetParent(parentTransform, false);
+            }
+
+            // Register with the driver
+            BasisCameraNamePlateDriver.Register(this);
+
+            // Initial text bake
+            _needsMeshUpdate = true;
+            RefreshMeshIfNeeded();
+            RefreshActiveState();
+        }
+
+        public void UpdateDisplayName(string newName)
+        {
+            if (DisplayName == newName) return;
+            DisplayName = newName;
+            _needsMeshUpdate = true;
+        }
+
+        public void OnPlayerLeft()
+        {
+            BasisCameraNamePlateDriver.Unregister(this);
+            gameObject.SetActive(false);
+            Destroy(gameObject);
+        }
+
+        public void RefreshMeshIfNeeded()
+        {
+            if (!_needsMeshUpdate) return;
+            _needsMeshUpdate = false;
+
+            if (BackgroundFilter != null)
+            {
+                if (_backgroundMesh != null)
+                {
+                    Destroy(_backgroundMesh);
+                }
+                BasisRemoteNamePlateDriver.GenerateTextFactory(DisplayName, BackgroundFilter, BackgroundRenderer, "CameraNamePlateCombinedMesh");
+                _backgroundMesh = BackgroundFilter.sharedMesh;
+            }
+            if (BackgroundRenderer != null && BackgroundRenderer.sharedMaterial == null)
+            {
+                if (BasisRemoteNamePlateDriver.SelectedNamePlateMaterial != null)
+                {
+                    BackgroundRenderer.sharedMaterial = BasisRemoteNamePlateDriver.SelectedNamePlateMaterial;
+                }
+            }
+        }
+
+        public void SetActive(bool active)
+        {
+            IsActive = active;
+            RefreshActiveState();
+        }
+
+        public void ApplyScale()
+        {
+            transform.localScale = Vector3.one * 0.02f * BasisRemoteNamePlateDriver.NamePlateSize * BasisCameraNamePlateDriver.NamePlateScale;
+        }
+
+        public void RefreshActiveState()
+        {
+            bool active = BasisCameraNamePlateDriver.ShouldPlateBeActive(this);
+            if (_lastAppliedActive == active && gameObject.activeSelf == active)
+            {
+                return;
+            }
+
+            _lastAppliedActive = active;
+            gameObject.SetActive(active);
+        }
+
+        private void OnDestroy()
+        {
+            if (_backgroundMesh != null)
+            {
+                Destroy(_backgroundMesh);
+                _backgroundMesh = null;
+            }
+        }
+    }
+}

--- a/Basis/Packages/com.basis.framework/UI/NamePlate/BasisCameraNamePlate.cs
+++ b/Basis/Packages/com.basis.framework/UI/NamePlate/BasisCameraNamePlate.cs
@@ -42,12 +42,7 @@ namespace Basis.Scripts.UI.NamePlate
         /// </summary>
         public string DisplayName;
 
-        private Mesh _backgroundMesh;
-
-        /// <summary>
-        /// Whether the mesh needs to be regenerated (name changed).
-        /// </summary>
-        private bool _needsMeshUpdate;
+        private BasisNamePlateVisual visual;
 
         public void Initialize(ushort playerId, string displayName, Transform parentTransform, BasisRemotePlayer remotePlayer = null)
         {
@@ -59,15 +54,9 @@ namespace Basis.Scripts.UI.NamePlate
 
             BackgroundFilter = gameObject.AddComponent<MeshFilter>();
             BackgroundRenderer = gameObject.AddComponent<MeshRenderer>();
-
-            // Use the same material as avatar nameplates
-            if (BasisRemoteNamePlateDriver.SelectedNamePlateMaterial != null)
-            {
-                BackgroundRenderer.sharedMaterial = BasisRemoteNamePlateDriver.SelectedNamePlateMaterial;
-                BackgroundRenderer.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
-                BackgroundRenderer.receiveShadows = false;
-                BackgroundRenderer.lightProbeUsage = UnityEngine.Rendering.LightProbeUsage.Off;
-            }
+            visual = new BasisNamePlateVisual("CameraNamePlateCombinedMesh");
+            visual.Attach(BackgroundFilter, BackgroundRenderer);
+            visual.SetDisplayName(displayName);
 
             // Parent under BasisDeviceManagement for lifetime management
             if (parentTransform != null)
@@ -78,9 +67,7 @@ namespace Basis.Scripts.UI.NamePlate
             // Register with the driver
             BasisCameraNamePlateDriver.Register(this);
 
-            // Initial text bake
-            _needsMeshUpdate = true;
-            RefreshMeshIfNeeded();
+            QueueMeshRefreshIfNeeded();
             RefreshActiveState();
         }
 
@@ -88,7 +75,7 @@ namespace Basis.Scripts.UI.NamePlate
         {
             if (DisplayName == newName) return;
             DisplayName = newName;
-            _needsMeshUpdate = true;
+            visual?.SetDisplayName(newName);
         }
 
         public void OnPlayerLeft()
@@ -98,27 +85,9 @@ namespace Basis.Scripts.UI.NamePlate
             Destroy(gameObject);
         }
 
-        public void RefreshMeshIfNeeded()
+        public void QueueMeshRefreshIfNeeded()
         {
-            if (!_needsMeshUpdate) return;
-            _needsMeshUpdate = false;
-
-            if (BackgroundFilter != null)
-            {
-                if (_backgroundMesh != null)
-                {
-                    Destroy(_backgroundMesh);
-                }
-                BasisRemoteNamePlateDriver.GenerateTextFactory(DisplayName, BackgroundFilter, BackgroundRenderer, "CameraNamePlateCombinedMesh");
-                _backgroundMesh = BackgroundFilter.sharedMesh;
-            }
-            if (BackgroundRenderer != null && BackgroundRenderer.sharedMaterial == null)
-            {
-                if (BasisRemoteNamePlateDriver.SelectedNamePlateMaterial != null)
-                {
-                    BackgroundRenderer.sharedMaterial = BasisRemoteNamePlateDriver.SelectedNamePlateMaterial;
-                }
-            }
+            visual?.QueueMeshRefreshIfNeeded();
         }
 
         public void SetActive(bool active)
@@ -130,6 +99,7 @@ namespace Basis.Scripts.UI.NamePlate
         public void ApplyScale()
         {
             transform.localScale = Vector3.one * 0.02f * BasisRemoteNamePlateDriver.NamePlateSize * BasisCameraNamePlateDriver.NamePlateScale;
+            visual?.ApplyMaterial();
         }
 
         public void RefreshActiveState()
@@ -146,11 +116,9 @@ namespace Basis.Scripts.UI.NamePlate
 
         private void OnDestroy()
         {
-            if (_backgroundMesh != null)
-            {
-                Destroy(_backgroundMesh);
-                _backgroundMesh = null;
-            }
+            BasisCameraNamePlateDriver.Unregister(this);
+            visual?.Dispose();
+            visual = null;
         }
     }
 }

--- a/Basis/Packages/com.basis.framework/UI/NamePlate/BasisCameraNamePlate.cs
+++ b/Basis/Packages/com.basis.framework/UI/NamePlate/BasisCameraNamePlate.cs
@@ -112,7 +112,7 @@ namespace Basis.Scripts.UI.NamePlate
 
         public void ApplyScale()
         {
-            transform.localScale = Vector3.one * 0.02f * BasisRemoteNamePlateDriver.NamePlateSize * BasisCameraNamePlateDriver.NamePlateScale;
+            transform.localScale = Vector3.one * 0.02f * BasisNamePlateSettings.NamePlateSize * BasisCameraNamePlateDriver.NamePlateScale;
             visual?.ApplyMaterial();
         }
 

--- a/Basis/Packages/com.basis.framework/UI/NamePlate/BasisCameraNamePlate.cs.meta
+++ b/Basis/Packages/com.basis.framework/UI/NamePlate/BasisCameraNamePlate.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6c88c757f4f9b8d4fafd157f7a339493

--- a/Basis/Packages/com.basis.framework/UI/NamePlate/BasisCameraNamePlateDriver.cs
+++ b/Basis/Packages/com.basis.framework/UI/NamePlate/BasisCameraNamePlateDriver.cs
@@ -59,6 +59,8 @@ namespace Basis.Scripts.UI.NamePlate
             if (_initialized) return;
             _initialized = true;
 
+            BasisNamePlateAssets.Initialize();
+            BasisNamePlateMeshBaker.Initialize();
             BasisNetworkPIPCameraDriver.OnRemotePIPCreated += OnRemotePIPCreated;
             BasisNetworkPIPCameraDriver.OnRemotePIPDestroyed += OnRemotePIPDestroyed;
         }
@@ -223,7 +225,7 @@ namespace Basis.Scripts.UI.NamePlate
 
                 plate.RefreshActiveState();
                 RefreshPlayerMetadata(plate);
-                plate.RefreshMeshIfNeeded();
+                plate.QueueMeshRefreshIfNeeded();
 
                 if (ShouldPlateBeActive(plate))
                 {
@@ -243,7 +245,7 @@ namespace Basis.Scripts.UI.NamePlate
                 BasisCameraNamePlate plate = activePlateList[index];
                 if (plate != null)
                 {
-                    plate.RefreshMeshIfNeeded();
+                    plate.QueueMeshRefreshIfNeeded();
                 }
             }
         }

--- a/Basis/Packages/com.basis.framework/UI/NamePlate/BasisCameraNamePlateDriver.cs
+++ b/Basis/Packages/com.basis.framework/UI/NamePlate/BasisCameraNamePlateDriver.cs
@@ -61,6 +61,7 @@ namespace Basis.Scripts.UI.NamePlate
 
             BasisNamePlateAssets.Initialize();
             BasisNamePlateMeshBaker.Initialize();
+            BasisNamePlateSettings.RefreshFromDefaults();
             BasisNetworkPIPCameraDriver.OnRemotePIPCreated += OnRemotePIPCreated;
             BasisNetworkPIPCameraDriver.OnRemotePIPDestroyed += OnRemotePIPDestroyed;
         }
@@ -148,8 +149,8 @@ namespace Basis.Scripts.UI.NamePlate
         public static bool ShouldPlateBeActive(BasisCameraNamePlate plate)
         {
             if (!NamePlateEnabled) return false;
-            if (!BasisRemoteNamePlateDriver.NamePlateEnabled) return false;
-            if (BasisRemoteNamePlateDriver.NamePlateMenuOnly && BasisMainMenu.Instance == null) return false;
+            if (!BasisNamePlateSettings.NamePlateEnabled) return false;
+            if (BasisNamePlateSettings.NamePlateMenuOnly && BasisMainMenu.Instance == null) return false;
             if (!plate.IsActive) return false;
             if (plate.RemotePlayer != null && plate.RemotePlayer.IsEffectivelyBlocked) return false;
             return true;

--- a/Basis/Packages/com.basis.framework/UI/NamePlate/BasisCameraNamePlateDriver.cs
+++ b/Basis/Packages/com.basis.framework/UI/NamePlate/BasisCameraNamePlateDriver.cs
@@ -32,6 +32,8 @@ namespace Basis.Scripts.UI.NamePlate
         /// </summary>
         public static bool NamePlateEnabled = true;
 
+        private const string NamePlateLayerName = "UI";
+
         /// <summary>
         /// Whether the driver has been initialized.
         /// </summary>
@@ -156,6 +158,11 @@ namespace Basis.Scripts.UI.NamePlate
             if (activePlates.ContainsKey(playerId)) return;
 
             GameObject plateGO = new GameObject($"CameraNamePlate_{playerId}");
+            int namePlateLayer = LayerMask.NameToLayer(NamePlateLayerName);
+            if (namePlateLayer >= 0)
+            {
+                plateGO.layer = namePlateLayer;
+            }
             plateGO.transform.SetParent(BasisDeviceManagement.Instance.transform, false);
             plateGO.transform.SetLocalPositionAndRotation(Vector3.zero, Quaternion.identity);
 

--- a/Basis/Packages/com.basis.framework/UI/NamePlate/BasisCameraNamePlateDriver.cs
+++ b/Basis/Packages/com.basis.framework/UI/NamePlate/BasisCameraNamePlateDriver.cs
@@ -321,7 +321,7 @@ namespace Basis.Scripts.UI.NamePlate
         // Event handlers
         // ===========================
 
-        private static void OnRemotePIPCreated(ushort playerId, float3 position, UnityEngine.Quaternion rotation)
+        private static void OnRemotePIPCreated(ushort playerId, float3 position, quaternion rotation)
         {
             if (BasisNetworkPlayer.GetPlayerById(playerId, out var networkPlayer) && networkPlayer != null)
             {

--- a/Basis/Packages/com.basis.framework/UI/NamePlate/BasisCameraNamePlateDriver.cs
+++ b/Basis/Packages/com.basis.framework/UI/NamePlate/BasisCameraNamePlateDriver.cs
@@ -101,7 +101,8 @@ namespace Basis.Scripts.UI.NamePlate
                 }
                 if (existing != null)
                 {
-                    existing.OnPlayerLeft();
+                    Unregister(existing);
+                    UnityEngine.Object.Destroy(existing.gameObject);
                 }
             }
 

--- a/Basis/Packages/com.basis.framework/UI/NamePlate/BasisCameraNamePlateDriver.cs
+++ b/Basis/Packages/com.basis.framework/UI/NamePlate/BasisCameraNamePlateDriver.cs
@@ -76,6 +76,11 @@ namespace Basis.Scripts.UI.NamePlate
             BasisNetworkPIPCameraDriver.OnRemotePIPCreated -= OnRemotePIPCreated;
             BasisNetworkPIPCameraDriver.OnRemotePIPDestroyed -= OnRemotePIPDestroyed;
 
+            ClearAll();
+        }
+
+        public static void ClearAll()
+        {
             foreach (var kvp in activePlates)
             {
                 if (kvp.Value != null && kvp.Value.gameObject != null)

--- a/Basis/Packages/com.basis.framework/UI/NamePlate/BasisCameraNamePlateDriver.cs
+++ b/Basis/Packages/com.basis.framework/UI/NamePlate/BasisCameraNamePlateDriver.cs
@@ -1,0 +1,343 @@
+using System.Collections.Generic;
+using Basis.BasisUI;
+using Basis.Scripts.BasisSdk.Players;
+using Basis.Scripts.Networking.NetworkedAvatar;
+using Basis.Scripts.Device_Management;
+using Basis.Scripts.Drivers;
+using UnityEngine;
+using Unity.Mathematics;
+
+namespace Basis.Scripts.UI.NamePlate
+{
+    /// <summary>
+    /// Static driver that manages nameplates for remote PIP camera feeds.
+    /// Spawns nameplates when a remote player's camera becomes active,
+    /// updates them when the player's name changes, and destroys them
+    /// when the camera deactivates or the player disconnects.
+    /// </summary>
+    public static class BasisCameraNamePlateDriver
+    {
+        /// <summary>
+        /// The Y-offset (in world space) above the PIP camera where the nameplate is positioned.
+        /// </summary>
+        public static float NamePlateYOffset = 0.22f;
+
+        /// <summary>
+        /// Scale multiplier for the nameplate size relative to the PIP camera size.
+        /// </summary>
+        public static float NamePlateScale = 1.0f;
+
+        /// <summary>
+        /// Whether nameplates are enabled for PIP cameras.
+        /// </summary>
+        public static bool NamePlateEnabled = true;
+
+        /// <summary>
+        /// Whether the driver has been initialized.
+        /// </summary>
+        private static bool _initialized;
+
+        /// <summary>
+        /// Registry of active nameplates keyed by player ID.
+        /// </summary>
+        private static readonly Dictionary<ushort, BasisCameraNamePlate> activePlates = new();
+        private static readonly Dictionary<ushort, int> activePlateIndices = new();
+        private static readonly List<BasisCameraNamePlate> activePlateList = new();
+
+        // ===========================
+        // Lifecycle
+        // ===========================
+
+        /// <summary>
+        /// Idempotent. Triggered by <see cref="Basis.Scripts.Device_Management.BasisDeviceManagement"/>
+        /// after device init completes. Subscribes to PIP camera events.
+        /// </summary>
+        public static void Initialize()
+        {
+            if (_initialized) return;
+            _initialized = true;
+
+            BasisNetworkPIPCameraDriver.OnRemotePIPCreated += OnRemotePIPCreated;
+            BasisNetworkPIPCameraDriver.OnRemotePIPDestroyed += OnRemotePIPDestroyed;
+        }
+
+        /// <summary>
+        /// Shutdown the driver. Unsubscribes from events and destroys all nameplates.
+        /// </summary>
+        public static void Shutdown()
+        {
+            if (!_initialized) return;
+            _initialized = false;
+
+            BasisNetworkPIPCameraDriver.OnRemotePIPCreated -= OnRemotePIPCreated;
+            BasisNetworkPIPCameraDriver.OnRemotePIPDestroyed -= OnRemotePIPDestroyed;
+
+            foreach (var kvp in activePlates)
+            {
+                if (kvp.Value != null && kvp.Value.gameObject != null)
+                    UnityEngine.Object.Destroy(kvp.Value.gameObject);
+            }
+            activePlates.Clear();
+            activePlateIndices.Clear();
+            activePlateList.Clear();
+        }
+
+        // ===========================
+        // Registration
+        // ===========================
+
+        public static void Register(BasisCameraNamePlate plate)
+        {
+            if (plate == null || plate.PlayerID == 0) return;
+            if (activePlates.TryGetValue(plate.PlayerID, out BasisCameraNamePlate existing))
+            {
+                if (ReferenceEquals(existing, plate))
+                {
+                    return;
+                }
+                if (existing != null)
+                {
+                    existing.OnPlayerLeft();
+                }
+            }
+
+            activePlates[plate.PlayerID] = plate;
+            activePlateIndices[plate.PlayerID] = activePlateList.Count;
+            activePlateList.Add(plate);
+        }
+
+        public static void Unregister(BasisCameraNamePlate plate)
+        {
+            if (plate == null || plate.PlayerID == 0) return;
+            if (!activePlates.TryGetValue(plate.PlayerID, out BasisCameraNamePlate registered)) return;
+            if (!ReferenceEquals(registered, plate)) return;
+
+            activePlates.Remove(plate.PlayerID);
+
+            if (!activePlateIndices.TryGetValue(plate.PlayerID, out int index)) return;
+
+            int lastIndex = activePlateList.Count - 1;
+            BasisCameraNamePlate last = activePlateList[lastIndex];
+            activePlateList[index] = last;
+            activePlateList.RemoveAt(lastIndex);
+            activePlateIndices.Remove(plate.PlayerID);
+
+            if (index != lastIndex && last != null)
+            {
+                activePlateIndices[last.PlayerID] = index;
+            }
+        }
+
+        // ===========================
+        // Per-player operations
+        // ===========================
+
+        /// <summary>
+        /// Create a nameplate for a PIP camera when its camera becomes active.
+        /// </summary>
+        public static bool ShouldPlateBeActive(BasisCameraNamePlate plate)
+        {
+            if (!NamePlateEnabled) return false;
+            if (!BasisRemoteNamePlateDriver.NamePlateEnabled) return false;
+            if (BasisRemoteNamePlateDriver.NamePlateMenuOnly && BasisMainMenu.Instance == null) return false;
+            if (!plate.IsActive) return false;
+            if (plate.RemotePlayer != null && plate.RemotePlayer.IsEffectivelyBlocked) return false;
+            return true;
+        }
+
+        public static void CreateForPlayer(ushort playerId, string displayName)
+        {
+            CreateForPlayer(playerId, displayName, null);
+        }
+
+        public static void CreateForPlayer(ushort playerId, string displayName, BasisRemotePlayer remotePlayer)
+        {
+            if (playerId == 0) return;
+            if (activePlates.ContainsKey(playerId)) return;
+
+            GameObject plateGO = new GameObject($"CameraNamePlate_{playerId}");
+            plateGO.transform.SetParent(BasisDeviceManagement.Instance.transform, false);
+            plateGO.transform.SetLocalPositionAndRotation(Vector3.zero, Quaternion.identity);
+
+            var plate = plateGO.AddComponent<BasisCameraNamePlate>();
+            plate.Initialize(playerId, displayName, null, remotePlayer);
+        }
+
+        /// <summary>
+        /// Destroy the nameplate for a player's camera (camera deactivated or player left).
+        /// </summary>
+        public static void DestroyForPlayer(ushort playerId)
+        {
+            if (activePlates.TryGetValue(playerId, out var plate) && plate != null)
+            {
+                plate.OnPlayerLeft();
+            }
+        }
+
+        /// <summary>
+        /// Update the display name for an existing nameplate.
+        /// </summary>
+        public static void UpdateDisplayName(ushort playerId, string newName)
+        {
+            if (activePlates.TryGetValue(playerId, out var plate) && plate != null)
+            {
+                plate.UpdateDisplayName(newName);
+            }
+        }
+
+        /// <summary>
+        /// Activate or deactivate a nameplate (camera toggled on/off).
+        /// </summary>
+        public static void SetPlateActive(ushort playerId, bool active)
+        {
+            if (activePlates.TryGetValue(playerId, out var plate) && plate != null)
+            {
+                plate.SetActive(active);
+            }
+        }
+
+        // ===========================
+        // Per-frame updates
+        // ===========================
+
+        /// <summary>
+        /// Called from BasisEventDriver per-frame to update all nameplate positions
+        /// and refresh meshes for plates whose names have changed.
+        /// </summary>
+        public static void UpdateAllPlatePositions()
+        {
+            for (int index = activePlateList.Count - 1; index >= 0; index--)
+            {
+                BasisCameraNamePlate plate = activePlateList[index];
+                if (plate == null)
+                {
+                    continue;
+                }
+
+                plate.RefreshActiveState();
+                RefreshPlayerMetadata(plate);
+                plate.RefreshMeshIfNeeded();
+
+                if (ShouldPlateBeActive(plate))
+                {
+                    UpdatePlatePosition(plate);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Refresh meshes for all plates that need it.
+        /// Call when names change.
+        /// </summary>
+        public static void RefreshAllMeshes()
+        {
+            for (int index = 0; index < activePlateList.Count; index++)
+            {
+                BasisCameraNamePlate plate = activePlateList[index];
+                if (plate != null)
+                {
+                    plate.RefreshMeshIfNeeded();
+                }
+            }
+        }
+
+        public static void ApplyNamePlateSettingsFromUI()
+        {
+            for (int index = 0; index < activePlateList.Count; index++)
+            {
+                BasisCameraNamePlate plate = activePlateList[index];
+                if (plate == null) continue;
+
+                plate.ApplyScale();
+                plate.RefreshActiveState();
+            }
+        }
+
+        // ===========================
+        // Positioning
+        // ===========================
+
+        private static void UpdatePlatePosition(ushort playerId)
+        {
+            if (!activePlates.TryGetValue(playerId, out var plate) || plate == null) return;
+
+            UpdatePlatePosition(plate);
+        }
+
+        private static void UpdatePlatePosition(BasisCameraNamePlate plate)
+        {
+            ushort playerId = plate.PlayerID;
+            if (BasisNetworkPIPCameraDriver.TryGetPIPPosition(playerId, out Vector3 pipPos))
+            {
+                Vector3 position = pipPos + (Vector3.up * NamePlateYOffset);
+                float3 toCam = (float3)(BasisLocalCameraDriver.Position - position);
+                float2 xz = new float2(toCam.x, toCam.z);
+                float yaw = math.lengthsq(xz) > 1e-12f ? math.atan2(xz.x, xz.y) : 0f;
+                quaternion billboardRotation = quaternion.RotateY(yaw);
+                Quaternion rotation = new Quaternion(
+                    billboardRotation.value.x,
+                    billboardRotation.value.y,
+                    billboardRotation.value.z,
+                    billboardRotation.value.w
+                );
+
+                plate.transform.SetPositionAndRotation(position, rotation);
+            }
+        }
+
+        private static void RefreshPlayerMetadata(BasisCameraNamePlate plate)
+        {
+            if (plate.RemotePlayer != null && !string.IsNullOrEmpty(plate.RemotePlayer.DisplayName))
+            {
+                if (plate.DisplayName != plate.RemotePlayer.DisplayName)
+                {
+                    plate.UpdateDisplayName(plate.RemotePlayer.DisplayName);
+                }
+                return;
+            }
+
+            if (!BasisNetworkPlayer.GetPlayerById(plate.PlayerID, out var networkPlayer) || networkPlayer == null)
+            {
+                return;
+            }
+
+            if (!networkPlayer.TryGetPlayer(out var player) || player == null)
+            {
+                return;
+            }
+
+            if (player is BasisRemotePlayer remotePlayer)
+            {
+                plate.RemotePlayer = remotePlayer;
+            }
+
+            if (!string.IsNullOrEmpty(player.DisplayName) && plate.DisplayName != player.DisplayName)
+            {
+                plate.UpdateDisplayName(player.DisplayName);
+            }
+        }
+
+        // ===========================
+        // Event handlers
+        // ===========================
+
+        private static void OnRemotePIPCreated(ushort playerId, float3 position, UnityEngine.Quaternion rotation)
+        {
+            if (BasisNetworkPlayer.GetPlayerById(playerId, out var networkPlayer) && networkPlayer != null)
+            {
+                networkPlayer.TryGetPlayer(out var player);
+                string displayName = player != null ? player.DisplayName : $"Player {playerId}";
+                CreateForPlayer(playerId, displayName, player as BasisRemotePlayer);
+            }
+            else
+            {
+                CreateForPlayer(playerId, $"Player {playerId}");
+            }
+        }
+
+        private static void OnRemotePIPDestroyed(ushort playerId)
+        {
+            DestroyForPlayer(playerId);
+        }
+    }
+}

--- a/Basis/Packages/com.basis.framework/UI/NamePlate/BasisCameraNamePlateDriver.cs.meta
+++ b/Basis/Packages/com.basis.framework/UI/NamePlate/BasisCameraNamePlateDriver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6290423486d61ab4db3361c6150a0531

--- a/Basis/Packages/com.basis.framework/UI/NamePlate/BasisNamePlateAssets.cs
+++ b/Basis/Packages/com.basis.framework/UI/NamePlate/BasisNamePlateAssets.cs
@@ -1,0 +1,175 @@
+using Basis.Scripts.Device_Management;
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+using UnityEngine.AddressableAssets;
+
+namespace Basis.Scripts.UI.NamePlate
+{
+    public static class BasisNamePlateAssets
+    {
+        public static Material TransparentMaterial { get; private set; }
+        public static Material OpaqueMaterial { get; private set; }
+        public static Material SelectedMaterial { get; private set; }
+        public static TextMeshPro TextBaker { get; private set; }
+
+        private const string TransparentMaterialAddress = "Packages/com.basis.sdk/Materials/TransParentNamePlateMaterial.mat";
+        private const string OpaqueMaterialAddress = "Packages/com.basis.sdk/Materials/OpaqueNamePlateMaterial.mat";
+        private const string FontAddress = "Packages/com.basis.sdk/Fonts/Poppins-Regular SDF NamePlate.asset";
+        private const float DefaultBakeFontSize = 72f;
+
+        private static bool initialized;
+        private static bool unicodeFallbacksEnsured;
+        private static HashSet<string> installedFontNamesLower;
+
+        public static void Initialize()
+        {
+            if (initialized)
+            {
+                EnsureBakerParent();
+                return;
+            }
+
+            if (TransparentMaterial == null)
+            {
+                TransparentMaterial = Addressables.LoadAssetAsync<Material>(TransparentMaterialAddress).WaitForCompletion();
+            }
+            if (OpaqueMaterial == null)
+            {
+                OpaqueMaterial = Addressables.LoadAssetAsync<Material>(OpaqueMaterialAddress).WaitForCompletion();
+            }
+
+            SelectedMaterial = BasisDeviceManagement.IsMobileHardware()
+                ? OpaqueMaterial
+                : TransparentMaterial;
+
+            if (TextBaker == null)
+            {
+                TMP_FontAsset font = Addressables.LoadAssetAsync<TMP_FontAsset>(FontAddress).WaitForCompletion();
+
+                GameObject bakingGO = new GameObject("BasisNameplateBaker");
+                if (BasisDeviceManagement.Instance != null)
+                {
+                    bakingGO.transform.SetParent(BasisDeviceManagement.Instance.transform, false);
+                }
+                bakingGO.SetActive(false);
+
+                TextBaker = bakingGO.AddComponent<TextMeshPro>();
+                TextBaker.font = font;
+                TextBaker.fontSize = DefaultBakeFontSize;
+                TextBaker.enableAutoSizing = false;
+                TextBaker.alignment = TextAlignmentOptions.Center;
+                TextBaker.color = Color.white;
+                TextBaker.enableVertexGradient = false;
+                TextBaker.textWrappingMode = TextWrappingModes.NoWrap;
+                TextBaker.overflowMode = TextOverflowModes.Overflow;
+            }
+
+            EnsureUnicodeFallbacksOnNameplateFont();
+            EnsureBakerParent();
+            initialized = true;
+        }
+
+        private static void EnsureBakerParent()
+        {
+            if (TextBaker == null || BasisDeviceManagement.Instance == null) return;
+            Transform bakerTransform = TextBaker.transform;
+            Transform deviceTransform = BasisDeviceManagement.Instance.transform;
+            if (bakerTransform.parent != deviceTransform)
+            {
+                bakerTransform.SetParent(deviceTransform, false);
+            }
+        }
+
+        private static void EnsureUnicodeFallbacksOnNameplateFont()
+        {
+            if (unicodeFallbacksEnsured) return;
+            unicodeFallbacksEnsured = true;
+
+            if (TextBaker == null || TextBaker.font == null) return;
+
+            TMP_FontAsset primary = TextBaker.font;
+            if (primary.fallbackFontAssetTable == null)
+            {
+                primary.fallbackFontAssetTable = new List<TMP_FontAsset>();
+            }
+
+            HashSet<string> registered = new HashSet<string>();
+            string[][] scriptCandidates =
+            {
+                new[] { "Yu Gothic UI", "Yu Gothic", "Meiryo UI", "Meiryo", "MS Gothic", "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Noto Sans CJK JP", "Noto Sans JP", "Source Han Sans JP", "TakaoGothic" },
+                new[] { "Malgun Gothic", "Gulim", "Dotum", "Batang", "Apple SD Gothic Neo", "AppleGothic", "Noto Sans CJK KR", "Noto Sans KR", "NanumGothic" },
+                new[] { "Microsoft YaHei UI", "Microsoft YaHei", "SimHei", "SimSun", "PingFang SC", "Hiragino Sans GB", "STHeiti", "Noto Sans CJK SC", "Noto Sans SC", "Source Han Sans SC", "WenQuanYi Micro Hei" },
+                new[] { "Microsoft JhengHei UI", "Microsoft JhengHei", "PMingLiU", "MingLiU", "PingFang TC", "Heiti TC", "Noto Sans CJK TC", "Noto Sans TC" },
+                new[] { "Tahoma", "Segoe UI", "Geeza Pro", "Damascus", "Noto Sans Arabic", "Noto Naskh Arabic", "DejaVu Sans" },
+                new[] { "Leelawadee UI", "Leelawadee", "Thonburi", "Sukhumvit Set", "Noto Sans Thai", "Loma" },
+                new[] { "David CLM", "Arial Hebrew", "Tahoma", "Segoe UI", "Lucida Grande", "Noto Sans Hebrew", "DejaVu Sans" },
+                new[] { "Nirmala UI", "Mangal", "Devanagari MT", "Kohinoor Devanagari", "Noto Sans Devanagari", "Lohit Devanagari" },
+            };
+
+            foreach (string[] candidates in scriptCandidates)
+            {
+                AddFirstAvailableFallback(primary, candidates, registered);
+            }
+        }
+
+        private static void AddFirstAvailableFallback(TMP_FontAsset primary, string[] candidates, HashSet<string> registered)
+        {
+            foreach (string family in candidates)
+            {
+                if (registered.Contains(family)) return;
+                if (!IsFontInstalled(family)) continue;
+
+                TMP_FontAsset fallback = null;
+                try
+                {
+                    fallback = TMP_FontAsset.CreateFontAsset(family, "Regular");
+                }
+                catch
+                {
+                    continue;
+                }
+
+                if (fallback == null) continue;
+
+                fallback.name = "NamePlate Fallback (" + family + ")";
+                primary.fallbackFontAssetTable.Add(fallback);
+                registered.Add(family);
+                return;
+            }
+        }
+
+        private static bool IsFontInstalled(string family)
+        {
+            if (installedFontNamesLower == null)
+            {
+                HashSet<string> set = new HashSet<string>();
+                try
+                {
+                    string[] names = Font.GetOSInstalledFontNames();
+                    if (names != null)
+                    {
+                        foreach (string name in names)
+                        {
+                            if (!string.IsNullOrEmpty(name)) set.Add(name.ToLowerInvariant());
+                        }
+                    }
+                }
+                catch
+                {
+                }
+                installedFontNamesLower = set;
+            }
+
+            if (installedFontNamesLower.Count == 0) return true;
+            string normalized = family.ToLowerInvariant();
+            if (installedFontNamesLower.Contains(normalized)) return true;
+
+            foreach (string installedName in installedFontNamesLower)
+            {
+                if (installedName.StartsWith(normalized)) return true;
+            }
+            return false;
+        }
+    }
+}

--- a/Basis/Packages/com.basis.framework/UI/NamePlate/BasisNamePlateAssets.cs
+++ b/Basis/Packages/com.basis.framework/UI/NamePlate/BasisNamePlateAssets.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
+using UnityEngine.ResourceManagement.AsyncOperations;
 
 namespace Basis.Scripts.UI.NamePlate
 {
@@ -12,6 +13,7 @@ namespace Basis.Scripts.UI.NamePlate
         public static Material OpaqueMaterial { get; private set; }
         public static Material SelectedMaterial { get; private set; }
         public static TextMeshPro TextBaker { get; private set; }
+        public static bool IsReady => TextBaker != null && SelectedMaterial != null;
 
         private const string TransparentMaterialAddress = "Packages/com.basis.sdk/Materials/TransParentNamePlateMaterial.mat";
         private const string OpaqueMaterialAddress = "Packages/com.basis.sdk/Materials/OpaqueNamePlateMaterial.mat";
@@ -32,42 +34,68 @@ namespace Basis.Scripts.UI.NamePlate
 
             if (TransparentMaterial == null)
             {
-                TransparentMaterial = Addressables.LoadAssetAsync<Material>(TransparentMaterialAddress).WaitForCompletion();
+                Addressables.LoadAssetAsync<Material>(TransparentMaterialAddress).Completed += OnTransparentMaterialLoaded;
             }
             if (OpaqueMaterial == null)
             {
-                OpaqueMaterial = Addressables.LoadAssetAsync<Material>(OpaqueMaterialAddress).WaitForCompletion();
+                Addressables.LoadAssetAsync<Material>(OpaqueMaterialAddress).Completed += OnOpaqueMaterialLoaded;
             }
 
-            SelectedMaterial = BasisDeviceManagement.IsMobileHardware()
-                ? OpaqueMaterial
-                : TransparentMaterial;
+            UpdateSelectedMaterial();
 
             if (TextBaker == null)
             {
-                TMP_FontAsset font = Addressables.LoadAssetAsync<TMP_FontAsset>(FontAddress).WaitForCompletion();
-
-                GameObject bakingGO = new GameObject("BasisNameplateBaker");
-                if (BasisDeviceManagement.Instance != null)
-                {
-                    bakingGO.transform.SetParent(BasisDeviceManagement.Instance.transform, false);
-                }
-                bakingGO.SetActive(false);
-
-                TextBaker = bakingGO.AddComponent<TextMeshPro>();
-                TextBaker.font = font;
-                TextBaker.fontSize = DefaultBakeFontSize;
-                TextBaker.enableAutoSizing = false;
-                TextBaker.alignment = TextAlignmentOptions.Center;
-                TextBaker.color = Color.white;
-                TextBaker.enableVertexGradient = false;
-                TextBaker.textWrappingMode = TextWrappingModes.NoWrap;
-                TextBaker.overflowMode = TextOverflowModes.Overflow;
+                Addressables.LoadAssetAsync<TMP_FontAsset>(FontAddress).Completed += OnFontLoaded;
             }
 
-            EnsureUnicodeFallbacksOnNameplateFont();
             EnsureBakerParent();
             initialized = true;
+        }
+
+        private static void OnTransparentMaterialLoaded(AsyncOperationHandle<Material> handle)
+        {
+            if (handle.Status == AsyncOperationStatus.Succeeded)
+            {
+                TransparentMaterial = handle.Result;
+                UpdateSelectedMaterial();
+            }
+        }
+
+        private static void OnOpaqueMaterialLoaded(AsyncOperationHandle<Material> handle)
+        {
+            if (handle.Status == AsyncOperationStatus.Succeeded)
+            {
+                OpaqueMaterial = handle.Result;
+                UpdateSelectedMaterial();
+            }
+        }
+
+        private static void OnFontLoaded(AsyncOperationHandle<TMP_FontAsset> handle)
+        {
+            if (handle.Status != AsyncOperationStatus.Succeeded || handle.Result == null) return;
+            if (TextBaker != null) return;
+
+            GameObject bakingGO = new GameObject("BasisNameplateBaker");
+            TextBaker = bakingGO.AddComponent<TextMeshPro>();
+            TextBaker.font = handle.Result;
+            TextBaker.fontSize = DefaultBakeFontSize;
+            TextBaker.enableAutoSizing = false;
+            TextBaker.alignment = TextAlignmentOptions.Center;
+            TextBaker.color = Color.white;
+            TextBaker.enableVertexGradient = false;
+            TextBaker.textWrappingMode = TextWrappingModes.NoWrap;
+            TextBaker.overflowMode = TextOverflowModes.Overflow;
+
+            EnsureBakerParent();
+            bakingGO.SetActive(false);
+            EnsureUnicodeFallbacksOnNameplateFont();
+        }
+
+        private static void UpdateSelectedMaterial()
+        {
+            SelectedMaterial = BasisDeviceManagement.IsMobileHardware()
+                ? OpaqueMaterial
+                : TransparentMaterial;
         }
 
         private static void EnsureBakerParent()
@@ -117,7 +145,7 @@ namespace Basis.Scripts.UI.NamePlate
         {
             foreach (string family in candidates)
             {
-                if (registered.Contains(family)) return;
+                if (registered.Contains(family)) continue;
                 if (!IsFontInstalled(family)) continue;
 
                 TMP_FontAsset fallback = null;

--- a/Basis/Packages/com.basis.framework/UI/NamePlate/BasisNamePlateAssets.cs
+++ b/Basis/Packages/com.basis.framework/UI/NamePlate/BasisNamePlateAssets.cs
@@ -9,10 +9,10 @@ namespace Basis.Scripts.UI.NamePlate
 {
     public static class BasisNamePlateAssets
     {
-        public static Material TransparentMaterial { get; private set; }
-        public static Material OpaqueMaterial { get; private set; }
-        public static Material SelectedMaterial { get; private set; }
-        public static TextMeshPro TextBaker { get; private set; }
+        public static Material TransparentMaterial;
+        public static Material OpaqueMaterial;
+        public static Material SelectedMaterial;
+        public static TextMeshPro TextBaker;
         public static bool IsReady => TextBaker != null && SelectedMaterial != null;
 
         private const string TransparentMaterialAddress = "Packages/com.basis.sdk/Materials/TransParentNamePlateMaterial.mat";

--- a/Basis/Packages/com.basis.framework/UI/NamePlate/BasisNamePlateAssets.cs.meta
+++ b/Basis/Packages/com.basis.framework/UI/NamePlate/BasisNamePlateAssets.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5dbe8a9471ef4c13a4a9f6d8a4f01458
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Basis/Packages/com.basis.framework/UI/NamePlate/BasisNamePlateMeshBaker.cs
+++ b/Basis/Packages/com.basis.framework/UI/NamePlate/BasisNamePlateMeshBaker.cs
@@ -17,10 +17,44 @@ namespace Basis.Scripts.UI.NamePlate
 
     public static class BasisNamePlateMeshBaker
     {
-        public static int MaxBakesPerFrame = 2;
-        public static float MaxPlateHalfWidth = 40f;
-        public static float RoundEdges = 0.85f;
-        public static int CornerVertexCount = 8;
+        private static int maxBakesPerFrame = 2;
+        private static float maxPlateHalfWidth = 40f;
+        private static float roundEdges = 0.85f;
+        private static int cornerVertexCount = 8;
+
+        public static int MaxBakesPerFrame
+        {
+            get => maxBakesPerFrame;
+            set => maxBakesPerFrame = Mathf.Max(1, value);
+        }
+
+        public static float MaxPlateHalfWidth
+        {
+            get => maxPlateHalfWidth;
+            set => maxPlateHalfWidth = Mathf.Max(0.001f, value);
+        }
+
+        public static float RoundEdges
+        {
+            get => roundEdges;
+            set => roundEdges = Mathf.Clamp01(value);
+        }
+
+        public static int CornerVertexCount
+        {
+            get => cornerVertexCount;
+            set
+            {
+                int clamped = Mathf.Max(3, value);
+                if (cornerVertexCount == clamped) return;
+                cornerVertexCount = clamped;
+                if (initialized)
+                {
+                    PrecomputeCornerData();
+                }
+            }
+        }
+
         public static float zOffset = 0.06f;
 
         private const float BakeFontSize = 72f;
@@ -57,6 +91,7 @@ namespace Basis.Scripts.UI.NamePlate
         public static void ProcessBakeQueue()
         {
             Initialize();
+            if (!BasisNamePlateAssets.IsReady) return;
 
             int budget = MaxBakesPerFrame;
             while (budget > 0 && bakeQueue.Count > 0)
@@ -73,6 +108,8 @@ namespace Basis.Scripts.UI.NamePlate
         public static Mesh BakeNow(string displayName, MeshFilter filter, MeshRenderer renderer, string meshName)
         {
             Initialize();
+            if (!BasisNamePlateAssets.IsReady) return null;
+
             TextMeshPro text = BasisNamePlateAssets.TextBaker;
             if (text == null || filter == null || renderer == null) return null;
 

--- a/Basis/Packages/com.basis.framework/UI/NamePlate/BasisNamePlateMeshBaker.cs
+++ b/Basis/Packages/com.basis.framework/UI/NamePlate/BasisNamePlateMeshBaker.cs
@@ -1,0 +1,232 @@
+using System.Collections.Generic;
+using TMPro;
+using Unity.Mathematics;
+using UnityEngine;
+
+namespace Basis.Scripts.UI.NamePlate
+{
+    public interface IBasisNamePlateBakeTarget
+    {
+        string DisplayName { get; }
+        MeshFilter MeshFilter { get; }
+        MeshRenderer MeshRenderer { get; }
+        string MeshName { get; }
+        bool IsBakeTargetValid { get; }
+        void OnBakeCompleted(Mesh mesh);
+    }
+
+    public static class BasisNamePlateMeshBaker
+    {
+        public static int MaxBakesPerFrame = 2;
+        public static float MaxPlateHalfWidth = 40f;
+        public static float RoundEdges = 0.85f;
+        public static int CornerVertexCount = 8;
+        public static float zOffset = 0.06f;
+
+        private const float BakeFontSize = 72f;
+        private static readonly Matrix4x4 FlipX = Matrix4x4.Scale(new Vector3(-1f, 1f, 1f));
+        private static readonly Queue<IBasisNamePlateBakeTarget> bakeQueue = new Queue<IBasisNamePlateBakeTarget>(64);
+
+        private static bool initialized;
+        private static int cachedCornerCount;
+        private static float[] sinTable;
+        private static float[] cosTable;
+        private static int[] cachedTriangles;
+        private static int cachedRingVertexCount;
+        private static int cachedVertexCount;
+        private static Vector3[] workVertices;
+        private static Vector3[] workNormals;
+        private static Vector2[] workUVs;
+
+        public static void Initialize()
+        {
+            if (initialized) return;
+            initialized = true;
+
+            BasisNamePlateAssets.Initialize();
+            PrecomputeCornerData();
+        }
+
+        public static void QueueBake(IBasisNamePlateBakeTarget target)
+        {
+            if (target == null || !target.IsBakeTargetValid) return;
+            Initialize();
+            bakeQueue.Enqueue(target);
+        }
+
+        public static void ProcessBakeQueue()
+        {
+            Initialize();
+
+            int budget = MaxBakesPerFrame;
+            while (budget > 0 && bakeQueue.Count > 0)
+            {
+                IBasisNamePlateBakeTarget target = bakeQueue.Dequeue();
+                if (target == null || !target.IsBakeTargetValid) continue;
+
+                Mesh mesh = BakeNow(target.DisplayName, target.MeshFilter, target.MeshRenderer, target.MeshName);
+                target.OnBakeCompleted(mesh);
+                budget--;
+            }
+        }
+
+        public static Mesh BakeNow(string displayName, MeshFilter filter, MeshRenderer renderer, string meshName)
+        {
+            Initialize();
+            TextMeshPro text = BasisNamePlateAssets.TextBaker;
+            if (text == null || filter == null || renderer == null) return null;
+
+            text.gameObject.SetActive(true);
+            text.fontSize = BakeFontSize;
+            text.text = displayName;
+            text.ForceMeshUpdate();
+
+            const float horizontalPadding = 2f;
+            Vector2 textSize = text.GetRenderedValues(true);
+            float halfWidth = (textSize.x * 0.5f) + horizontalPadding;
+
+            if (halfWidth > MaxPlateHalfWidth && textSize.x > 0.001f)
+            {
+                float maxTextWidth = (MaxPlateHalfWidth - horizontalPadding) * 2f;
+                text.fontSize = BakeFontSize * (maxTextWidth / textSize.x);
+                text.ForceMeshUpdate();
+                textSize = text.GetRenderedValues(true);
+                halfWidth = (textSize.x * 0.5f) + horizontalPadding;
+            }
+
+            Mesh plateMesh = GenerateRoundedQuad(halfWidth, 4.5f, "Rounded NamePlate Quad");
+
+            TMP_TextInfo textInfo = text.textInfo;
+            int subMeshLimit = 0;
+            int textPartCount = 0;
+            if (textInfo != null && textInfo.meshInfo != null)
+            {
+                subMeshLimit = math.min(textInfo.materialCount, textInfo.meshInfo.Length);
+                for (int i = 0; i < subMeshLimit; i++)
+                {
+                    if (textInfo.meshInfo[i].vertexCount > 0)
+                    {
+                        textPartCount++;
+                    }
+                }
+            }
+
+            int totalParts = 1 + textPartCount;
+            CombineInstance[] combine = new CombineInstance[totalParts];
+            Material[] materials = new Material[totalParts];
+
+            combine[0] = new CombineInstance { mesh = plateMesh, transform = Matrix4x4.identity };
+            materials[0] = BasisNamePlateAssets.SelectedMaterial;
+
+            int writeIdx = 1;
+            for (int i = 0; i < subMeshLimit; i++)
+            {
+                TMP_MeshInfo info = textInfo.meshInfo[i];
+                if (info.vertexCount == 0 || info.mesh == null) continue;
+
+                combine[writeIdx] = new CombineInstance { mesh = info.mesh, transform = FlipX };
+                materials[writeIdx] = info.material;
+                writeIdx++;
+            }
+
+            Mesh combinedMesh = new Mesh { name = meshName };
+            combinedMesh.CombineMeshes(combine, false);
+
+            filter.sharedMesh = combinedMesh;
+            renderer.sharedMaterials = materials;
+
+            Object.Destroy(plateMesh);
+            text.gameObject.SetActive(false);
+            return combinedMesh;
+        }
+
+        public static Mesh GenerateRoundedQuad(float halfWidth, float halfHeight, string meshName)
+        {
+            Initialize();
+
+            float width = halfWidth * 2f;
+            float height = halfHeight * 2f;
+            float maxRadius = Mathf.Min(halfWidth, halfHeight);
+            float radius = Mathf.Clamp01(RoundEdges) * maxRadius;
+
+            Vector2 uvOffset = new Vector2(0.5f, 0.5f);
+            Vector2 uvScale = new Vector2(1f / width, 1f / height);
+
+            workVertices[0] = new Vector3(0, 0, zOffset);
+            workUVs[0] = uvOffset;
+
+            for (int ci = 0; ci < cachedCornerCount; ci++)
+            {
+                float sin = sinTable[ci];
+                float cos = cosTable[ci];
+
+                float oneMinusCos = 1f - cos;
+                float oneMinusSin = 1f - sin;
+
+                Vector2 tl = new Vector2(-halfWidth + oneMinusCos * radius, halfHeight - oneMinusSin * radius);
+                Vector2 tr = new Vector2(halfWidth - oneMinusSin * radius, halfHeight - oneMinusCos * radius);
+                Vector2 br = new Vector2(halfWidth - oneMinusCos * radius, -halfHeight + oneMinusSin * radius);
+                Vector2 bl = new Vector2(-halfWidth + oneMinusSin * radius, -halfHeight + oneMinusCos * radius);
+
+                int idx1 = 1 + ci;
+                int idx2 = idx1 + cachedCornerCount;
+                int idx3 = idx2 + cachedCornerCount;
+                int idx4 = idx3 + cachedCornerCount;
+
+                workVertices[idx1] = new Vector3(tl.x, tl.y, zOffset);
+                workVertices[idx2] = new Vector3(tr.x, tr.y, zOffset);
+                workVertices[idx3] = new Vector3(br.x, br.y, zOffset);
+                workVertices[idx4] = new Vector3(bl.x, bl.y, zOffset);
+
+                workUVs[idx1] = tl * uvScale + uvOffset;
+                workUVs[idx2] = tr * uvScale + uvOffset;
+                workUVs[idx3] = br * uvScale + uvOffset;
+                workUVs[idx4] = bl * uvScale + uvOffset;
+            }
+
+            return new Mesh
+            {
+                name = meshName,
+                vertices = workVertices,
+                normals = workNormals,
+                uv = workUVs,
+                triangles = cachedTriangles
+            };
+        }
+
+        private static void PrecomputeCornerData()
+        {
+            cachedCornerCount = Mathf.Max(3, CornerVertexCount);
+            cachedRingVertexCount = cachedCornerCount * 4;
+            cachedVertexCount = cachedRingVertexCount + 1;
+
+            float angleStep = Mathf.PI * 0.5f / (cachedCornerCount - 1);
+            sinTable = new float[cachedCornerCount];
+            cosTable = new float[cachedCornerCount];
+            for (int ci = 0; ci < cachedCornerCount; ci++)
+            {
+                float angle = ci * angleStep;
+                sinTable[ci] = Mathf.Sin(angle);
+                cosTable[ci] = Mathf.Cos(angle);
+            }
+
+            cachedTriangles = new int[cachedRingVertexCount * 3];
+            for (int i = 0; i < cachedRingVertexCount; i++)
+            {
+                int tri = i * 3;
+                cachedTriangles[tri] = 0;
+                cachedTriangles[tri + 1] = 1 + ((i + 1) % cachedRingVertexCount);
+                cachedTriangles[tri + 2] = 1 + i;
+            }
+
+            workVertices = new Vector3[cachedVertexCount];
+            workNormals = new Vector3[cachedVertexCount];
+            workUVs = new Vector2[cachedVertexCount];
+
+            for (int i = 0; i < cachedVertexCount; i++)
+            {
+                workNormals[i] = Vector3.forward;
+            }
+        }
+    }
+}

--- a/Basis/Packages/com.basis.framework/UI/NamePlate/BasisNamePlateMeshBaker.cs.meta
+++ b/Basis/Packages/com.basis.framework/UI/NamePlate/BasisNamePlateMeshBaker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d05639b3e5a640f9a6fd27847f6c64d0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Basis/Packages/com.basis.framework/UI/NamePlate/BasisNamePlateSettings.cs
+++ b/Basis/Packages/com.basis.framework/UI/NamePlate/BasisNamePlateSettings.cs
@@ -1,0 +1,24 @@
+using Basis.BasisUI;
+
+namespace Basis.Scripts.UI.NamePlate
+{
+    public static class BasisNamePlateSettings
+    {
+        public static bool NamePlateEnabled = true;
+        public static bool NamePlateMenuOnly;
+        public static bool NamePlateHoverMenuOnly;
+        public static float NamePlateSize = 1f;
+        public static float NamePlateTransparency = 0.45f;
+        public static float ChatSize = 1f;
+
+        public static void RefreshFromDefaults()
+        {
+            NamePlateEnabled = BasisSettingsDefaults.NPEnabled.RawValue;
+            NamePlateMenuOnly = BasisSettingsDefaults.NPMenuOnly.RawValue;
+            NamePlateHoverMenuOnly = BasisSettingsDefaults.NPHoverMenuOnly.RawValue;
+            NamePlateSize = BasisSettingsDefaults.NPSize.RawValue;
+            NamePlateTransparency = BasisSettingsDefaults.NPTransparency.RawValue;
+            ChatSize = BasisSettingsDefaults.ChatSize.RawValue;
+        }
+    }
+}

--- a/Basis/Packages/com.basis.framework/UI/NamePlate/BasisNamePlateSettings.cs.meta
+++ b/Basis/Packages/com.basis.framework/UI/NamePlate/BasisNamePlateSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b60470e5233843c68e85f41cdb361a2a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Basis/Packages/com.basis.framework/UI/NamePlate/BasisNamePlateVisual.cs
+++ b/Basis/Packages/com.basis.framework/UI/NamePlate/BasisNamePlateVisual.cs
@@ -45,7 +45,6 @@ namespace Basis.Scripts.UI.NamePlate
         public void RefreshMeshNowIfNeeded()
         {
             if (!needsMeshUpdate) return;
-            needsMeshUpdate = false;
             bakeQueued = false;
             Mesh mesh = BasisNamePlateMeshBaker.BakeNow(displayName, MeshFilter, MeshRenderer, meshName);
             OnBakeCompleted(mesh);
@@ -53,6 +52,7 @@ namespace Basis.Scripts.UI.NamePlate
 
         public void OnBakeCompleted(Mesh mesh)
         {
+            if (mesh == null) return;
             bakeQueued = false;
             needsMeshUpdate = false;
             if (generatedMesh != null && generatedMesh != mesh)

--- a/Basis/Packages/com.basis.framework/UI/NamePlate/BasisNamePlateVisual.cs
+++ b/Basis/Packages/com.basis.framework/UI/NamePlate/BasisNamePlateVisual.cs
@@ -1,0 +1,93 @@
+using UnityEngine;
+
+namespace Basis.Scripts.UI.NamePlate
+{
+    public sealed class BasisNamePlateVisual : IBasisNamePlateBakeTarget
+    {
+        private readonly string meshName;
+        private Mesh generatedMesh;
+        private string displayName;
+        private bool needsMeshUpdate;
+        private bool bakeQueued;
+
+        public MeshFilter MeshFilter { get; private set; }
+        public MeshRenderer MeshRenderer { get; private set; }
+        public string DisplayName => displayName;
+        public string MeshName => meshName;
+        public bool IsBakeTargetValid => MeshFilter != null && MeshRenderer != null;
+
+        public BasisNamePlateVisual(string meshName)
+        {
+            this.meshName = meshName;
+        }
+
+        public void Attach(MeshFilter filter, MeshRenderer renderer)
+        {
+            MeshFilter = filter;
+            MeshRenderer = renderer;
+            ConfigureRenderer(renderer);
+        }
+
+        public void SetDisplayName(string newName)
+        {
+            if (displayName == newName) return;
+            displayName = newName;
+            needsMeshUpdate = true;
+        }
+
+        public void QueueMeshRefreshIfNeeded()
+        {
+            if (!needsMeshUpdate || bakeQueued) return;
+            bakeQueued = true;
+            BasisNamePlateMeshBaker.QueueBake(this);
+        }
+
+        public void RefreshMeshNowIfNeeded()
+        {
+            if (!needsMeshUpdate) return;
+            needsMeshUpdate = false;
+            bakeQueued = false;
+            Mesh mesh = BasisNamePlateMeshBaker.BakeNow(displayName, MeshFilter, MeshRenderer, meshName);
+            OnBakeCompleted(mesh);
+        }
+
+        public void OnBakeCompleted(Mesh mesh)
+        {
+            bakeQueued = false;
+            needsMeshUpdate = false;
+            if (generatedMesh != null && generatedMesh != mesh)
+            {
+                Object.Destroy(generatedMesh);
+            }
+            generatedMesh = mesh;
+        }
+
+        public void ApplyMaterial()
+        {
+            if (MeshRenderer != null && BasisNamePlateAssets.SelectedMaterial != null)
+            {
+                MeshRenderer.sharedMaterial = BasisNamePlateAssets.SelectedMaterial;
+            }
+        }
+
+        public void Dispose()
+        {
+            if (generatedMesh != null)
+            {
+                Object.Destroy(generatedMesh);
+                generatedMesh = null;
+            }
+        }
+
+        private static void ConfigureRenderer(MeshRenderer renderer)
+        {
+            if (renderer == null) return;
+
+            BasisNamePlateAssets.Initialize();
+            renderer.sharedMaterial = BasisNamePlateAssets.SelectedMaterial;
+            renderer.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+            renderer.receiveShadows = false;
+            renderer.lightProbeUsage = UnityEngine.Rendering.LightProbeUsage.Off;
+        }
+    }
+}

--- a/Basis/Packages/com.basis.framework/UI/NamePlate/BasisNamePlateVisual.cs.meta
+++ b/Basis/Packages/com.basis.framework/UI/NamePlate/BasisNamePlateVisual.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2d6a16f8f24546a587408f1dcbd17760
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Basis/Packages/com.basis.framework/UI/NamePlate/BasisRemoteNamePlateDriver.cs
+++ b/Basis/Packages/com.basis.framework/UI/NamePlate/BasisRemoteNamePlateDriver.cs
@@ -450,6 +450,7 @@ namespace Basis.Scripts.UI.NamePlate
             }
 
             SetAllPlateVisibility();
+            BasisCameraNamePlateDriver.ApplyNamePlateSettingsFromUI();
         }
 
         // ===========================
@@ -491,9 +492,16 @@ namespace Basis.Scripts.UI.NamePlate
 
         public static void GenerateTextFactory(BasisRemotePlayer remotePlayer, BasisRemoteNamePlate namePlate)
         {
+            GenerateTextFactory(remotePlayer.DisplayName, namePlate.Filter, namePlate.Renderer, "CombinedNameplateMesh");
+        }
+
+        public static void GenerateTextFactory(string displayName, MeshFilter filter, MeshRenderer renderer, string meshName)
+        {
+            if (Text == null || filter == null || renderer == null) return;
+
             Text.gameObject.SetActive(true);
             Text.fontSize = BakeFontSize;
-            Text.text = remotePlayer.DisplayName;
+            Text.text = displayName;
             Text.ForceMeshUpdate();
 
             const float horizontalPadding = 2f;
@@ -545,11 +553,11 @@ namespace Basis.Scripts.UI.NamePlate
                 writeIdx++;
             }
 
-            Mesh combinedMesh = new Mesh { name = CombinedNameplateMeshName };
+            Mesh combinedMesh = new Mesh { name = meshName };
             combinedMesh.CombineMeshes(combine, false);
 
-            namePlate.Filter.sharedMesh = combinedMesh;
-            namePlate.Renderer.sharedMaterials = materials;
+            filter.sharedMesh = combinedMesh;
+            renderer.sharedMaterials = materials;
 
             Object.Destroy(plateMesh);
             Text.gameObject.SetActive(false);

--- a/Basis/Packages/com.basis.framework/UI/NamePlate/BasisRemoteNamePlateDriver.cs
+++ b/Basis/Packages/com.basis.framework/UI/NamePlate/BasisRemoteNamePlateDriver.cs
@@ -57,10 +57,10 @@ namespace Basis.Scripts.UI.NamePlate
         public static TextMeshPro Text;
 
         // Lazy-loaded from Addressables on first Initialize.
-        public static Material TransParentNamePlateMaterial;
-        public static Material OpaqueNamePlateMaterial;
+        public static Material TransParentNamePlateMaterial => BasisNamePlateAssets.TransparentMaterial;
+        public static Material OpaqueNamePlateMaterial => BasisNamePlateAssets.OpaqueMaterial;
 
-        public static Material SelectedNamePlateMaterial;
+        public static Material SelectedNamePlateMaterial => BasisNamePlateAssets.SelectedMaterial;
 
         public static float RoundEdges = 0.85f;
         public static int CornerVertexCount = 8;
@@ -105,8 +105,6 @@ namespace Basis.Scripts.UI.NamePlate
             BasisNamePlateMeshBaker.Initialize();
             EnsureAssetsLoaded();
 
-            SelectedNamePlateMaterial = BasisNamePlateAssets.SelectedMaterial;
-
             NamePlateEnabled = BasisSettingsDefaults.NPEnabled.RawValue;
             NamePlateMenuOnly = BasisSettingsDefaults.NPMenuOnly.RawValue;
             NamePlateHoverMenuOnly = BasisSettingsDefaults.NPHoverMenuOnly.RawValue;
@@ -126,8 +124,6 @@ namespace Basis.Scripts.UI.NamePlate
         private static void EnsureAssetsLoaded()
         {
             BasisNamePlateAssets.Initialize();
-            TransParentNamePlateMaterial = BasisNamePlateAssets.TransparentMaterial;
-            OpaqueNamePlateMaterial = BasisNamePlateAssets.OpaqueMaterial;
             Text = BasisNamePlateAssets.TextBaker;
         }
 
@@ -441,7 +437,8 @@ namespace Basis.Scripts.UI.NamePlate
 
         private static void ProcessBakeQueue()
         {
-            if (Text == null) return;
+            Text = BasisNamePlateAssets.TextBaker;
+            if (!BasisNamePlateAssets.IsReady) return;
 
             int budget = MaxBakesPerFrame;
             while (budget > 0 && bakeQueue.Count > 0)

--- a/Basis/Packages/com.basis.framework/UI/NamePlate/BasisRemoteNamePlateDriver.cs
+++ b/Basis/Packages/com.basis.framework/UI/NamePlate/BasisRemoteNamePlateDriver.cs
@@ -10,7 +10,6 @@ using Unity.Collections.LowLevel.Unsafe;
 using Unity.Jobs;
 using Unity.Mathematics;
 using UnityEngine;
-using UnityEngine.AddressableAssets;
 
 namespace Basis.Scripts.UI.NamePlate
 {
@@ -63,11 +62,6 @@ namespace Basis.Scripts.UI.NamePlate
 
         public static Material SelectedNamePlateMaterial;
 
-        // Addressables keys for the materials/font that used to be serialized on the prefab.
-        private const string TransparentMaterialAddress = "Packages/com.basis.sdk/Materials/TransParentNamePlateMaterial.mat";
-        private const string OpaqueMaterialAddress = "Packages/com.basis.sdk/Materials/OpaqueNamePlateMaterial.mat";
-        private const string FontAddress = "Packages/com.basis.sdk/Fonts/Poppins-Regular SDF NamePlate.asset";
-
         public static float RoundEdges = 0.85f;
         public static int CornerVertexCount = 8;
         public static float zOffset = 0.06f;
@@ -83,20 +77,19 @@ namespace Basis.Scripts.UI.NamePlate
         private static bool lastMenuOpenState;
         private static bool _initialized;
 
-        // Precomputed per CornerVertexCount
+        // Legacy rounded-quad cache kept for compatibility helpers that are no longer
+        // called during normal nameplate baking.
         private static int cachedCornerCount;
         private static float[] sinTable;
         private static float[] cosTable;
         private static int[] cachedTriangles;
         private static int cachedRingVertexCount;
         private static int cachedVertexCount;
-
-        // Reusable working arrays (avoid per-call managed allocation)
         private static Vector3[] workVertices;
         private static Vector3[] workNormals;
         private static Vector2[] workUVs;
-
         private static bool _unicodeFallbacksEnsured;
+        private static HashSet<string> _installedFontNamesLower;
 
         /// <summary>
         /// Idempotent. Triggered by <see cref="Basis.Scripts.Device_Management.BasisDeviceManagement"/>
@@ -108,11 +101,11 @@ namespace Basis.Scripts.UI.NamePlate
             if (_initialized) return;
             _initialized = true;
 
+            BasisNamePlateAssets.Initialize();
+            BasisNamePlateMeshBaker.Initialize();
             EnsureAssetsLoaded();
 
-            SelectedNamePlateMaterial = BasisDeviceManagement.IsMobileHardware()
-                ? OpaqueNamePlateMaterial
-                : TransParentNamePlateMaterial;
+            SelectedNamePlateMaterial = BasisNamePlateAssets.SelectedMaterial;
 
             NamePlateEnabled = BasisSettingsDefaults.NPEnabled.RawValue;
             NamePlateMenuOnly = BasisSettingsDefaults.NPMenuOnly.RawValue;
@@ -123,8 +116,6 @@ namespace Basis.Scripts.UI.NamePlate
             lastMenuOpenState = BasisMainMenu.Instance != null;
 
             UpdateCachedColors(NamePlateTransparency);
-            PrecomputeCornerData();
-            EnsureUnicodeFallbacksOnNameplateFont();
         }
 
         /// <summary>
@@ -134,32 +125,10 @@ namespace Basis.Scripts.UI.NamePlate
         /// </summary>
         private static void EnsureAssetsLoaded()
         {
-            if (TransParentNamePlateMaterial == null)
-            {
-                TransParentNamePlateMaterial = Addressables.LoadAssetAsync<Material>(TransparentMaterialAddress).WaitForCompletion();
-            }
-            if (OpaqueNamePlateMaterial == null)
-            {
-                OpaqueNamePlateMaterial = Addressables.LoadAssetAsync<Material>(OpaqueMaterialAddress).WaitForCompletion();
-            }
-            if (Text == null)
-            {
-                var font = Addressables.LoadAssetAsync<TMP_FontAsset>(FontAddress).WaitForCompletion();
-
-                var bakingGO = new GameObject("BasisNameplateBaker");
-                bakingGO.transform.SetParent(BasisDeviceManagement.Instance.transform, false);
-                bakingGO.SetActive(false);
-
-                Text = bakingGO.AddComponent<TextMeshPro>();
-                Text.font = font;
-                Text.fontSize = BakeFontSize;
-                Text.enableAutoSizing = false;
-                Text.alignment = TextAlignmentOptions.Center;
-                Text.color = Color.white;
-                Text.enableVertexGradient = false;
-                Text.textWrappingMode = TextWrappingModes.NoWrap;
-                Text.overflowMode = TextOverflowModes.Overflow;
-            }
+            BasisNamePlateAssets.Initialize();
+            TransParentNamePlateMaterial = BasisNamePlateAssets.TransparentMaterial;
+            OpaqueNamePlateMaterial = BasisNamePlateAssets.OpaqueMaterial;
+            Text = BasisNamePlateAssets.TextBaker;
         }
 
         /// <summary>
@@ -259,8 +228,6 @@ namespace Basis.Scripts.UI.NamePlate
                 return;
             }
         }
-
-        private static HashSet<string> _installedFontNamesLower;
 
         private static bool IsFontInstalled(string family)
         {
@@ -450,7 +417,6 @@ namespace Basis.Scripts.UI.NamePlate
             }
 
             SetAllPlateVisibility();
-            BasisCameraNamePlateDriver.ApplyNamePlateSettingsFromUI();
         }
 
         // ===========================
@@ -466,9 +432,6 @@ namespace Basis.Scripts.UI.NamePlate
         private static readonly Queue<BakeRequest> bakeQueue = new(64);
         public static int MaxBakesPerFrame = 2;
         public static float MaxPlateHalfWidth = 40f;
-        private const float BakeFontSize = 72f;
-
-        private static readonly Matrix4x4 FlipX = Matrix4x4.Scale(new Vector3(-1f, 1f, 1f));
 
         public static void QueueTextBake(BasisRemotePlayer remotePlayer, BasisRemoteNamePlate namePlate)
         {
@@ -497,70 +460,7 @@ namespace Basis.Scripts.UI.NamePlate
 
         public static void GenerateTextFactory(string displayName, MeshFilter filter, MeshRenderer renderer, string meshName)
         {
-            if (Text == null || filter == null || renderer == null) return;
-
-            Text.gameObject.SetActive(true);
-            Text.fontSize = BakeFontSize;
-            Text.text = displayName;
-            Text.ForceMeshUpdate();
-
-            const float horizontalPadding = 2f;
-            Vector2 textSize = Text.GetRenderedValues(true);
-            float halfWidth = (textSize.x * 0.5f) + horizontalPadding;
-
-            float textScale = 1f;
-            if (halfWidth > MaxPlateHalfWidth && textSize.x > 0.001f)
-            {
-                float maxTextWidth = (MaxPlateHalfWidth - horizontalPadding) * 2f;
-                textScale = maxTextWidth / textSize.x;
-                halfWidth = MaxPlateHalfWidth;
-            }
-
-            Matrix4x4 textTransform = textScale == 1f
-                ? FlipX
-                : Matrix4x4.Scale(new Vector3(-textScale, textScale, 1f));
-
-            Mesh plateMesh = GenerateRoundedQuad(halfWidth, 4.5f, "Rounded NamePlate Quad");
-
-            var textInfo = Text.textInfo;
-            int subMeshLimit = 0;
-            int textPartCount = 0;
-            if (textInfo != null && textInfo.meshInfo != null)
-            {
-                subMeshLimit = math.min(textInfo.materialCount, textInfo.meshInfo.Length);
-                for (int i = 0; i < subMeshLimit; i++)
-                {
-                    if (textInfo.meshInfo[i].vertexCount > 0)
-                        textPartCount++;
-                }
-            }
-
-            int totalParts = 1 + textPartCount;
-            var combine = new CombineInstance[totalParts];
-            var materials = new Material[totalParts];
-
-            combine[0] = new CombineInstance { mesh = plateMesh, transform = Matrix4x4.identity };
-            materials[0] = SelectedNamePlateMaterial;
-
-            int writeIdx = 1;
-            for (int i = 0; i < subMeshLimit; i++)
-            {
-                var info = textInfo.meshInfo[i];
-                if (info.vertexCount == 0 || info.mesh == null) continue;
-
-                combine[writeIdx] = new CombineInstance { mesh = info.mesh, transform = textTransform };
-                materials[writeIdx] = info.material;
-                writeIdx++;
-            }
-
-            Mesh combinedMesh = new Mesh { name = meshName };
-            combinedMesh.CombineMeshes(combine, false);
-
-            filter.sharedMesh = combinedMesh;
-            renderer.sharedMaterials = materials;
-
-            Object.Destroy(plateMesh);
-            Text.gameObject.SetActive(false);
+            BasisNamePlateMeshBaker.BakeNow(displayName, filter, renderer, meshName);
         }
 
         /// <summary>
@@ -570,55 +470,10 @@ namespace Basis.Scripts.UI.NamePlate
         /// </summary>
         public static Mesh GenerateRoundedQuad(float halfWidth, float halfHeight, string meshName)
         {
-            float width = halfWidth * 2f;
-            float height = halfHeight * 2f;
-
-            float maxRadius = Mathf.Min(halfWidth, halfHeight);
-            float radius = Mathf.Clamp01(RoundEdges) * maxRadius;
-
-            Vector2 uvOffset = new Vector2(0.5f, 0.5f);
-            Vector2 uvScale = new Vector2(1f / width, 1f / height);
-
-            workVertices[0] = new Vector3(0, 0, zOffset);
-            workUVs[0] = uvOffset;
-
-            for (int ci = 0; ci < cachedCornerCount; ci++)
-            {
-                float sin = sinTable[ci];
-                float cos = cosTable[ci];
-
-                float oneMinusCos = 1f - cos;
-                float oneMinusSin = 1f - sin;
-
-                Vector2 tl = new Vector2(-halfWidth + oneMinusCos * radius, halfHeight - oneMinusSin * radius);
-                Vector2 tr = new Vector2(halfWidth - oneMinusSin * radius, halfHeight - oneMinusCos * radius);
-                Vector2 br = new Vector2(halfWidth - oneMinusCos * radius, -halfHeight + oneMinusSin * radius);
-                Vector2 bl = new Vector2(-halfWidth + oneMinusSin * radius, -halfHeight + oneMinusCos * radius);
-
-                int idx1 = 1 + ci;
-                int idx2 = idx1 + cachedCornerCount;
-                int idx3 = idx2 + cachedCornerCount;
-                int idx4 = idx3 + cachedCornerCount;
-
-                workVertices[idx1] = new Vector3(tl.x, tl.y, zOffset);
-                workVertices[idx2] = new Vector3(tr.x, tr.y, zOffset);
-                workVertices[idx3] = new Vector3(br.x, br.y, zOffset);
-                workVertices[idx4] = new Vector3(bl.x, bl.y, zOffset);
-
-                workUVs[idx1] = tl * uvScale + uvOffset;
-                workUVs[idx2] = tr * uvScale + uvOffset;
-                workUVs[idx3] = br * uvScale + uvOffset;
-                workUVs[idx4] = bl * uvScale + uvOffset;
-            }
-
-            return new Mesh
-            {
-                name = meshName,
-                vertices = workVertices,
-                normals = workNormals,
-                uv = workUVs,
-                triangles = cachedTriangles
-            };
+            BasisNamePlateMeshBaker.RoundEdges = RoundEdges;
+            BasisNamePlateMeshBaker.CornerVertexCount = CornerVertexCount;
+            BasisNamePlateMeshBaker.zOffset = zOffset;
+            return BasisNamePlateMeshBaker.GenerateRoundedQuad(halfWidth, halfHeight, meshName);
         }
 
         // ===========================

--- a/Basis/Packages/com.basis.framework/UI/NamePlate/BasisRemoteNamePlateDriver.cs
+++ b/Basis/Packages/com.basis.framework/UI/NamePlate/BasisRemoteNamePlateDriver.cs
@@ -105,12 +105,8 @@ namespace Basis.Scripts.UI.NamePlate
             BasisNamePlateMeshBaker.Initialize();
             EnsureAssetsLoaded();
 
-            NamePlateEnabled = BasisSettingsDefaults.NPEnabled.RawValue;
-            NamePlateMenuOnly = BasisSettingsDefaults.NPMenuOnly.RawValue;
-            NamePlateHoverMenuOnly = BasisSettingsDefaults.NPHoverMenuOnly.RawValue;
-            NamePlateSize = BasisSettingsDefaults.NPSize.RawValue;
-            NamePlateTransparency = BasisSettingsDefaults.NPTransparency.RawValue;
-            ChatSize = BasisSettingsDefaults.ChatSize.RawValue;
+            BasisNamePlateSettings.RefreshFromDefaults();
+            SyncSharedSettingsFromNamePlateSettings();
             lastMenuOpenState = BasisMainMenu.Instance != null;
 
             UpdateCachedColors(NamePlateTransparency);
@@ -302,6 +298,25 @@ namespace Basis.Scripts.UI.NamePlate
             }
         }
 
+        private static void SyncSharedSettingsFromNamePlateSettings()
+        {
+            NamePlateEnabled = BasisNamePlateSettings.NamePlateEnabled;
+            NamePlateMenuOnly = BasisNamePlateSettings.NamePlateMenuOnly;
+            NamePlateHoverMenuOnly = BasisNamePlateSettings.NamePlateHoverMenuOnly;
+            NamePlateSize = BasisNamePlateSettings.NamePlateSize;
+            NamePlateTransparency = BasisNamePlateSettings.NamePlateTransparency;
+            ChatSize = BasisNamePlateSettings.ChatSize;
+        }
+
+        private static void SyncSharedBakerSettings()
+        {
+            BasisNamePlateMeshBaker.MaxBakesPerFrame = MaxBakesPerFrame;
+            BasisNamePlateMeshBaker.MaxPlateHalfWidth = MaxPlateHalfWidth;
+            BasisNamePlateMeshBaker.RoundEdges = RoundEdges;
+            BasisNamePlateMeshBaker.CornerVertexCount = CornerVertexCount;
+            BasisNamePlateMeshBaker.zOffset = zOffset;
+        }
+
         /// <summary>
         /// Precomputes sin/cos lookup table, triangle indices, normals,
         /// and allocates working arrays. Only needs to run when CornerVertexCount changes.
@@ -378,24 +393,14 @@ namespace Basis.Scripts.UI.NamePlate
         /// </summary>
         public static void ApplyNamePlateSettingsFromUI()
         {
-            bool enabled = BasisSettingsDefaults.NPEnabled.RawValue;
-            bool menuOnly = BasisSettingsDefaults.NPMenuOnly.RawValue;
-            bool hoverMenuOnly = BasisSettingsDefaults.NPHoverMenuOnly.RawValue;
-            float newSize = BasisSettingsDefaults.NPSize.RawValue;
-            float newTransparency = BasisSettingsDefaults.NPTransparency.RawValue;
+            BasisNamePlateSettings.RefreshFromDefaults();
+            SyncSharedSettingsFromNamePlateSettings();
 
-            NamePlateEnabled = enabled;
-            NamePlateMenuOnly = menuOnly;
-            NamePlateHoverMenuOnly = hoverMenuOnly;
-            NamePlateSize = newSize;
-            NamePlateTransparency = newTransparency;
-            ChatSize = BasisSettingsDefaults.ChatSize.RawValue;
-
-            UpdateCachedColors(newTransparency);
+            UpdateCachedColors(NamePlateTransparency);
 
             FlushPendingStructuralChanges();
 
-            Vector3 scale = new Vector3(0.02f, 0.02f, 0.02f) * newSize;
+            Vector3 scale = new Vector3(0.02f, 0.02f, 0.02f) * NamePlateSize;
             var arr = plates;
             int n = count;
             for (int i = 0; i < n; i++)
@@ -439,6 +444,7 @@ namespace Basis.Scripts.UI.NamePlate
         {
             Text = BasisNamePlateAssets.TextBaker;
             if (!BasisNamePlateAssets.IsReady) return;
+            SyncSharedBakerSettings();
 
             int budget = MaxBakesPerFrame;
             while (budget > 0 && bakeQueue.Count > 0)
@@ -457,6 +463,7 @@ namespace Basis.Scripts.UI.NamePlate
 
         public static void GenerateTextFactory(string displayName, MeshFilter filter, MeshRenderer renderer, string meshName)
         {
+            SyncSharedBakerSettings();
             BasisNamePlateMeshBaker.BakeNow(displayName, filter, renderer, meshName);
         }
 
@@ -467,9 +474,7 @@ namespace Basis.Scripts.UI.NamePlate
         /// </summary>
         public static Mesh GenerateRoundedQuad(float halfWidth, float halfHeight, string meshName)
         {
-            BasisNamePlateMeshBaker.RoundEdges = RoundEdges;
-            BasisNamePlateMeshBaker.CornerVertexCount = CornerVertexCount;
-            BasisNamePlateMeshBaker.zOffset = zOffset;
+            SyncSharedBakerSettings();
             return BasisNamePlateMeshBaker.GenerateRoundedQuad(halfWidth, halfHeight, meshName);
         }
 


### PR DESCRIPTION
## Summary
* To help users to know which camera belongs to who, reused many of the parts from the remote player nameplates.
<img width="435" height="513" alt="Unity_2026-06-05_22-10-51" src="https://github.com/user-attachments/assets/0077dce3-1018-4497-9d7a-f0b2374868b7" />

* Refactored Nameplates to be more modular, and not hard depend on remotenameplates.
** Need to refactor https://github.com/BasisVR/Basis/pull/836, to work on the modular system
## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [x] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — `BasisEventDriver` runs the single per-frame tick that drives the whole framework (network apply, local player sim, blendshapes, JigglePhysics, nameplates, and more) as one sequential chain. An unhandled exception anywhere in that chain aborts the rest of the tick, so every step after the throwing one is silently skipped for that frame. New work added to the driver must either be guaranteed not to throw, or be wrapped in a `try`/`catch` that contains the failure and surfaces it through `BasisDebug` — logged once / rate-limited, never every frame (see the existing `HVRBasisBuiltInAddresses.Simulate()` guard for the pattern). Expect this to be scrutinized closely in review.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [ ] Windows
- [ ] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [ ] Tested in VR (note headset under **Notes**)
- [ ] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [ ] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [ ] N/A — change does not touch any of the above

## Notes
<!-- Optional context for reviewers. Headset model, why a required box is N/A, anything else worth knowing. -->
