### PR TITLE
docs(mediaplayer): document RIST transport and multichannel audio

### DIFF
--- a/Basis/Packages/com.basis.mediaplayer/README.md
+++ b/Basis/Packages/com.basis.mediaplayer/README.md
@@ -16,7 +16,7 @@ presented **zero-copy** into a Unity texture. No transcode server, no VP9, no
 |---|---|---|
 | `rtspt://` | PC/VR low latency (RTP interleaved over TCP) | `rtspt://stream.vrcdn.live/live/vrcdn` |
 | `rtmp://`  | RTMP pull | `rtmp://stream.vrcdn.live/live/vrcdn` |
-| `rist://`  | RIST live ingest (UDP, loss recovery + optional AES) | `rist://host:5000?secret=KEY&aes-type=128` |
+| `rist://`  | RIST live ingest (UDP, loss recovery + optional AES) | `rist://stream.example:5000?secret=KEY&aes-type=128` |
 | `https://…​.mp4` | fragmented MP4 over HTTPS | `https://stream.vrcdn.live/live/vrcdn.live.mp4` |
 | `https://…​.ts`  | MPEG-TS over HTTPS (Quest) | `https://stream.vrcdn.live/live/vrcdn.live.ts` |
 | `https://…​.m3u8` | HLS / Low-Latency HLS (Windows) | `https://stream.example/live/index.m3u8` |

--- a/Basis/Packages/com.basis.mediaplayer/README.md
+++ b/Basis/Packages/com.basis.mediaplayer/README.md
@@ -16,6 +16,7 @@ presented **zero-copy** into a Unity texture. No transcode server, no VP9, no
 |---|---|---|
 | `rtspt://` | PC/VR low latency (RTP interleaved over TCP) | `rtspt://stream.vrcdn.live/live/vrcdn` |
 | `rtmp://`  | RTMP pull | `rtmp://stream.vrcdn.live/live/vrcdn` |
+| `rist://`  | RIST live ingest (UDP, loss recovery + optional AES) | `rist://host:5000?secret=KEY&aes-type=128` |
 | `https://…​.mp4` | fragmented MP4 over HTTPS | `https://stream.vrcdn.live/live/vrcdn.live.mp4` |
 | `https://…​.ts`  | MPEG-TS over HTTPS (Quest) | `https://stream.vrcdn.live/live/vrcdn.live.ts` |
 | `https://…​.m3u8` | HLS / Low-Latency HLS (Windows) | `https://stream.example/live/index.m3u8` |
@@ -37,6 +38,20 @@ a plain HLS origin you get its segment-bound latency, not 5 s.
 Runs on **Windows** (WinHTTP fetch), **clear streams**, **single rendition**.
 Android/Quest support is planned.
 
+### RIST
+
+`rist://` ingests a RIST stream — MPEG-TS over UDP via librist, with
+packet-loss recovery and optional AES encryption. librist reads its connection
+options straight from the URL query: `?secret=<key>&aes-type=128` (or `256`)
+for encryption, and `?buffer=<ms>` to size the recovery buffer. The buffer can
+also be set from C# via `BasisMediaSource.Options["buffer"]`, folded into the
+URL automatically. The recovered transport stream feeds the same MPEG-TS
+demuxer as the HTTP/TS path.
+
+RIST is **opt-in at build time** — the default plugin links only OS frameworks.
+Build with `-DBASIS_WITH_RIST=ON` against prebuilt librist (see *Building the
+native plugin* below).
+
 ## Usage
 
 ```csharp
@@ -53,12 +68,30 @@ Add a `BasisMediaPlayerAudio` (+ `AudioSource`) for sound;
 The CPU `IBasisFrameSource` path (e.g. `BasisSyntheticTestSource`) is still
 available by assigning `player.Source` directly — useful for tests without a feed.
 
+### Audio (stereo and multichannel)
+
+Stereo or mono audio routes through a `BasisMediaPlayerAudio` (+ `AudioSource`)
+on the player GameObject. For surround content, set `BasisMediaSource.AudioRouting`
+to `UnityMultiChannelSources` and add a `BasisMediaPlayerMultiChannelAudio`
+instead: it splits the decoded stream (up to 8 channels) across one `AudioSource`
+per channel — each tagged with a `BasisMediaAudioChannel` — so a 5.1 / 7.1 mix
+can be positioned speaker-by-speaker in the world. The
+`Prefabs/MediaPlayerMultiChannelStreaming` prefab is wired up for this.
+
+Channel ceiling depends on the source: **LPCM over MPEG-TS** carries a full 7.1
+(8 channels); **AAC on Windows** decodes up to 5.1 (the Media Foundation
+decoder's limit).
+
 ## Building the native plugin
 
 Source is under `Native~/`. By default it links **only OS frameworks** (no
-third-party libs). The optional RIST transport (`-DBASIS_WITH_RIST=ON`) statically
-links prebuilt librist + mbedTLS from `Native~/third_party/` — see
-`Native~/third_party/README.md`. You also need Unity's PluginAPI headers — see
+third-party libs). The optional RIST transport (`-DBASIS_WITH_RIST=ON`)
+statically links prebuilt librist (which vendors its own mbedTLS) from
+`Native~/third_party/`. Build that archive with `Native~/build-librist.ps1`
+(Windows) or `build-librist.sh` (Linux/Android), or download it from the
+**media-native (RIST)** CI workflow's artifacts — see
+`Native~/third_party/README.md`. Then add `-DBASIS_WITH_RIST=ON` to the cmake
+configure step below. You also need Unity's PluginAPI headers — see
 `Native~/unity/README.md`.
 
 **Windows → `Plugins/Windows/x86_64/basis_media_native.dll`**


### PR DESCRIPTION
## Summary
Documents two media-player features that already shipped but weren't covered in the package README: the **RIST** transport (#853) and **multichannel / surround audio** (#856).

- Adds a `rist://` row to the Supported URLs table and a `### RIST` subsection — MPEG-TS over UDP via librist, loss recovery + optional AES, the `?secret=` / `?aes-type=` / `?buffer=` query params (and that `Options["buffer"]` is folded into the URL), and that it's opt-in via `-DBASIS_WITH_RIST=ON`.
- Clarifies how to obtain librist for that flag: the `build-librist.ps1` / `build-librist.sh` scripts, or the **media-native (RIST)** CI workflow's artifacts.
- Adds a `### Audio (stereo and multichannel)` subsection covering `UnityMultiChannelSources` routing, `BasisMediaPlayerMultiChannelAudio`, the surround prefab, and the per-source channel ceiling (LPCM-over-TS = full 7.1; AAC on Windows = 5.1).

Docs only — no code changes.

## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [x] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — `BasisEventDriver` runs the single per-frame tick that drives the whole framework (network apply, local player sim, blendshapes, JigglePhysics, nameplates, and more) as one sequential chain. An unhandled exception anywhere in that chain aborts the rest of the tick, so every step after the throwing one is silently skipped for that frame. New work added to the driver must either be guaranteed not to throw, or be wrapped in a `try`/`catch` that contains the failure and surfaces it through `BasisDebug` — logged once / rate-limited, never every frame (see the existing `HVRBasisBuiltInAddresses.Simulate()` guard for the pattern). Expect this to be scrutinized closely in review.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [ ] Windows
- [ ] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [ ] Tested in VR (note headset under **Notes**)
- [ ] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [x] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [x] N/A — change does not touch any of the above

## Notes
Documentation-only change to `com.basis.mediaplayer/README.md` — there's no code to build or run, so the code-quality required checks are all genuinely N/A and ticked per the template's instruction. Rather than building, I verified every documented detail against the shipped source: the `rist://` scheme allow-list (`BasisMediaPlayerSecurity`) and the `Options["buffer"]` URL-folding (`BasisMediaPlayer.ResolveNativeUri`), the `UnityMultiChannelSources` routing and `BasisMediaPlayerMultiChannelAudio` surface, and the `build-librist` scripts + `media-native` CI workflow that produce the librist archive.
