### PR TITLE
Pip nameplate fixes

### DIFF
--- a/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/IndividualPlayerProvider.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/IndividualPlayerProvider.cs
@@ -143,6 +143,9 @@ namespace Basis.BasisUI
                 player.OnChatMessageReceived?.Invoke(string.Empty);
             }
             player.OnNamePlateActiveStateShouldRefresh?.Invoke();
+#if !UNITY_SERVER
+            BasisNetworkPIPCameraDriver.RefreshPipNamePlateVisibilityFromPlayerState();
+#endif
 
             // Mirror the block onto the other side so they also can't see/hear us
             // (session-scoped temp block).

--- a/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/SettingsProviderNamePlate.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/SettingsProviderNamePlate.cs
@@ -97,7 +97,9 @@ namespace Basis.BasisUI
         public static void ApplyNamePlateSettings()
         {
             BasisRemoteNamePlateDriver.ApplyNamePlateSettingsFromUI();
+#if !UNITY_SERVER
             BasisNetworkPIPCameraDriver.ApplyPipNamePlateSettingsFromUI();
+#endif        
         }
     }
 }

--- a/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/SettingsProviderNamePlate.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/SettingsProviderNamePlate.cs
@@ -97,6 +97,7 @@ namespace Basis.BasisUI
         public static void ApplyNamePlateSettings()
         {
             BasisRemoteNamePlateDriver.ApplyNamePlateSettingsFromUI();
+            BasisNetworkPIPCameraDriver.ApplyPipNamePlateSettingsFromUI();
         }
     }
 }

--- a/Basis/Packages/com.basis.framework/Networking/BasisNetworkLifeCycle.cs
+++ b/Basis/Packages/com.basis.framework/Networking/BasisNetworkLifeCycle.cs
@@ -77,6 +77,9 @@ public static class BasisNetworkLifeCycle
             }
 
             BasisRemoteNetworkDriver.Apply();//complete in-flight jobs before clearing players
+#if !UNITY_SERVER
+            BasisNetworkPIPCameraDriver.ClearRemotePIPs();
+#endif
             BasisNetworkPlayers.ClearAllRegistries();//remove players
             Basis.Scripts.Networking.Receivers.BasisShoutAudioDriver.DeInitialize();//remove shout audio sources
             await BasisNetworkSpawnItem.Reset();//remove items

--- a/Basis/Packages/com.basis.framework/Networking/BasisNetworkPIPCameraDriver.cs
+++ b/Basis/Packages/com.basis.framework/Networking/BasisNetworkPIPCameraDriver.cs
@@ -1,4 +1,5 @@
 using Basis.Network.Core;
+using Basis.BasisUI;
 using Basis.Scripts.BasisSdk.Players;
 using Basis.Scripts.Device_Management;
 using Basis.Scripts.Drivers;
@@ -71,7 +72,8 @@ public static class BasisNetworkPIPCameraDriver
 
     private const float NamePlateScale = 0.015f;
     private const float NamePlateMargin = 0.04f;
-    private const float NamePlateHalfHeight = 4.5f * NamePlateScale;
+    private const float NamePlateMeshHalfHeight = 4.5f;
+    private const string NamePlateLayerName = "UI";
 
     private const int InitialCapacity = 16;
     private const float LerpSpeed = 12f;
@@ -82,6 +84,8 @@ public static class BasisNetworkPIPCameraDriver
     private const int SimulatePriority = 203;
 
     private static bool initialized;
+    private static bool lastPipMenuOpenState;
+    private static float nextDisplayNameRefreshTime;
 
     /// <summary>
     /// Initialize native containers and subscribe to the simulation loop.
@@ -104,6 +108,7 @@ public static class BasisNetworkPIPCameraDriver
         loadedPrefab = prefabHandle.WaitForCompletion();
 
         BasisLocalPlayer.AfterSimulateOnLate.AddAction(SimulatePriority, Simulate);
+        lastPipMenuOpenState = BasisMainMenu.Instance != null;
         initialized = true;
     }
 
@@ -119,31 +124,7 @@ public static class BasisNetworkPIPCameraDriver
 
         pipHandle.Complete();
 
-        // Destroy owner-name tags (baked mesh + GameObject)
-        foreach (var kvp in pipNamePlates)
-        {
-            RemotePipNamePlate plate = kvp.Value;
-            if (plate == null) continue;
-            if (plate.Filter != null && plate.Filter.sharedMesh != null)
-            {
-                UnityEngine.Object.Destroy(plate.Filter.sharedMesh);
-            }
-            if (plate.Root != null)
-            {
-                UnityEngine.Object.Destroy(plate.Root);
-            }
-        }
-        pipNamePlates.Clear();
-
-        // Destroy all spawned PIP instances
-        foreach (var kvp in pipInstances)
-        {
-            if (kvp.Value != null)
-            {
-                UnityEngine.Object.Destroy(kvp.Value);
-            }
-        }
-        pipInstances.Clear();
+        ClearRemotePIPsInternal();
 
         // Release the loaded prefab
         if (prefabHandle.IsValid())
@@ -167,6 +148,52 @@ public static class BasisNetworkPIPCameraDriver
         initialized = false;
     }
 
+    public static void ClearRemotePIPs()
+    {
+        if (!initialized) return;
+
+        pipHandle.Complete();
+        ClearRemotePIPsInternal();
+    }
+
+    public static void ApplyPipNamePlateSettingsFromUI()
+    {
+        if (!initialized) return;
+
+        pipHandle.Complete();
+
+        float scale = GetNamePlateScale();
+        foreach (var kvp in pipNamePlates)
+        {
+            RemotePipNamePlate plate = kvp.Value;
+            if (plate == null || plate.Root == null) continue;
+
+            plate.Root.transform.localScale = new Vector3(scale, scale, scale);
+        }
+
+        for (int i = 0; i < denseToPlayerId.Count; i++)
+        {
+            ushort playerId = denseToPlayerId[i];
+            if (!pipInstances.TryGetValue(playerId, out GameObject instance) || instance == null)
+            {
+                continue;
+            }
+
+            nameplateHeights[i] = ComputeNamePlateHeight(instance, instance.transform.position);
+        }
+
+        RefreshPipNamePlateVisibility();
+        EnqueueAllNameBakes();
+    }
+
+    public static void RefreshPipNamePlateVisibilityFromPlayerState()
+    {
+        if (!initialized) return;
+
+        pipHandle.Complete();
+        RefreshPipNamePlateVisibility();
+    }
+
     /// <summary>
     /// Per-frame simulation driven by BasisLocalPlayer.AfterSimulateOnLate.
     /// Smooths toward the latest network targets and writes the camera + nameplate
@@ -182,6 +209,8 @@ public static class BasisNetworkPIPCameraDriver
         if (count == 0) return;
 
         ProcessPendingNameBakes();
+        RefreshResolvedDisplayNames();
+        RefreshPipNamePlateVisibilityOnMenuTransition();
 
         Vector3 viewer = BasisLocalCameraDriver.Position;
 
@@ -438,8 +467,14 @@ public static class BasisNetworkPIPCameraDriver
         float height = ComputeNamePlateHeight(instance, pos);
 
         GameObject plateGo = new GameObject("OwnerNamePlate");
+        int layer = LayerMask.NameToLayer(NamePlateLayerName);
+        if (layer >= 0)
+        {
+            plateGo.layer = layer;
+        }
         UnityEngine.Object.DontDestroyOnLoad(plateGo);
-        plateGo.transform.localScale = new Vector3(NamePlateScale, NamePlateScale, NamePlateScale);
+        float scale = GetNamePlateScale();
+        plateGo.transform.localScale = new Vector3(scale, scale, scale);
         plateGo.transform.position = new Vector3(pos.x, pos.y + height, pos.z);
 
         MeshFilter filter = plateGo.AddComponent<MeshFilter>();
@@ -468,15 +503,8 @@ public static class BasisNetworkPIPCameraDriver
         };
         pipNamePlates[playerId] = plate;
 
-        if (TryResolveDisplayName(playerId, out string displayName) &&
-            BasisRemoteNamePlateDriver.BakeNameMesh(displayName, filter, renderer))
-        {
-            plate.Baked = true;
-        }
-        else
-        {
-            pendingNameBakes.Add(playerId);
-        }
+        EnqueueNameBake(playerId);
+        RefreshPipNamePlateVisibility(playerId, plate);
     }
 
     /// <summary>
@@ -538,7 +566,9 @@ public static class BasisNetworkPIPCameraDriver
     /// </summary>
     private static void ProcessPendingNameBakes()
     {
-        for (int i = pendingNameBakes.Count - 1; i >= 0; i--)
+        int budget = BasisRemoteNamePlateDriver.MaxBakesPerFrame;
+
+        for (int i = pendingNameBakes.Count - 1; i >= 0 && budget > 0; i--)
         {
             ushort playerId = pendingNameBakes[i];
             if (!pipNamePlates.TryGetValue(playerId, out RemotePipNamePlate plate) || plate.Baked)
@@ -548,12 +578,99 @@ public static class BasisNetworkPIPCameraDriver
             }
 
             if (TryResolveDisplayName(playerId, out string displayName) &&
-                BasisRemoteNamePlateDriver.BakeNameMesh(displayName, plate.Filter, plate.Renderer))
+                BakePipNamePlate(plate, displayName))
             {
+                plate.DisplayName = displayName;
                 plate.Baked = true;
                 pendingNameBakes.RemoveAt(i);
+                budget--;
             }
         }
+    }
+
+    private static void RefreshResolvedDisplayNames()
+    {
+        if (Time.unscaledTime < nextDisplayNameRefreshTime) return;
+        nextDisplayNameRefreshTime = Time.unscaledTime + 1f;
+
+        int budget = BasisRemoteNamePlateDriver.MaxBakesPerFrame;
+        foreach (var kvp in pipNamePlates)
+        {
+            if (budget <= 0) break;
+
+            ushort playerId = kvp.Key;
+            RemotePipNamePlate plate = kvp.Value;
+            if (plate == null || plate.Filter == null || plate.Renderer == null) continue;
+            if (!TryResolveDisplayName(playerId, out string displayName)) continue;
+            if (plate.DisplayName == displayName) continue;
+
+            if (BakePipNamePlate(plate, displayName))
+            {
+                plate.DisplayName = displayName;
+                plate.Baked = true;
+                budget--;
+            }
+        }
+    }
+
+    private static bool BakePipNamePlate(RemotePipNamePlate plate, string displayName)
+    {
+        if (plate == null || plate.Filter == null || plate.Renderer == null) return false;
+
+        if (plate.Filter.sharedMesh != null)
+        {
+            UnityEngine.Object.Destroy(plate.Filter.sharedMesh);
+            plate.Filter.sharedMesh = null;
+        }
+
+        return BasisRemoteNamePlateDriver.BakeNameMesh(displayName, plate.Filter, plate.Renderer);
+    }
+
+    private static void ClearRemotePIPsInternal()
+    {
+        foreach (var kvp in pipNamePlates)
+        {
+            RemotePipNamePlate plate = kvp.Value;
+            if (plate == null) continue;
+            if (plate.Filter != null && plate.Filter.sharedMesh != null)
+            {
+                UnityEngine.Object.Destroy(plate.Filter.sharedMesh);
+            }
+            if (plate.Root != null)
+            {
+                UnityEngine.Object.Destroy(plate.Root);
+            }
+        }
+        pipNamePlates.Clear();
+
+        foreach (var kvp in pipInstances)
+        {
+            if (kvp.Value != null)
+            {
+                UnityEngine.Object.Destroy(kvp.Value);
+            }
+        }
+        pipInstances.Clear();
+
+        currentPositions.Clear();
+        targetPositions.Clear();
+        currentRotations.Clear();
+        targetRotations.Clear();
+        nameplateHeights.Clear();
+
+        for (int i = cameraTransforms.length - 1; i >= 0; i--)
+        {
+            cameraTransforms.RemoveAtSwapBack(i);
+        }
+
+        for (int i = namePlateTransforms.length - 1; i >= 0; i--)
+        {
+            namePlateTransforms.RemoveAtSwapBack(i);
+        }
+
+        playerIdToIndex.Clear();
+        denseToPlayerId.Clear();
+        pendingNameBakes.Clear();
     }
 
     private static float ComputeNamePlateHeight(GameObject cameraInstance, Vector3 cameraPosition)
@@ -561,9 +678,19 @@ public static class BasisNetworkPIPCameraDriver
         if (TryGetModelWorldBounds(cameraInstance, out Bounds bounds))
         {
             float clearance = Vector3.Distance(bounds.center, cameraPosition) + bounds.extents.magnitude;
-            return clearance + NamePlateMargin + NamePlateHalfHeight;
+            return clearance + NamePlateMargin + GetNamePlateHalfHeight();
         }
         return 0.25f;
+    }
+
+    private static float GetNamePlateScale()
+    {
+        return NamePlateScale * BasisRemoteNamePlateDriver.NamePlateSize;
+    }
+
+    private static float GetNamePlateHalfHeight()
+    {
+        return NamePlateMeshHalfHeight * GetNamePlateScale();
     }
 
     private static bool TryGetModelWorldBounds(GameObject root, out Bounds bounds)
@@ -600,12 +727,92 @@ public static class BasisNetworkPIPCameraDriver
         return false;
     }
 
+    private static bool ShouldPipNamePlateBeActive(ushort playerId)
+    {
+        if (!BasisRemoteNamePlateDriver.NamePlateEnabled)
+        {
+            return false;
+        }
+
+        if (BasisRemoteNamePlateDriver.NamePlateMenuOnly && BasisMainMenu.Instance == null)
+        {
+            return false;
+        }
+
+        if (BasisNetworkPlayer.GetPlayerById(playerId, out BasisNetworkPlayer networkPlayer) &&
+            networkPlayer != null &&
+            networkPlayer.Player is BasisRemotePlayer remotePlayer &&
+            remotePlayer.IsEffectivelyBlocked)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static void RefreshPipNamePlateVisibility()
+    {
+        foreach (var kvp in pipNamePlates)
+        {
+            RefreshPipNamePlateVisibility(kvp.Key, kvp.Value);
+        }
+    }
+
+    private static void RefreshPipNamePlateVisibility(ushort playerId, RemotePipNamePlate plate)
+    {
+        if (plate == null || plate.Root == null) return;
+
+        bool active = ShouldPipNamePlateBeActive(playerId);
+        if (plate.Root.activeSelf != active)
+        {
+            plate.Root.SetActive(active);
+        }
+    }
+
+    private static void RefreshPipNamePlateVisibilityOnMenuTransition()
+    {
+        if (!BasisRemoteNamePlateDriver.NamePlateMenuOnly || !BasisRemoteNamePlateDriver.NamePlateEnabled)
+        {
+            return;
+        }
+
+        bool menuOpen = BasisMainMenu.Instance != null;
+        if (menuOpen == lastPipMenuOpenState)
+        {
+            return;
+        }
+
+        lastPipMenuOpenState = menuOpen;
+        RefreshPipNamePlateVisibility();
+    }
+
+    private static void EnqueueNameBake(ushort playerId)
+    {
+        if (!pendingNameBakes.Contains(playerId))
+        {
+            pendingNameBakes.Add(playerId);
+        }
+    }
+
+    private static void EnqueueAllNameBakes()
+    {
+        foreach (var kvp in pipNamePlates)
+        {
+            RemotePipNamePlate plate = kvp.Value;
+            if (plate == null) continue;
+
+            plate.Baked = false;
+            EnqueueNameBake(kvp.Key);
+        }
+    }
+
     private sealed class RemotePipNamePlate
     {
         public GameObject Root;
         public MeshFilter Filter;
         public MeshRenderer Renderer;
         public bool Baked;
+        public string DisplayName;
     }
 
     [BurstCompile(FloatMode = FloatMode.Fast)]

--- a/Basis/Packages/com.basis.framework/Networking/Handles/BasisNetworkHandleTempBlock.cs
+++ b/Basis/Packages/com.basis.framework/Networking/Handles/BasisNetworkHandleTempBlock.cs
@@ -102,6 +102,9 @@ public static class BasisNetworkHandleTempBlock
             remotePlayer.OnChatMessageReceived?.Invoke(string.Empty);
         }
         remotePlayer.OnNamePlateActiveStateShouldRefresh?.Invoke();
+#if !UNITY_SERVER
+        BasisNetworkPIPCameraDriver.RefreshPipNamePlateVisibilityFromPlayerState();
+#endif
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
* Updated PIP owner nameplates to respect normal nameplate visibility settings. And menu only showing.
* Hid PIP owner nameplates for blocked/temp-blocked remote players.
* Added PIP nameplate refresh when block/temp-block state changes.
* Added PIP nameplate settings application when nameplate settings are changed.
* Added remote PIP/nameplate cleanup during network reboot/session reset.
* Added budgeted PIP owner nameplate text baking using the normal remote nameplate bake budget.
* Added display-name refresh/rebake support for active PIP owner labels.
* Set spawned OwnerNamePlate objects to the `UI` layer when available.

## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [x] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — `BasisEventDriver` runs the single per-frame tick that drives the whole framework (network apply, local player sim, blendshapes, JigglePhysics, nameplates, and more) as one sequential chain. An unhandled exception anywhere in that chain aborts the rest of the tick, so every step after the throwing one is silently skipped for that frame. New work added to the driver must either be guaranteed not to throw, or be wrapped in a `try`/`catch` that contains the failure and surfaces it through `BasisDebug` — logged once / rate-limited, never every frame (see the existing `HVRBasisBuiltInAddresses.Simulate()` guard for the pattern). Expect this to be scrutinized closely in review.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [x] Windows
- [ ] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [ ] Tested in VR (note headset under **Notes**)
- [ ] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [ ] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [ ] N/A — change does not touch any of the above

## Notes
<!-- Optional context for reviewers. Headset model, why a required box is N/A, anything else worth knowing. -->
