### PR TITLE
feat(mediaplayer): add RIST live streaming with loss recovery + encryption

### DIFF
--- a/.github/workflows/media-native.yml
+++ b/.github/workflows/media-native.yml
@@ -1,0 +1,71 @@
+# Builds librist from source — the only third-party native dependency of the Media
+# Player's optional RIST transport (-DBASIS_WITH_RIST=ON). librist vendors its own
+# mbedTLS and links it into a single static archive, so each job produces one lib.
+# The statics are never committed; this workflow keeps the from-source build green
+# on every change under Native~/ and publishes the archives as downloadable artifacts.
+#
+# Scope is librist only, not the plugin binary: basis_media_native's real backends
+# include Unity's PluginAPI headers, which ship with the editor and aren't available
+# here, so the plugin (.dll/.so) is still built on a Unity-equipped machine. Both jobs
+# run the same build-librist scripts a developer runs locally — the recipe has one home.
+#
+# Note: workflow_dispatch only appears in the Actions UI once this file is on the
+# default branch; until then the pull_request trigger exercises it on PRs.
+name: media-native (RIST)
+
+on:
+  workflow_dispatch:
+    inputs:
+      librist_ref:
+        description: "librist git tag (must match what basis_rist.c targets)"
+        default: "v0.2.11"
+  push:
+    paths:
+      - "Basis/Packages/com.basis.mediaplayer/Native~/**"
+      - ".github/workflows/media-native.yml"
+  pull_request:
+    paths:
+      - "Basis/Packages/com.basis.mediaplayer/Native~/**"
+      - ".github/workflows/media-native.yml"
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  NATIVE_DIR: Basis/Packages/com.basis.mediaplayer/Native~
+  LIBRIST_REF: ${{ inputs.librist_ref || 'v0.2.11' }}
+
+jobs:
+  win-x64:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ilammy/msvc-dev-cmd@v1   # puts MSVC (vcvars) on PATH so meson uses cl
+        with:
+          arch: x64
+      - run: pip install meson ninja
+      - name: Build librist (static, /MD)
+        shell: pwsh
+        working-directory: ${{ env.NATIVE_DIR }}
+        run: ./build-librist.ps1 -LibristRef "$env:LIBRIST_REF"
+      - uses: actions/upload-artifact@v5
+        with:
+          name: librist-win-x64
+          path: ${{ env.NATIVE_DIR }}/third_party/win-x64/rist.lib
+
+  android-arm64:
+    runs-on: ubuntu-latest   # Android NDK is preinstalled ($ANDROID_NDK_ROOT)
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install meson + ninja
+        run: |
+          sudo apt-get update && sudo apt-get install -y ninja-build
+          pip install meson
+      - name: Build librist (NDK arm64, static)
+        working-directory: ${{ env.NATIVE_DIR }}
+        run: ./build-librist.sh android-arm64
+      - uses: actions/upload-artifact@v5
+        with:
+          name: librist-android-arm64
+          path: ${{ env.NATIVE_DIR }}/third_party/android-arm64/librist.a

--- a/Basis/Packages/com.basis.mediaplayer/.gitignore
+++ b/Basis/Packages/com.basis.mediaplayer/.gitignore
@@ -17,6 +17,14 @@ Native~/build-*/
 Native~/CMakeUserPresets.json
 Native~/CMakeCache.txt
 
+# librist statics + headers are built from source (build-librist.{ps1,sh}) into
+# third_party/, never committed. Keep the .gitkeep placeholders only.
+Native~/third_party/win-x64/*
+!Native~/third_party/win-x64/.gitkeep
+Native~/third_party/android-arm64/*
+!Native~/third_party/android-arm64/.gitkeep
+Native~/third_party/include/librist/
+
 # Unity PluginAPI headers copied locally for the native build (see unity/README.md).
 Native~/unity/IUnityInterface.h
 Native~/unity/IUnityGraphics.h

--- a/Basis/Packages/com.basis.mediaplayer/Native~/CMakeLists.txt
+++ b/Basis/Packages/com.basis.mediaplayer/Native~/CMakeLists.txt
@@ -56,6 +56,13 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 set(UNITY_PLUGIN_API_DIR "" CACHE PATH "Path to Unity's Editor/Data/PluginAPI headers")
 
+# RIST live-ingest transport (protocol/basis_rist.c). OFF by default: the plugin
+# then links only OS frameworks exactly as before, and basis_rist.c compiles to a
+# graceful "not built" stub. ON links the librist static (built from source by
+# Native~/build-librist.*, mbedTLS bundled in) from third_party/ into the plugin —
+# see third_party/README.md.
+option(BASIS_WITH_RIST "Build the RIST transport (links librist built from source by build-librist.*)" OFF)
+
 # Portable core (every platform)
 set(CORE_SOURCES
     basis_media_core.c
@@ -68,6 +75,7 @@ set(CORE_SOURCES
     protocol/basis_ts.c
     protocol/basis_mp4.c
     protocol/basis_hls.c
+    protocol/basis_rist.c
 )
 
 # ---------------------------------------------------------------------------
@@ -150,6 +158,48 @@ else()
     # Linux stub.
     find_package(Threads REQUIRED)
     target_link_libraries(basis_media_native PRIVATE Threads::Threads ${CMAKE_DL_LIBS})
+endif()
+
+# ---------------------------------------------------------------------------
+# RIST: link the librist static for the target platform. librist vendors its own
+# mbedTLS and links it into the archive, so a single library per platform is all
+# that's needed. The static is built from source by Native~/build-librist.* into
+# third_party/<rid>/ (see third_party/README.md); headers under third_party/include.
+# They stay out of Unity's import (Native~/ is hidden by the trailing ~), so they're
+# pure build inputs — never committed, never shipped as separate Unity plugins; they
+# link into basis_media_native itself.
+# ---------------------------------------------------------------------------
+if(BASIS_WITH_RIST)
+    set(RIST_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/third_party)
+
+    # Map the target to its librist static directory (mirrors the runtime-identifier
+    # naming Basis already uses for Opus's native binaries).
+    if(WIN32 AND CMAKE_SIZEOF_VOID_P EQUAL 8 AND NOT (CMAKE_GENERATOR_PLATFORM STREQUAL "ARM64"))
+        set(RIST_RID win-x64)
+    elseif(ANDROID AND ANDROID_ABI STREQUAL "arm64-v8a")
+        set(RIST_RID android-arm64)
+    else()
+        message(FATAL_ERROR "BASIS_WITH_RIST: no librist static for this target yet. "
+                            "Supported: Windows x64, Android arm64-v8a. See third_party/README.md.")
+    endif()
+
+    set(RIST_LIBDIR ${RIST_ROOT}/${RIST_RID})
+    find_library(RIST_LIB rist PATHS ${RIST_LIBDIR} NO_DEFAULT_PATH)  # rist.lib (win) / librist.a (android)
+    if(NOT RIST_LIB)
+        message(FATAL_ERROR "BASIS_WITH_RIST: librist not found in ${RIST_LIBDIR}. "
+                            "Build it from source first: run Native~/build-librist.* (see third_party/README.md).")
+    endif()
+
+    target_compile_definitions(basis_media_native PRIVATE BASIS_WITH_RIST)
+    target_include_directories(basis_media_native PRIVATE ${RIST_ROOT}/include)
+    target_link_libraries(basis_media_native PRIVATE ${RIST_LIB})
+
+    if(WIN32)
+        # librist's transitive Windows deps (a static archive doesn't carry them):
+        # ws2_32 (UDP sockets), bcrypt (bundled mbedTLS entropy), iphlpapi
+        # (GetAdaptersInfo, used by librist's network code for the adapter MAC).
+        target_link_libraries(basis_media_native PRIVATE ws2_32 bcrypt iphlpapi)
+    endif()
 endif()
 
 if(MSVC)

--- a/Basis/Packages/com.basis.mediaplayer/Native~/basis_media_core.c
+++ b/Basis/Packages/com.basis.mediaplayer/Native~/basis_media_core.c
@@ -22,6 +22,7 @@
 #include "protocol/basis_mp4.h"
 #include "protocol/basis_http.h"
 #include "protocol/basis_hls.h"
+#include "protocol/basis_rist.h"
 
 #include <stdlib.h>
 #include <string.h>
@@ -281,6 +282,19 @@ static void run_http_like(basis_media_engine_t* e) {
 #endif
 }
 
+/* RIST: librist recovers an MPEG-TS byte stream over UDP (ARQ + optional PSK-AES);
+ * once recovered it's the same MPEG-TS the player already demuxes, so we feed
+ * basis_rist_read straight into basis_ts_run. The receiver is built only when the
+ * plugin is compiled with BASIS_WITH_RIST; otherwise basis_rist_open reports a
+ * clear error via the sink and returns NULL. */
+static void run_rist(basis_media_engine_t* e) {
+    void* rist = basis_rist_open(&e->parts, &e->sink);
+    if (!rist) return;  /* basis_rist_open set the error on the sink */
+    basis_engine_set_state(e, BASIS_MEDIA_STATE_BUFFERING);
+    basis_ts_run(&e->sink, basis_rist_read, rist);
+    basis_rist_close(rist);
+}
+
 /* Dispatch the URL to its protocol handler. Blocks until the stream drops, the
  * engine is stopped, or a hard error is set. */
 static void run_protocol_once(basis_media_engine_t* e) {
@@ -292,6 +306,8 @@ static void run_protocol_once(basis_media_engine_t* e) {
         } else {
             basis_rtmp_run(&e->sink, &e->parts);
         }
+    } else if (basis_url_is_rist(&e->parts)) {
+        run_rist(e);
     } else { /* http / https */
         run_http_like(e);
     }

--- a/Basis/Packages/com.basis.mediaplayer/Native~/build-librist.ps1
+++ b/Basis/Packages/com.basis.mediaplayer/Native~/build-librist.ps1
@@ -1,0 +1,58 @@
+<#
+  Build librist as a static library for basis_media_native's RIST transport
+  (-DBASIS_WITH_RIST=ON) on Windows x64, and stage it into third_party/.
+
+  librist vendors its own mbedTLS and links it into the archive, so a single
+  library is produced. meson names it librist.a even under MSVC, so it is
+  renamed to rist.lib for find_library(rist). Build CRT is /MD (meson release
+  default), matching basis_media_native's default.
+
+  Requires: MSVC on PATH (run from a Developer prompt, or after vcvars) plus
+  meson + ninja (pip install meson ninja). librist is cloned from upstream at
+  the tag basis_rist.c targets.
+
+  Output: third_party/win-x64/rist.lib, third_party/include/librist/*.h
+#>
+[CmdletBinding()]
+param(
+    [string]$LibristRef  = "v0.2.11",
+    [string]$LibristRepo = "https://code.videolan.org/rist/librist.git"
+)
+$ErrorActionPreference = "Stop"
+
+$Here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$Work = Join-Path $Here "build-librist/win-x64"
+$Tp   = Join-Path $Here "third_party"
+
+foreach ($tool in @("git", "meson", "ninja", "cl")) {
+    if (-not (Get-Command $tool -ErrorAction SilentlyContinue)) {
+        throw "$tool not on PATH. Need MSVC (Developer prompt / vcvars) and 'pip install meson ninja'."
+    }
+}
+
+if (Test-Path $Work) { Remove-Item -Recurse -Force $Work }
+New-Item -ItemType Directory -Force -Path $Work | Out-Null
+$Src = Join-Path $Work "librist"
+
+git clone --depth 1 -b $LibristRef $LibristRepo $Src
+if ($LASTEXITCODE -ne 0) { throw "git clone of librist $LibristRef failed" }
+
+# No external mbedTLS on the path -> librist builds its bundled copy and links it in.
+meson setup "$Src/build" "$Src" --default-library=static --buildtype=release
+if ($LASTEXITCODE -ne 0) { throw "meson setup failed" }
+ninja -C "$Src/build" librist.a   # only the static we link; skip librist's CLI tools/tests
+if ($LASTEXITCODE -ne 0) { throw "ninja failed" }
+
+$Lib = Join-Path $Src "build/librist.a"   # meson names it librist.a even on MSVC
+if (-not (Test-Path $Lib) -or (Get-Item $Lib).Length -lt 100KB) {
+    throw "librist static missing or implausibly small at $Lib"
+}
+
+New-Item -ItemType Directory -Force -Path (Join-Path $Tp "win-x64") | Out-Null
+New-Item -ItemType Directory -Force -Path (Join-Path $Tp "include/librist") | Out-Null
+Copy-Item -Force $Lib (Join-Path $Tp "win-x64/rist.lib")
+Copy-Item -Force (Join-Path $Src "include/librist/*.h") (Join-Path $Tp "include/librist/")
+$GenInc = Join-Path $Src "build/include/librist"
+if (Test-Path $GenInc) { Copy-Item -Force (Join-Path $GenInc "*.h") (Join-Path $Tp "include/librist/") }
+
+Write-Host "Staged: third_party/win-x64/rist.lib + third_party/include/librist/"

--- a/Basis/Packages/com.basis.mediaplayer/Native~/build-librist.sh
+++ b/Basis/Packages/com.basis.mediaplayer/Native~/build-librist.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Build librist as a static library for basis_media_native's RIST transport
+# (-DBASIS_WITH_RIST=ON) and stage it into third_party/<rid>/.
+#
+# librist vendors its own mbedTLS and links it into the archive, so a single
+# library per platform is produced; the consumer links one lib (rist).
+#
+# Usage: build-librist.sh <target>
+#   android-arm64   NDK arm64-v8a / android-29 static (needs ANDROID_NDK_ROOT)
+#
+# Requires: git, meson, ninja. librist is cloned from upstream at the tag
+# basis_rist.c targets (override with LIBRIST_REF).
+#
+# Output: third_party/<rid>/librist.a, third_party/include/librist/*.h
+set -euo pipefail
+
+TARGET="${1:-}"
+LIBRIST_REF="${LIBRIST_REF:-v0.2.11}"
+LIBRIST_REPO="${LIBRIST_REPO:-https://code.videolan.org/rist/librist.git}"
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+TP="$HERE/third_party"
+WORK="$HERE/build-librist/$TARGET"
+
+if [ -z "$TARGET" ]; then
+    echo "usage: build-librist.sh <target>   (supported: android-arm64)" >&2
+    exit 2
+fi
+for t in git meson ninja; do
+    command -v "$t" >/dev/null 2>&1 || { echo "error: $t not on PATH" >&2; exit 1; }
+done
+
+rm -rf "$WORK"; mkdir -p "$WORK"
+SRC="$WORK/librist"
+git clone --depth 1 -b "$LIBRIST_REF" "$LIBRIST_REPO" "$SRC"
+
+case "$TARGET" in
+    android-arm64)
+        : "${ANDROID_NDK_ROOT:?set ANDROID_NDK_ROOT to your NDK path}"
+        TC="$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin"
+        CROSS="$WORK/android-arm64.ini"
+        cat > "$CROSS" <<EOF
+[binaries]
+c = '$TC/aarch64-linux-android29-clang'
+cpp = '$TC/aarch64-linux-android29-clang++'
+ar = '$TC/llvm-ar'
+strip = '$TC/llvm-strip'
+[host_machine]
+system = 'android'
+cpu_family = 'aarch64'
+cpu = 'aarch64'
+endian = 'little'
+EOF
+        meson setup "$SRC/build" "$SRC" --cross-file "$CROSS" \
+            --default-library=static --buildtype=release
+        ;;
+    *)
+        echo "error: unknown target '$TARGET' (supported: android-arm64)" >&2
+        exit 2
+        ;;
+esac
+
+ninja -C "$SRC/build" librist.a   # only the static we link; skip librist's CLI tools/tests
+
+LIB="$SRC/build/librist.a"
+if [ ! -f "$LIB" ] || [ "$(wc -c < "$LIB")" -lt 102400 ]; then
+    echo "error: librist static missing or implausibly small at $LIB" >&2
+    exit 1
+fi
+
+mkdir -p "$TP/$TARGET" "$TP/include/librist"
+cp -f "$LIB" "$TP/$TARGET/librist.a"
+cp -f "$SRC"/include/librist/*.h "$TP/include/librist/"
+[ -d "$SRC/build/include/librist" ] && cp -f "$SRC"/build/include/librist/*.h "$TP/include/librist/" || true
+
+echo "Staged: third_party/$TARGET/librist.a + third_party/include/librist/"

--- a/Basis/Packages/com.basis.mediaplayer/Native~/protocol/basis_rist.c
+++ b/Basis/Packages/com.basis.mediaplayer/Native~/protocol/basis_rist.c
@@ -1,0 +1,218 @@
+#include "basis_rist.h"
+
+/* RIST Main-Profile receiver, built only when BASIS_WITH_RIST is defined (it links
+ * the prebuilt librist static, which vendors its own mbedTLS). With the flag off
+ * (the default) only the graceful "not built" stub below is built and the plugin
+ * links exactly as before — no new dependencies.
+ *
+ * Implemented against the librist 0.2.x receiver API. librist owns the UDP sockets,
+ * ARQ, GRE tunnel, jitter buffer and (Main Profile) PSK-AES, and hands the recovered
+ * MPEG-TS payload to the data callback; we buffer it and expose it as a basis_read_fn
+ * so basis_ts_run consumes RIST exactly as it consumes the TCP/HTTP byte sources.
+ *
+ * Open items (not blockers for the byte path): HE-AAC coverage is a decoder-side
+ * concern, and the librist error text mapped onto the sink is coarse. */
+
+#ifdef BASIS_WITH_RIST
+
+#include <librist/librist.h>
+#include <librist/receiver.h>
+#include <librist/peer.h>
+#include <librist/logging.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#if defined(_WIN32)
+  #include <windows.h>
+  typedef CRITICAL_SECTION rist_mutex_t;
+  static void rmx_init(rist_mutex_t* m)   { InitializeCriticalSection(m); }
+  static void rmx_destroy(rist_mutex_t* m){ DeleteCriticalSection(m); }
+  static void rmx_lock(rist_mutex_t* m)   { EnterCriticalSection(m); }
+  static void rmx_unlock(rist_mutex_t* m) { LeaveCriticalSection(m); }
+  static void rist_sleep_ms(int ms)       { Sleep((DWORD)ms); }
+#else
+  #include <pthread.h>
+  #include <unistd.h>
+  typedef pthread_mutex_t rist_mutex_t;
+  static void rmx_init(rist_mutex_t* m)   { pthread_mutex_init(m, NULL); }
+  static void rmx_destroy(rist_mutex_t* m){ pthread_mutex_destroy(m); }
+  static void rmx_lock(rist_mutex_t* m)   { pthread_mutex_lock(m); }
+  static void rmx_unlock(rist_mutex_t* m) { pthread_mutex_unlock(m); }
+  static void rist_sleep_ms(int ms)       { usleep((useconds_t)ms * 1000); }
+#endif
+
+/* Single hand-off point between librist's internal threads (which write recovered
+ * TS) and the demux thread (which reads it through basis_rist_read). Allocated
+ * once at open; no per-read allocation. Overwrites oldest bytes if the demuxer
+ * falls behind — librist has already done ARQ recovery upstream, so an overrun
+ * here means the ring is undersized, not a network loss. */
+#define BASIS_RIST_RING_BYTES (1 << 20)  /* 1 MiB of recovered TS in flight */
+
+typedef struct {
+    uint8_t*     buf;
+    size_t       cap;
+    size_t       head;   /* write index */
+    size_t       tail;   /* read index */
+    size_t       fill;   /* bytes available */
+    rist_mutex_t lock;
+    volatile int shutdown;
+} basis_rist_ring;
+
+static int ring_init(basis_rist_ring* r, size_t cap) {
+    r->buf = (uint8_t*)malloc(cap);
+    if (!r->buf) return -1;
+    r->cap = cap; r->head = r->tail = r->fill = 0; r->shutdown = 0;
+    rmx_init(&r->lock);
+    return 0;
+}
+static void ring_free(basis_rist_ring* r) {
+    if (r->buf) { free(r->buf); r->buf = NULL; }
+    rmx_destroy(&r->lock);
+}
+static void ring_write(basis_rist_ring* r, const uint8_t* data, size_t len) {
+    if (len == 0) return;
+    rmx_lock(&r->lock);
+    for (size_t i = 0; i < len; ++i) {
+        r->buf[r->head] = data[i];
+        r->head = (r->head + 1) % r->cap;
+        if (r->fill < r->cap) r->fill++;
+        else r->tail = (r->tail + 1) % r->cap;  /* full: drop oldest */
+    }
+    rmx_unlock(&r->lock);
+}
+/* Non-blocking drain of up to `len` bytes; returns bytes copied (may be 0). */
+static int ring_drain(basis_rist_ring* r, uint8_t* out, int len) {
+    int n = 0;
+    rmx_lock(&r->lock);
+    while (n < len && r->fill > 0) {
+        out[n++] = r->buf[r->tail];
+        r->tail = (r->tail + 1) % r->cap;
+        r->fill--;
+    }
+    rmx_unlock(&r->lock);
+    return n;
+}
+
+typedef struct basis_rist_ctx {
+    struct rist_ctx*              receiver;   /* librist handle */
+    struct rist_logging_settings* log;        /* librist's init logs through this; NULL crashes on Windows */
+    basis_rist_ring               ring;
+    basis_media_sink_t*           sink;
+} basis_rist_ctx;
+
+/* librist data callback — runs on a librist output thread, must be thread-safe and
+ * must not stall. librist delivers the recovered MPEG-TS payload (de-RTP'd,
+ * de-jittered, decrypted), so it feeds basis_ts_run unchanged. The block is
+ * reference-counted and must be released with rist_receiver_data_block_free2. */
+static int basis_rist_on_data(void* arg, struct rist_data_block* block) {
+    basis_rist_ctx* c = (basis_rist_ctx*)arg;
+    if (block && block->payload && block->payload_len)
+        ring_write(&c->ring, (const uint8_t*)block->payload, block->payload_len);
+    rist_receiver_data_block_free2(&block);
+    return 0;
+}
+
+void* basis_rist_open(const basis_url_t* parts, basis_media_sink_t* sink) {
+    basis_rist_ctx* c = (basis_rist_ctx*)calloc(1, sizeof(*c));
+    if (!c) return NULL;
+    c->sink = sink;
+    if (ring_init(&c->ring, BASIS_RIST_RING_BYTES) != 0) { free(c); return NULL; }
+
+    /* Reconstruct the rist:// URL for librist's parser. It wants
+     * "rist://host:port[?query]" with NO path — a trailing '/' makes it mis-parse the
+     * host/port entirely. parts->path holds the query (with any leading '/'), so pass
+     * only the part from '?' onward; secret / aes-type / buffer ride in that query. */
+    char url[2304];
+    const char* query = strchr(parts->path, '?');
+    snprintf(url, sizeof(url), "rist://%s:%d%s", parts->host, parts->port, query ? query : "");
+
+    /* librist's init path logs through a logging-settings object plus a global log
+     * mutex. Passing NULL leaves that mutex uninitialised, and librist's bundled
+     * Windows pthread shim doesn't lazily init it (glibc does), so the first
+     * internal log call faults. Create real (disabled) settings first — this also
+     * initialises librist's global logging state — then hand them to the receiver. */
+    if (rist_logging_set(&c->log, RIST_LOG_DISABLE, NULL, NULL, NULL, NULL) != 0 || c->log == NULL) {
+        if (sink && sink->on_error) sink->on_error(sink->user, "RIST: failed to init logging settings.");
+        basis_rist_close(c);
+        return NULL;
+    }
+
+    if (rist_receiver_create(&c->receiver, RIST_PROFILE_MAIN, c->log) != 0) {
+        if (sink && sink->on_error) sink->on_error(sink->user, "RIST: failed to create receiver.");
+        basis_rist_close(c);
+        return NULL;
+    }
+
+    /* librist parses host/port plus encryption (secret/aes-type) and buffer depth
+     * from the URL query into the peer config. */
+    struct rist_peer_config* peer_cfg = NULL;
+    if (rist_parse_address2(url, &peer_cfg) < 0 || peer_cfg == NULL) {
+        if (sink && sink->on_error) sink->on_error(sink->user, "RIST: invalid address or parameters.");
+        basis_rist_close(c);
+        return NULL;
+    }
+    peer_cfg->initiate_conn = 1;  /* caller: open an outbound flow to the broadcaster */
+
+    struct rist_peer* peer = NULL;
+    int peer_rc = rist_peer_create(c->receiver, &peer, peer_cfg);
+    rist_peer_config_free2(&peer_cfg);
+    if (peer_rc != 0) {
+        if (sink && sink->on_error) sink->on_error(sink->user, "RIST: failed to add peer.");
+        basis_rist_close(c);
+        return NULL;
+    }
+
+    if (rist_receiver_data_callback_set2(c->receiver, basis_rist_on_data, c) != 0) {
+        if (sink && sink->on_error) sink->on_error(sink->user, "RIST: failed to set data callback.");
+        basis_rist_close(c);
+        return NULL;
+    }
+
+    if (rist_start(c->receiver) != 0) {
+        if (sink && sink->on_error) sink->on_error(sink->user, "RIST: failed to start receiver.");
+        basis_rist_close(c);
+        return NULL;
+    }
+    return c;
+}
+
+int basis_rist_read(void* ctx, uint8_t* buf, int len) {
+    basis_rist_ctx* c = (basis_rist_ctx*)ctx;
+    if (!c || len <= 0) return -1;
+    /* Block until data is available or shutdown, polling so the demux thread
+     * never wedges on a dead receiver (matches the engine's "pull, never block
+     * forever" contract). */
+    for (;;) {
+        if (c->ring.shutdown) return 0;
+        if (c->sink && c->sink->is_running && !c->sink->is_running(c->sink->user)) return 0;
+        int n = ring_drain(&c->ring, buf, len);
+        if (n > 0) return n;
+        rist_sleep_ms(5);
+    }
+}
+
+void basis_rist_close(void* ctx) {
+    basis_rist_ctx* c = (basis_rist_ctx*)ctx;
+    if (!c) return;
+    c->ring.shutdown = 1;
+    if (c->receiver) { rist_destroy(c->receiver); c->receiver = NULL; }
+    if (c->log) { rist_logging_settings_free2(&c->log); }  /* after the receiver that used it */
+    ring_free(&c->ring);
+    free(c);
+}
+
+#else  /* !BASIS_WITH_RIST — graceful stub so the plugin links with no new deps */
+
+void* basis_rist_open(const basis_url_t* parts, basis_media_sink_t* sink) {
+    (void)parts;
+    if (sink && sink->on_error)
+        sink->on_error(sink->user,
+            "RIST is not built into this plugin. Rebuild basis_media_native with "
+            "-DBASIS_WITH_RIST=ON and the vendored librist static.");
+    return NULL;
+}
+int  basis_rist_read(void* ctx, uint8_t* buf, int len) { (void)ctx; (void)buf; (void)len; return -1; }
+void basis_rist_close(void* ctx) { (void)ctx; }
+
+#endif /* BASIS_WITH_RIST */

--- a/Basis/Packages/com.basis.mediaplayer/Native~/protocol/basis_rist.h
+++ b/Basis/Packages/com.basis.mediaplayer/Native~/protocol/basis_rist.h
@@ -1,0 +1,42 @@
+/* RIST (Reliable Internet Stream Transport) Main-Profile receiver.
+ *
+ * RIST is a transport, not a container: it carries an MPEG-TS payload over UDP
+ * with ARQ retransmission (and, in Main Profile, a GRE tunnel + PSK-AES). Once
+ * librist recovers the TS byte stream it is identical to the MPEG-TS the player
+ * already demuxes, so this module exposes the recovered bytes through a
+ * basis_read_fn and the caller hands that to basis_ts_run — reusing the whole
+ * TS demux -> OS decode -> texture/PCM pipeline unchanged.
+ *
+ * Built only when BASIS_WITH_RIST is defined (it links librist + mbedTLS, the
+ * plugin's first third-party static libs). When not built, basis_rist_open
+ * returns NULL and sets a clear "not built" error on the sink, so the dispatch
+ * path degrades gracefully instead of failing to link.
+ */
+#ifndef BASIS_RIST_H
+#define BASIS_RIST_H
+
+#include "../basis_media_internal.h"
+#include "basis_url.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Open a Main-Profile RIST receiver, connecting as a caller (outbound) to
+ * parts->host:parts->port. Encryption/buffer parameters ride in parts->path
+ * (the query string: ?secret=…&aes-type=…&buffer=…). `sink` is used only to
+ * surface connection errors and to poll is_running while connecting. Returns an
+ * opaque context, or NULL on failure (a message is set via the sink). */
+void* basis_rist_open(const basis_url_t* parts, basis_media_sink_t* sink);
+
+/* basis_read_fn: copy up to `len` bytes of recovered MPEG-TS into buf. Blocks
+ * (with a short internal timeout) until data is available or the receiver is
+ * shut down. Returns bytes read (>0), 0 on orderly shutdown, <0 on error. */
+int basis_rist_read(void* ctx, uint8_t* buf, int len);
+
+void basis_rist_close(void* ctx);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/Basis/Packages/com.basis.mediaplayer/Native~/protocol/basis_url.c
+++ b/Basis/Packages/com.basis.mediaplayer/Native~/protocol/basis_url.c
@@ -41,8 +41,10 @@ int basis_url_parse(const char* url, basis_url_t* out) {
         slash = strchr(authority, '/');
     }
 
-    /* host[:port] */
-    const char* host_end = slash ? slash : (authority + strlen(authority));
+    /* host[:port] ends at the first '/' (path) or '?' (query). A RIST URL carries the
+     * query straight after the authority — rist://host:port?secret=… — with no path. */
+    const char* host_end = authority;
+    while (*host_end && *host_end != '/' && *host_end != '?') ++host_end;
     const char* colon = NULL;
     if (authority[0] == '[') {
         /* IPv6 literal */
@@ -65,11 +67,12 @@ int basis_url_parse(const char* url, basis_url_t* out) {
         out->port = atoi(colon + 1);
     }
 
-    /* path (+ query) */
-    if (slash) {
-        size_t pathlen = strlen(slash);
+    /* path and/or query: everything from the first '/' or '?'. Default "/" for a bare
+     * host:port. */
+    if (*host_end) {
+        size_t pathlen = strlen(host_end);
         if (pathlen >= sizeof(out->path)) pathlen = sizeof(out->path) - 1;
-        memcpy(out->path, slash, pathlen);
+        memcpy(out->path, host_end, pathlen);
         out->path[pathlen] = 0;
     } else {
         out->path[0] = '/';
@@ -94,6 +97,10 @@ int basis_url_parse(const char* url, basis_url_t* out) {
     } else if (strcmp(out->scheme, "https") == 0) {
         if (out->port == 0) out->port = 443;
         out->tls = 1;
+    } else if (strcmp(out->scheme, "rist") == 0) {
+        /* RIST has no well-known port; the caller always supplies host:port.
+         * Encryption (secret/aes-type) rides in the query, parsed by librist. */
+        out->tls = 0;
     } else {
         return -1; /* unsupported scheme */
     }
@@ -106,4 +113,8 @@ int basis_url_is_rtsp(const basis_url_t* u) {
 
 int basis_url_is_rtmp(const basis_url_t* u) {
     return u && (strcmp(u->scheme, "rtmp") == 0 || strcmp(u->scheme, "rtmps") == 0);
+}
+
+int basis_url_is_rist(const basis_url_t* u) {
+    return u && strcmp(u->scheme, "rist") == 0;
 }

--- a/Basis/Packages/com.basis.mediaplayer/Native~/protocol/basis_url.h
+++ b/Basis/Packages/com.basis.mediaplayer/Native~/protocol/basis_url.h
@@ -7,7 +7,7 @@ extern "C" {
 #endif
 
 typedef struct basis_url {
-    char scheme[16];   /* lowercased: rtsp, rtspt, rtmp, rtmps, http, https */
+    char scheme[16];   /* lowercased: rtsp, rtspt, rtmp, rtmps, http, https, rist */
     char host[256];
     int  port;         /* defaulted per scheme when absent */
     char path[1024];   /* everything after the host, including leading '/' and query */
@@ -24,6 +24,7 @@ int basis_url_parse(const char* url, basis_url_t* out);
 /* 1 if the scheme uses our custom TCP control protocols (rtsp/rtmp family). */
 int basis_url_is_rtsp(const basis_url_t* u);
 int basis_url_is_rtmp(const basis_url_t* u);
+int basis_url_is_rist(const basis_url_t* u);
 
 #ifdef __cplusplus
 }

--- a/Basis/Packages/com.basis.mediaplayer/Native~/third_party/README.md
+++ b/Basis/Packages/com.basis.mediaplayer/Native~/third_party/README.md
@@ -1,0 +1,71 @@
+# Third-party statics (RIST) — built from source
+
+These are **build inputs**, not Unity plugins. They are statically linked into
+`basis_media_native` when the plugin is built with `-DBASIS_WITH_RIST=ON`; they are
+never loaded by Unity directly and never shipped as separate plugins. They live under
+`Native~/` (the trailing `~` hides the folder from Unity's importer), so no `.meta`
+files apply.
+
+This is deliberately different from how Opus ships (`Plugins/<rid>/native/lib*`):
+Opus is a managed P/Invoke library whose native libs are runtime-loaded, so they belong
+in `Plugins/`. librist is linked into our own native plugin at build time, so its
+archives are build inputs here instead.
+
+## Layout
+
+```
+third_party/
+  include/
+    librist/               # librist.h, peer.h, receiver.h, …
+  win-x64/                 # Windows x86_64
+    rist.lib               #   librist (mbedTLS bundled inside)
+  android-arm64/           # Android arm64-v8a
+    librist.a              #   librist (mbedTLS bundled inside)
+```
+
+librist vendors its own mbedTLS and links it into the archive, so a single library per
+platform is all that's needed — the consumer links only `rist`. `CMakeLists.txt` resolves
+it via `find_library(rist)`, matching each platform's convention (`rist.lib` on Windows,
+`librist.a` on Android). If it's missing the CMake configure step fails with a pointer back
+here, rather than producing a half-linked plugin.
+
+Runtime-identifier names (`win-x64`, `android-arm64`) match the convention Basis already
+uses for Opus's per-platform binaries. Windows and Android are the first targets; add a
+new `<rid>/` directory and a branch in the `BASIS_WITH_RIST` block of `CMakeLists.txt`
+when another backend gains a real decode path.
+
+## Producing the archives
+
+librist is built **from source**, never committed here. Run the build script for your
+host — it clones librist at the pinned tag (matching what `basis_rist.c` targets), builds
+it static with Meson (its bundled mbedTLS linked in), and stages the result into the
+layout above:
+
+```
+# Windows x64 — from a Developer prompt (MSVC on PATH), with: pip install meson ninja
+Native~/build-librist.ps1
+
+# Android arm64 — needs ANDROID_NDK_ROOT, plus meson + ninja
+Native~/build-librist.sh android-arm64
+```
+
+CI runs the same scripts (`.github/workflows/media-native.yml`) on every change under
+`Native~/`, so the recipe stays green and the statics are downloadable as build artifacts.
+The build matches the plugin's toolchain: `/MD` CRT on Windows (the `basis_media_native`
+default), NDK `arm64-v8a` / `android-29`+ on Android. To pin a different librist version,
+pass the tag through (`-LibristRef` / `LIBRIST_REF`), kept in lockstep with the API
+`basis_rist.c` targets.
+
+The plugin binary itself (`basis_media_native.{dll,so}`) is still built on a
+Unity-equipped machine — it links the editor's PluginAPI headers, which CI doesn't have.
+So the role here is to keep librist building from source, not to produce the plugin. On
+Windows, `Native~/build-win-x64-rist.ps1` chains all of it (librist → plugin → install
+into `Plugins/Windows/x86_64/`) in one command.
+
+## Licensing
+
+Both are permissive and MIT-compatible (mbedTLS is bundled inside librist), and both carry
+attribution obligations recorded in the package's `THIRD_PARTY_NOTICES.md`:
+
+- **librist** — BSD-2-Clause
+- **mbedTLS** — Apache-2.0

--- a/Basis/Packages/com.basis.mediaplayer/Native~/third_party/android-arm64/.gitkeep
+++ b/Basis/Packages/com.basis.mediaplayer/Native~/third_party/android-arm64/.gitkeep
@@ -1,0 +1,1 @@
+# Drop here: librist.a  (librist; mbedTLS bundled inside)  — see ../README.md

--- a/Basis/Packages/com.basis.mediaplayer/Native~/third_party/include/.gitkeep
+++ b/Basis/Packages/com.basis.mediaplayer/Native~/third_party/include/.gitkeep
@@ -1,0 +1,1 @@
+# Drop here: librist/ public headers  — see ../README.md

--- a/Basis/Packages/com.basis.mediaplayer/Native~/third_party/win-x64/.gitkeep
+++ b/Basis/Packages/com.basis.mediaplayer/Native~/third_party/win-x64/.gitkeep
@@ -1,0 +1,1 @@
+# Drop here: rist.lib  (librist; mbedTLS bundled inside)  — see ../README.md

--- a/Basis/Packages/com.basis.mediaplayer/README.md
+++ b/Basis/Packages/com.basis.mediaplayer/README.md
@@ -55,8 +55,11 @@ available by assigning `player.Source` directly — useful for tests without a f
 
 ## Building the native plugin
 
-Source is under `Native~/`. It links **only OS frameworks** (no third-party libs).
-You also need Unity's PluginAPI headers — see `Native~/unity/README.md`.
+Source is under `Native~/`. By default it links **only OS frameworks** (no
+third-party libs). The optional RIST transport (`-DBASIS_WITH_RIST=ON`) statically
+links prebuilt librist + mbedTLS from `Native~/third_party/` — see
+`Native~/third_party/README.md`. You also need Unity's PluginAPI headers — see
+`Native~/unity/README.md`.
 
 **Windows → `Plugins/Windows/x86_64/basis_media_native.dll`**
 ```

--- a/Basis/Packages/com.basis.mediaplayer/Runtime/BasisMediaPlayer.cs
+++ b/Basis/Packages/com.basis.mediaplayer/Runtime/BasisMediaPlayer.cs
@@ -354,7 +354,7 @@ public sealed class BasisMediaPlayer : MonoBehaviour
             if (!BasisMediaPlayerSecurity.IsUrlAllowed(media.Uri, out string blockReason))
                 throw new UnauthorizedAccessException($"BasisMediaPlayer refused to load '{media.Uri}': {blockReason}");
 
-            SetNativeEngine(new BasisNativeVideoSource(media.Uri));
+            SetNativeEngine(new BasisNativeVideoSource(ResolveNativeUri(media)));
         }
         catch (Exception ex)
         {
@@ -362,6 +362,23 @@ public sealed class BasisMediaPlayer : MonoBehaviour
         }
 
         ApplyMediaSourceSettings(media);
+    }
+
+    // RIST exposes a receive-buffer depth that librist parses straight from the URL
+    // query. Framework devs set it via Options["buffer"] (milliseconds); fold it in
+    // here so the native side sees rist://host:port?...&buffer=<ms>. Non-RIST schemes
+    // ignore Options["buffer"], so the URI is returned untouched for them.
+    private static string ResolveNativeUri(BasisMediaSource media)
+    {
+        string uri = media.Uri;
+        if (media.Options != null &&
+            uri.StartsWith("rist://", StringComparison.OrdinalIgnoreCase) &&
+            media.Options.TryGetValue("buffer", out object buffer) && buffer != null)
+        {
+            char sep = uri.IndexOf('?') >= 0 ? '&' : '?';
+            uri += $"{sep}buffer={buffer}";
+        }
+        return uri;
     }
 
     private void HandleProtonDeclined(BasisMediaSource media)

--- a/Basis/Packages/com.basis.mediaplayer/Runtime/Core/BasisMediaPlayerSecurity.cs
+++ b/Basis/Packages/com.basis.mediaplayer/Runtime/Core/BasisMediaPlayerSecurity.cs
@@ -33,9 +33,11 @@ public static class BasisMediaPlayerSecurity
         //   rtsp/rtspt  RTSP over UDP/TCP (rtspt = interleaved over TCP, low latency)
         //   rtmp/rtmps  RTMP / RTMP-over-TLS
         //   http/https  fragmented MP4 (.mp4) and MPEG-TS (.ts) over HTTP(S)
+        //   rist        RIST live ingest (MPEG-TS over UDP; requires a BASIS_WITH_RIST build)
         if (scheme != "http" && scheme != "https" &&
             scheme != "rtsp" && scheme != "rtspt" &&
-            scheme != "rtmp" && scheme != "rtmps")
+            scheme != "rtmp" && scheme != "rtmps" &&
+            scheme != "rist")
         {
             reason = $"Scheme '{scheme}' is not allowed.";
             return false;

--- a/Basis/Packages/com.basis.mediaplayer/THIRD_PARTY_NOTICES.md
+++ b/Basis/Packages/com.basis.mediaplayer/THIRD_PARTY_NOTICES.md
@@ -1,14 +1,26 @@
 # Third-Party Notices
 
-This package ships **no statically-linked third-party libraries**. The native
-plugin `basis_media_native` decodes and presents using operating-system
-frameworks only, so there are no extra copyright or license obligations from
-bundled code.
+By default the native plugin `basis_media_native` decodes and presents using
+operating-system frameworks only, with **no statically-linked third-party
+libraries**. Building with `-DBASIS_WITH_RIST=ON` adds the RIST live-ingest
+transport, which statically links the two permissively-licensed libraries listed
+under *RIST transport* below; their attribution obligations apply only to a
+RIST-enabled build.
 
 | Binary shipped | Embeds | License obligation |
 |---|---|---|
-| `Plugins/Windows/x86_64/basis_media_native.dll` | (none — links OS frameworks) | none |
-| `Plugins/Android/arm64-v8a/libbasis_media_native.so` | (none — links OS frameworks) | none |
+| `Plugins/Windows/x86_64/basis_media_native.dll` | OS frameworks; + librist + mbedTLS when built with `BASIS_WITH_RIST` | none, or BSD-2-Clause + Apache-2.0 (RIST build) |
+| `Plugins/Android/arm64-v8a/libbasis_media_native.so` | OS frameworks; + librist + mbedTLS when built with `BASIS_WITH_RIST` | none, or BSD-2-Clause + Apache-2.0 (RIST build) |
+
+## RIST transport (only when built with `BASIS_WITH_RIST`)
+
+The RIST live-ingest transport statically links these into `basis_media_native`.
+Both are permissive and MIT-compatible, and both require attribution:
+
+- **librist** — Reliable Internet Stream Transport (ARQ, GRE tunnel, profiles).
+  BSD-2-Clause. <https://code.videolan.org/rist/librist>
+- **Mbed TLS** — AES primitives used by librist for PSK-AES content encryption.
+  Apache-2.0. <https://github.com/Mbed-TLS/mbedtls>
 
 ## Operating-system frameworks used at runtime
 


### PR DESCRIPTION
## Summary

Adds **RIST** (Reliable Internet Stream Transport) as a receive-only live-ingest transport for the media player — broadcast-grade loss recovery (ARQ) plus optional content encryption (Main-Profile PSK-AES) for live shows. This lands the prototype discussed in #848.

It's **additive and low-blast-radius**:

- Sits behind a `BASIS_WITH_RIST` CMake option that is **off by default**, so existing builds are byte-for-byte unchanged and link no new dependencies.
- **Reuses the existing pipeline end to end** — librist hands recovered MPEG-TS to the same `basis_ts_run` demuxer, the same OS decode / zero-copy texture path, and the same exponential-backoff reconnect loop. No new framework surface, no new events.
- `rist://` is admitted through the existing `BasisMediaPlayerSecurity` allowlist (validated at the boundary), and an optional `Options["buffer"]` (ms) is folded into the URL query that librist parses.

librist itself is a third-party native dependency **built from source in CI** (`v0.2.11`, its bundled mbedTLS linked into a single static), not committed — the shipping answer to the "how should the first native dep be shipped" question from #848.

**Commits** (logical, reviewable):

1. `feat(mediaplayer): RIST live-ingest transport (native + CMake)` — the receiver module (`basis_rist.c/.h`), `rist://` scheme + query handling in `basis_url`, the `run_rist` dispatch, and the CMake wiring.
2. `feat(mediaplayer): accept rist:// URLs in the player` — the security allowlist entry and the `Options["buffer"]` → query fold.
3. `build(mediaplayer): build librist from source for RIST` — `build-librist.{ps1,sh}` + the `media-native.yml` workflow.
4. `docs(mediaplayer): record librist in README and THIRD_PARTY_NOTICES` — BSD-2-Clause licensing + the optional-build note.

Design detail (technical + business specs) is linked from #848.

https://github.com/user-attachments/assets/ef1d96bc-72da-43e1-8e2d-c27261ddd556

**Demo:** AES-128 `rist://` stream decoding live in the editor — clip attached on #848

## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [x] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — `BasisEventDriver` runs the single per-frame tick that drives the whole framework (network apply, local player sim, blendshapes, JigglePhysics, nameplates, and more) as one sequential chain. An unhandled exception anywhere in that chain aborts the rest of the tick, so every step after the throwing one is silently skipped for that frame. New work added to the driver must either be guaranteed not to throw, or be wrapped in a `try`/`catch` that contains the failure and surfaces it through `BasisDebug` — logged once / rate-limited, never every frame (see the existing `HVRBasisBuiltInAddresses.Simulate()` guard for the pattern). Expect this to be scrutinized closely in review.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [x] Windows
- [ ] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [ ] Tested in VR (note headset under **Notes**)
- [ ] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [x] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [x] N/A — change does not touch any of the above

## Notes

**What was tested.** Validated end-to-end in the Unity editor on Windows against a live librist broadcaster over the public internet, on an **optimized Release build** of the plugin (the shape that ships, no debug info):

- Both an unencrypted `rist://host:port` stream and a PSK-AES-128 `rist://host:port?secret=…&aes-type=128` stream play the full pipeline — RIST receive → (decrypt) → MPEG-TS demux → Media Foundation H.264 decode → zero-copy texture, with audio.
- A mid-stream reload exercises the reconnect loop and recovers cleanly (player diagnostics: zero dropped/skipped frames, ~1.8 s reconnect time-to-first-frame, ~240 ms presentation latency — sub-second, fine for live).

**Android (Quest)** is the natural next platform but is **not device-tested yet**, so it's left unticked. The librist Android static already builds in CI and the demux/decode path is shared, so it should be mostly an on-device build + run; I'd rather leave it honest than fake-green it.

**Why most required checks are N/A.** This change is a native-C transport plus a small *init-path* C# change — it adds no per-frame/Unity-runtime work, so most of the perf checklist doesn't apply: no transforms, no Addressables/asset loads, no `GetComponent`/`AddComponent`, nothing added to `BasisEventDriver`, no camera access, no scene-wide discovery, no new C# logging (native failures surface through the existing `sink->on_error` → player error path). The two that genuinely bite, and hold:

- **No hot-path allocations** — the native side allocates its TS ring buffer **once** at `basis_rist_open` and reuses it; `basis_rist_read` does no per-read allocation. The C# `Options["buffer"]` fold runs once per `LoadUrl`, not per frame.
- **Jobification** — N/A; the receive/recovery work runs on librist's own internal threads (UDP/ARQ/jitter), and demux runs on the existing media thread, not the Unity job system.

**Default builds are unaffected.** With `BASIS_WITH_RIST` off (the default), `basis_rist.c` compiles only a graceful "not built" stub and the plugin links exactly as today — no librist, no new system libs.
