### PR TITLE
fix: IPv6

### DIFF
--- a/Basis Server/BasisNetworkCore/BasisServerConfiguration.cs
+++ b/Basis Server/BasisNetworkCore/BasisServerConfiguration.cs
@@ -43,7 +43,7 @@ public class Configuration
     public float LowQualityDistance = 40f;
     public bool OverrideAutoDiscoveryOfIpv = false;
     public string IPv4Address = "0.0.0.0";
-    public string IPv6Address = "::1";
+    public string IPv6Address = "::";
     public string Password = "default_password";
     public bool UseAuth = true;
     public bool UseAuthIdentity = true;

--- a/Basis Server/BasisNetworkCore/LNLConnectionTargetParser.cs
+++ b/Basis Server/BasisNetworkCore/LNLConnectionTargetParser.cs
@@ -1,4 +1,6 @@
 using System.Globalization;
+using System.Net;
+using System.Net.Sockets;
 
 namespace Basis.Network.Core
 {
@@ -24,7 +26,9 @@ namespace Basis.Network.Core
             string portString = target.Get(ConnectionTarget.Keys.Port, DefaultPort.ToString(CultureInfo.InvariantCulture));
             string password = target.Get(ConnectionTarget.Keys.Password, string.Empty);
 
-            string s = $"{address}:{portString}";
+            bool isIPv6 = IPAddress.TryParse(address, out IPAddress ip)
+                && ip.AddressFamily == AddressFamily.InterNetworkV6;
+            string s = isIPv6 ? $"[{address}]:{portString}" : $"{address}:{portString}";
             if (!string.IsNullOrEmpty(password)) s += "#" + password;
             return s;
         }
@@ -46,23 +50,57 @@ namespace Basis.Network.Core
                 left = raw.Substring(0, hashIdx);
             }
 
-            int colonIdx = left.LastIndexOf(':');
-            if (colonIdx > 0
-                && colonIdx < left.Length - 1
-                && ushort.TryParse(left.Substring(colonIdx + 1), out ushort parsedPort)
-                && parsedPort > 0)
+            if (left.Length > 0 && left[0] == '[')
             {
-                address = left.Substring(0, colonIdx).Trim();
-                port = parsedPort;
-                portProvided = true;
+                // Bracketed IPv6 literal: [addr]:port or [addr]
+                int closeBracket = left.IndexOf(']');
+                if (closeBracket > 0)
+                {
+                    address = left.Substring(1, closeBracket - 1).Trim();
+                    string afterBracket = left.Substring(closeBracket + 1);
+                    if (afterBracket.Length > 1 && afterBracket[0] == ':')
+                    {
+                        if (ushort.TryParse(afterBracket.Substring(1), out ushort parsedPort) && parsedPort > 0)
+                        {
+                            port = parsedPort;
+                            portProvided = true;
+                        }
+                    }
+                }
+                else
+                {
+                    address = left.Trim(); // malformed bracket — treat whole string as address
+                }
             }
             else
             {
-                address = left.Trim();
+                int colonIdx = left.LastIndexOf(':');
+                if (colonIdx > 0
+                    && colonIdx < left.Length - 1
+                    && ushort.TryParse(left.Substring(colonIdx + 1), out ushort parsedPort)
+                    && parsedPort > 0)
+                {
+                    string candidateAddress = left.Substring(0, colonIdx).Trim();
+                    // If the candidate address still contains a colon it is a bare IPv6
+                    // literal (e.g. "::1", "2001:db8::1") being misread as host:port.
+                    // Leave it unsplit; the user must use [addr]:port notation for
+                    // an IPv6 address with an explicit port.
+                    if (candidateAddress.IndexOf(':') < 0)
+                    {
+                        address = candidateAddress;
+                        port = parsedPort;
+                        portProvided = true;
+                    }
+                    else
+                    {
+                        address = left.Trim();
+                    }
+                }
+                else
+                {
+                    address = left.Trim();
+                }
             }
-
-            if (address.StartsWith("[") && address.EndsWith("]") && address.Length >= 2)
-                address = address.Substring(1, address.Length - 2);
 
             return !string.IsNullOrEmpty(address);
         }

--- a/Basis Server/BasisNetworkServer/BasisNetworkHealthCheck.cs
+++ b/Basis Server/BasisNetworkServer/BasisNetworkHealthCheck.cs
@@ -1,6 +1,7 @@
 using Basis.Network.Core;
 using System;
 using System.Net;
+using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -30,15 +31,15 @@ namespace Basis.Network.Server
             // Normalize path: ensure leading slash, remove trailing slash (except root)
             pathNormalized = NormalizePath(config.HealthPath);
 
-            // Prefix must end with slash.
-            httpListener.Prefixes.Add($"http://{host}:{port}/");
+            // Prefix must end with slash. IPv6 address literals need bracket notation.
+            httpListener.Prefixes.Add($"http://{FormatHost(host)}:{port}/");
             httpListener.Start();
 
             startTimeUtc = DateTimeOffset.UtcNow;
 
             listenTask = ListenLoopAsync(cts.Token);
 
-            BNL.Log($"HTTP health check started at 'http://{host}:{port}{pathNormalized}'");
+            BNL.Log($"HTTP health check started at 'http://{FormatHost(host)}:{port}{pathNormalized}'");
         }
 
         private static string NormalizePath(string p)
@@ -164,6 +165,12 @@ namespace Basis.Network.Server
                 try { context?.Response?.Abort(); } catch { /* ignore */ }
             }
         }
+
+        // HttpListener URL prefixes require bracket notation for IPv6 address literals.
+        private static string FormatHost(string host) =>
+            IPAddress.TryParse(host, out IPAddress addr) && addr.AddressFamily == AddressFamily.InterNetworkV6
+                ? $"[{host}]"
+                : host;
 
         public void Stop() => Dispose();
 

--- a/Basis Server/BasisNetworkServer/BasisRestApiHandler.cs
+++ b/Basis Server/BasisNetworkServer/BasisRestApiHandler.cs
@@ -2,6 +2,7 @@
 using Basis.Network.Core;
 using System;
 using System.Net;
+using System.Net.Sockets;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
@@ -24,10 +25,10 @@ namespace Basis.Network.Server
             _keyHash = string.IsNullOrEmpty(_apiKey)
                 ? Array.Empty<byte>()
                 : HashBytes(Encoding.UTF8.GetBytes(_apiKey));
-            _listener.Prefixes.Add($"http://{config.ApiHost}:{config.ApiPort}/");
+            _listener.Prefixes.Add($"http://{FormatHost(config.ApiHost)}:{config.ApiPort}/");
             _listener.Start();
             _ = ListenLoopAsync(_cts.Token);
-            BNL.Log($"REST API started at http://{config.ApiHost}:{config.ApiPort}/api/");
+            BNL.Log($"REST API started at http://{FormatHost(config.ApiHost)}:{config.ApiPort}/api/");
         }
 
         private async Task ListenLoopAsync(CancellationToken token)
@@ -97,6 +98,12 @@ namespace Basis.Network.Server
             using var sha = SHA256.Create();
             return sha.ComputeHash(data);
         }
+
+        // HttpListener URL prefixes require bracket notation for IPv6 address literals.
+        private static string FormatHost(string host) =>
+            IPAddress.TryParse(host, out IPAddress addr) && addr.AddressFamily == AddressFamily.InterNetworkV6
+                ? $"[{host}]"
+                : host;
 
         public void Dispose()
         {

--- a/Basis Server/BasisNetworkServer/NetworkServer.cs
+++ b/Basis Server/BasisNetworkServer/NetworkServer.cs
@@ -187,29 +187,30 @@ public static class NetworkServer
 
     public static void StartListening(Configuration configuration)
     {
+        IPAddress ipv4, ipv6;
         if (configuration.OverrideAutoDiscoveryOfIpv)
         {
-            IPAddress? IPv4Address, IPv6Address;
-            if (!IPAddress.TryParse(Configuration.IPv4Address, out IPv4Address))
+            if (!IPAddress.TryParse(Configuration.IPv4Address, out ipv4))
             {
-                BNL.LogWarning("Failed to parse IPv4 bind address, falling back to 0.0.0.0");
-                IPv4Address = IPAddress.Parse("0.0.0.0");
+                BNL.LogWarning($"Failed to parse IPv4 bind address '{Configuration.IPv4Address}', falling back to 0.0.0.0");
+                ipv4 = IPAddress.Any;
             }
-
-            if (!IPAddress.TryParse(Configuration.IPv6Address, out IPv6Address))
+            if (!IPAddress.TryParse(Configuration.IPv6Address, out ipv6))
             {
-                BNL.LogWarning("Failed to parse IPv6 bind address, falling back to ::");
-                IPv6Address = IPAddress.IPv6Any;
+                BNL.LogWarning($"Failed to parse IPv6 bind address '{Configuration.IPv6Address}', falling back to [::]");
+                ipv6 = IPAddress.IPv6Any;
             }
-
-            BNL.Log($"Server Wiring up SetPort {Configuration.SetPort} IPv6Address {Configuration.IPv6Address}");
-            Server.Start(IPv4Address, IPv6Address, Configuration.SetPort);
         }
         else
         {
-            BNL.Log($"Server Wiring up SetPort {Configuration.SetPort}");
-            Server.Start(IPAddress.Any, IPAddress.IPv6Any, Configuration.SetPort);
+            ipv4 = IPAddress.Any;
+            ipv6 = IPAddress.IPv6Any;
         }
+
+        Server.Start(ipv4, ipv6, configuration.SetPort);
+        BNL.Log($"Listening on UDP port {configuration.SetPort}");
+        BNL.Log($"  IPv4 bind: {ipv4}");
+        BNL.Log($"  IPv6 bind: [{ipv6}]");
     }
     #endregion
     public static void BroadcastMessageToClients(NetDataWriter writer, byte channel, NetPeer sender, ReadOnlySpan<NetPeer> clients, DeliveryMethod deliveryMethod = DeliveryMethod.Sequenced, int maxMessages = 70)

--- a/Basis Server/BasisNetworkServer/NetworkServer.cs
+++ b/Basis Server/BasisNetworkServer/NetworkServer.cs
@@ -198,8 +198,8 @@ public static class NetworkServer
 
             if (!IPAddress.TryParse(Configuration.IPv6Address, out IPv6Address))
             {
-                BNL.LogWarning("Failed to parse IPv6 bind address, falling back to ::1");
-                IPv6Address = IPAddress.Parse("::1");
+                BNL.LogWarning("Failed to parse IPv6 bind address, falling back to ::");
+                IPv6Address = IPAddress.IPv6Any;
             }
 
             BNL.Log($"Server Wiring up SetPort {Configuration.SetPort} IPv6Address {Configuration.IPv6Address}");

--- a/Basis/Packages/com.basis.framework/Device Management/Devices/Headless/BasisHeadlessHealthCheck.cs
+++ b/Basis/Packages/com.basis.framework/Device Management/Devices/Headless/BasisHeadlessHealthCheck.cs
@@ -69,7 +69,7 @@ public sealed class BasisHeadlessHealthCheck : IDisposable
             }
             catch (Exception ex)
             {
-                UnityEngine.Debug.LogWarning("Headless health check loop error: " + ex);
+                BasisDebug.LogWarning("Headless health check loop error: " + ex, BasisDebug.LogTag.Networking);
                 continue;
             }
 

--- a/Basis/Packages/com.basis.framework/Device Management/Devices/Headless/BasisHeadlessHealthCheck.cs
+++ b/Basis/Packages/com.basis.framework/Device Management/Devices/Headless/BasisHeadlessHealthCheck.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net;
+using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,11 +17,17 @@ public sealed class BasisHeadlessHealthCheck : IDisposable
     public BasisHeadlessHealthCheck(string host, int port, string path)
     {
         pathNormalized = NormalizePath(path);
-        httpListener.Prefixes.Add($"http://{host}:{port}/");
+        httpListener.Prefixes.Add($"http://{FormatHost(host)}:{port}/");
         httpListener.Start();
         BasisHeadlessRuntimeStatus.SetHealthListenerRunning(true);
         listenTask = ListenLoopAsync(cts.Token);
     }
+
+    // HttpListener URL prefixes require bracket notation for IPv6 address literals.
+    private static string FormatHost(string host) =>
+        IPAddress.TryParse(host, out IPAddress addr) && addr.AddressFamily == AddressFamily.InterNetworkV6
+            ? $"[{host}]"
+            : host;
 
     public static string NormalizePath(string path)
     {

--- a/Basis/Packages/com.basis.framework/Networking/BasisConnectionService.cs
+++ b/Basis/Packages/com.basis.framework/Networking/BasisConnectionService.cs
@@ -117,7 +117,20 @@ namespace Basis.Scripts.Networking
                 BasisNetworkManagement.NetworkStackId = stackId;
 
                 ReportConnectionProgress(60f, BasisLocalization.Get("menu.servers.status.loadingBundle"));
+
+                // Probe the server while the bundle loads to discover which address family
+                // is actually reachable. Skipped in host-mode: the local server may not be
+                // listening yet. Non-fatal: if the probe fails we fall back to the hostname.
+                Task<string> resolveTask = isHostMode
+                    ? Task.FromResult(address)
+                    : ResolveConnectionAddressAsync(entry.Target, address);
                 await LoadDefaultAssetBundleAsync();
+                string resolvedIp = await resolveTask;
+                if (!string.IsNullOrEmpty(resolvedIp) && resolvedIp != address)
+                {
+                    BasisDebug.Log($"[IPv6Fallback] Resolved {address} → {resolvedIp}", BasisDebug.LogTag.Networking);
+                    BasisNetworkManagement.Ip = resolvedIp;
+                }
 
                 ReportConnectionProgress(90f, BasisLocalization.Get("menu.servers.status.connecting"));
                 BasisNetworkManagement.Connect();
@@ -137,6 +150,25 @@ namespace Basis.Scripts.Networking
                 ReportConnectionError(BasisLocalization.Get("menu.servers.error.connectFailed"));
                 BasisDebug.LogError(ex.ToString());
             }
+        }
+
+        /// <summary>
+        /// Probes the server and returns the <see cref="IPAddress"/> string that actually
+        /// responded, or <paramref name="fallback"/> if the probe cannot reach either family.
+        /// A 2.5-second budget is split: first half for IPv6, second half for IPv4.
+        /// </summary>
+        private static async Task<string> ResolveConnectionAddressAsync(ConnectionTarget target, string fallback)
+        {
+            try
+            {
+                using CancellationTokenSource cts = new CancellationTokenSource(2500);
+                ServerProbeResult probe = await BasisNetworkStackRegistry.ProbeAsync(
+                    target, 2500, cts.Token).ConfigureAwait(false);
+                if (probe?.ResolvedAddress != null)
+                    return probe.ResolvedAddress.ToString();
+            }
+            catch { }
+            return fallback;
         }
 
         public static async Task LoadDefaultAssetBundleAsync()

--- a/Basis/Packages/com.basis.framework/Networking/BasisConnectionService.cs
+++ b/Basis/Packages/com.basis.framework/Networking/BasisConnectionService.cs
@@ -5,6 +5,8 @@ using Basis.Scripts.Device_Management.Devices.Desktop;
 using Basis.Scripts.Drivers;
 using Basis.Network.Core;
 using System;
+using System.Net;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using UnityEngine;
@@ -128,7 +130,7 @@ namespace Basis.Scripts.Networking
                 string resolvedIp = await resolveTask;
                 if (!string.IsNullOrEmpty(resolvedIp) && resolvedIp != address)
                 {
-                    BasisDebug.Log($"[IPv6Fallback] Resolved {address} → {resolvedIp}", BasisDebug.LogTag.Networking);
+                    BasisDebug.Log($"Resolved {address} → {resolvedIp}", BasisDebug.LogTag.Networking);
                     BasisNetworkManagement.Ip = resolvedIp;
                 }
 
@@ -271,7 +273,10 @@ namespace Basis.Scripts.Networking
             if (!LNLConnectionTargetParser.TryParseConnectionString(value, out string addr, out ushort port, out _, out string password))
                 return false;
 
-            ConnectionTarget target = new ConnectionTarget(BasisNetworkStackRegistry.DefaultId, $"{addr}:{port}");
+            bool isIPv6 = IPAddress.TryParse(addr, out IPAddress parsedAddr)
+                && parsedAddr.AddressFamily == AddressFamily.InterNetworkV6;
+            string raw = isIPv6 ? $"[{addr}]:{port}" : $"{addr}:{port}";
+            ConnectionTarget target = new ConnectionTarget(BasisNetworkStackRegistry.DefaultId, raw);
             target.Set(ConnectionTarget.Keys.Address, addr);
             target.Set(ConnectionTarget.Keys.Port, port.ToString(System.Globalization.CultureInfo.InvariantCulture));
             target.Set(ConnectionTarget.Keys.Password, password ?? string.Empty);

--- a/Basis/Packages/com.basis.framework/Networking/BasisNetworkIPResolve.cs
+++ b/Basis/Packages/com.basis.framework/Networking/BasisNetworkIPResolve.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net;
+using System.Net.Sockets;
 using UnityEngine;
 
 public static class BasisNetworkIPResolve
@@ -11,20 +12,20 @@ public static class BasisNetworkIPResolve
             IPAddress[] ips = Dns.GetHostAddresses(hostname);
             if (ips != null && ips.Length > 0)
             {
-                string[] addresses = new string[ips.Length];
-                for (int Index = 0; Index < ips.Length; Index++)
+                foreach (IPAddress ip in ips)
+                    BasisDebug.Log($"IP Candidate: {ip}");
+
+                // Prefer IPv6 when the OS supports it (mirrors LiteNetLib's resolution order)
+                if (Socket.OSSupportsIPv6)
                 {
-                    addresses[Index] = ips[Index].ToString();
-                    BasisDebug.Log($"IP Candidate: {addresses[Index]}");
-
-                    bool hasThreePeriods = addresses[Index].Split('.').Length - 1 == 3;
-                    if (hasThreePeriods)
-                    {
-                        return addresses[Index]; // select IPv4 if possible (for now)
-                    }
-
+                    foreach (IPAddress ip in ips)
+                        if (ip.AddressFamily == AddressFamily.InterNetworkV6)
+                            return ip.ToString();
                 }
-                return addresses[0]; // pick first one: IPv4 or IPv6 we don't care right now
+                foreach (IPAddress ip in ips)
+                    if (ip.AddressFamily == AddressFamily.InterNetwork)
+                        return ip.ToString();
+                return ips[0].ToString();
             }
         }
         catch (System.Exception ex)
@@ -68,10 +69,7 @@ public static class BasisNetworkIPResolve
     public static string[] ResolveLocahost(string localhost)
     {
         string[] addresses = ResolveLocalhostToIP(localhost);
-        if (addresses != null)
-        {
-        }
-        else
+        if (addresses == null)
         {
             BasisDebug.LogError("Failed to resolve localhost to IP address.");
         }

--- a/Basis/Packages/com.basis.framework/Networking/BasisNetworkIPResolve.cs
+++ b/Basis/Packages/com.basis.framework/Networking/BasisNetworkIPResolve.cs
@@ -13,7 +13,7 @@ public static class BasisNetworkIPResolve
             if (ips != null && ips.Length > 0)
             {
                 foreach (IPAddress ip in ips)
-                    BasisDebug.Log($"IP Candidate: {ip}");
+                    BasisDebug.Log($"IP Candidate: {ip}", BasisDebug.LogTag.Networking);
 
                 // Prefer IPv6 when the OS supports it (mirrors LiteNetLib's resolution order)
                 if (Socket.OSSupportsIPv6)

--- a/Basis/Packages/com.basis.framework/Networking/BasisNetworkIPResolve.cs
+++ b/Basis/Packages/com.basis.framework/Networking/BasisNetworkIPResolve.cs
@@ -61,17 +61,18 @@ public static class BasisNetworkIPResolve
     {
         if (IpString.ToLower() == LocalHost)
         {
-            string[] IpStrings = BasisNetworkIPResolve.ResolveLocahost(IpString);
+            string[] IpStrings = BasisNetworkIPResolve.ResolveLocalhost(IpString);
             IpString = IpStrings[0];
         }
         return IPAddress.Parse(IpString);
     }
-    public static string[] ResolveLocahost(string localhost)
+    public static string[] ResolveLocalhost(string localhost)
     {
         string[] addresses = ResolveLocalhostToIP(localhost);
         if (addresses == null)
         {
             BasisDebug.LogError("Failed to resolve localhost to IP address.");
+            throw new System.IO.Exception("Failed to resolve localhost to IP address.");
         }
         return addresses;
     }

--- a/Basis/Packages/com.basis.framework/Networking/BasisNetworkIPResolve.cs
+++ b/Basis/Packages/com.basis.framework/Networking/BasisNetworkIPResolve.cs
@@ -72,7 +72,7 @@ public static class BasisNetworkIPResolve
         if (addresses == null)
         {
             BasisDebug.LogError("Failed to resolve localhost to IP address.");
-            throw new System.IO.Exception("Failed to resolve localhost to IP address.");
+            throw new System.IO.IOException("Failed to resolve localhost to IP address.");
         }
         return addresses;
     }

--- a/Basis/Packages/com.basis.framework/Networking/BasisServerInfoClient.cs
+++ b/Basis/Packages/com.basis.framework/Networking/BasisServerInfoClient.cs
@@ -1,5 +1,6 @@
 using Basis.Network.Core;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Net;
@@ -14,6 +15,12 @@ namespace Basis.Scripts.Networking
     /// Registers the LiteNetLib server-info probe with <see cref="BasisNetworkStackRegistry"/>.
     /// Fires a single unconnected "server info" packet at the listening port (the LiteNetLib
     /// equivalent of a Minecraft Server List Ping) and awaits the response.
+    ///
+    /// When the hostname resolves to both AAAA and A records, IPv6 is attempted first with
+    /// half the total timeout budget. If IPv6 times out or fails the probe falls through to
+    /// IPv4 with the remaining budget. The winning <see cref="IPAddress"/> is stored in
+    /// <see cref="ServerProbeResult.ResolvedAddress"/> so callers can connect directly to the
+    /// confirmed-reachable address family without re-resolving DNS.
     /// </summary>
     public static class BasisServerInfoClient
     {
@@ -25,42 +32,117 @@ namespace Basis.Scripts.Networking
 
         public static async Task<ServerProbeResult> ProbeAsync(ConnectionTarget target, int timeoutMs, CancellationToken ct)
         {
-            ServerProbeResult result = new ServerProbeResult();
-            if (target == null)
-            {
-                result.Error = "Target is null";
-                return result;
-            }
+            ServerProbeResult fail = new ServerProbeResult();
+            if (target == null) { fail.Error = "Target is null"; return fail; }
 
             string host = target.Get(ConnectionTarget.Keys.Address, string.Empty);
-            if (string.IsNullOrWhiteSpace(host))
-            {
-                result.Error = "Host is empty";
-                return result;
-            }
+            if (string.IsNullOrWhiteSpace(host)) { fail.Error = "Host is empty"; return fail; }
 
-            string portString = target.Get(ConnectionTarget.Keys.Port, LNLConnectionTargetParser.DefaultPort.ToString(CultureInfo.InvariantCulture));
+            string portString = target.Get(ConnectionTarget.Keys.Port,
+                LNLConnectionTargetParser.DefaultPort.ToString(CultureInfo.InvariantCulture));
             if (!ushort.TryParse(portString, NumberStyles.Integer, CultureInfo.InvariantCulture, out ushort port) || port == 0)
             {
-                result.Error = "Port is invalid";
-                return result;
+                fail.Error = "Port is invalid";
+                return fail;
             }
+
+            // Resolve all addresses upfront so we can pick the right family.
+            IPAddress[] ipv6, ipv4;
+            try
+            {
+                ResolvedAddresses resolved = await ResolveAllAsync(host, ct).ConfigureAwait(false);
+                ipv6 = resolved.IPv6;
+                ipv4 = resolved.IPv4;
+            }
+            catch (Exception ex)
+            {
+                fail.Error = "DNS resolution failed: " + ex.Message;
+                return fail;
+            }
+
+            if (ipv6.Length == 0 && ipv4.Length == 0)
+            {
+                fail.Error = "DNS resolution returned no addresses";
+                return fail;
+            }
+
+            // Split budget: half for the IPv6 attempt when both families exist.
+            // If only one family is present it gets the full budget.
+            bool bothFamilies = ipv6.Length > 0 && ipv4.Length > 0;
+            int v6Budget = bothFamilies ? timeoutMs / 2 : timeoutMs;
+            int v4Budget = bothFamilies ? Math.Max(timeoutMs - v6Budget, 1000) : timeoutMs;
 
             EventBasedNetListener listener = new EventBasedNetListener();
             Configuration probeConfig = new Configuration { NetworkStackId = BasisNetworkStackRegistry.LiteNetLibId };
             NetManager manager = BasisNetworkStackRegistry.Create(probeConfig.NetworkStackId, listener, probeConfig);
+            // Start with dual-stack so we can send to either address family.
+            manager.Start(IPAddress.Any, IPAddress.IPv6Any, 0);
 
             ushort nonce;
             unchecked { nonce = (ushort)Guid.NewGuid().GetHashCode(); }
 
-            TaskCompletionSource<ServerProbeResult> tcs = new TaskCompletionSource<ServerProbeResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+            try
+            {
+                // ── IPv6 first ────────────────────────────────────────────────────────
+                if (ipv6.Length > 0)
+                {
+                    ServerProbeResult r = await SendProbeAsync(
+                        listener, manager, nonce, port, ipv6[0], v6Budget, ct).ConfigureAwait(false);
+                    if (r.Reachable)
+                    {
+                        r.ResolvedAddress = ipv6[0];
+                        return r;
+                    }
+                    if (ct.IsCancellationRequested) return r;
+                }
+
+                // ── IPv4 fallback ─────────────────────────────────────────────────────
+                if (ipv4.Length > 0)
+                {
+                    ServerProbeResult r = await SendProbeAsync(
+                        listener, manager, nonce, port, ipv4[0], v4Budget, ct).ConfigureAwait(false);
+                    if (r.Reachable) r.ResolvedAddress = ipv4[0];
+                    return r;
+                }
+
+                fail.Error = "No reachable address found";
+                fail.TimedOut = true;
+                return fail;
+            }
+            finally
+            {
+                try { manager.Stop(); } catch { }
+            }
+        }
+
+        /// <summary>
+        /// Sends a single probe packet to <paramref name="address"/>:<paramref name="port"/>
+        /// and waits up to <paramref name="timeoutMs"/> for a matching response.
+        /// The handler also checks the source endpoint to reject stale packets from a
+        /// previous attempt that arrive late.
+        /// </summary>
+        private static async Task<ServerProbeResult> SendProbeAsync(
+            EventBasedNetListener listener,
+            NetManager manager,
+            ushort nonce,
+            ushort port,
+            IPAddress address,
+            int timeoutMs,
+            CancellationToken ct)
+        {
+            IPEndPoint endpoint = new IPEndPoint(address, port);
+            TaskCompletionSource<ServerProbeResult> tcs =
+                new TaskCompletionSource<ServerProbeResult>(TaskCreationOptions.RunContinuationsAsynchronously);
             Stopwatch rtt = new Stopwatch();
 
             void OnReceiveUnconnected(IPEndPoint remoteEndPoint, NetPacketReader reader)
             {
                 try
                 {
+                    // Reject packets from the wrong endpoint (stale reply from a prior attempt).
+                    if (!remoteEndPoint.Equals(endpoint)) return;
                     if (reader.AvailableBytes < 8) return;
+
                     uint magic = reader.GetUInt();
                     if (magic != BasisNetworkCommons.ServerInfoResponseMagic) return;
 
@@ -84,30 +166,13 @@ namespace Basis.Scripts.Networking
                         RoundTripMs = (int)rtt.ElapsedMilliseconds,
                     });
                 }
-                catch
-                {
-                }
-                finally
-                {
-                    reader.Recycle(true);
-                }
+                catch { }
+                finally { reader.Recycle(true); }
             }
 
             listener.NetworkReceiveUnconnectedEvent += OnReceiveUnconnected;
-
             try
             {
-                IPAddress address = await ResolveHostAsync(host, ct).ConfigureAwait(false);
-                if (address == null)
-                {
-                    result.Error = "DNS resolution failed";
-                    return result;
-                }
-
-                IPEndPoint endpoint = new IPEndPoint(address, port);
-
-                manager.Start(IPAddress.Any, IPAddress.IPv6Any, 0);
-
                 NetDataWriter writer = new NetDataWriter(true, BasisNetworkCommons.ServerInfoMinRequestBytes);
                 writer.Put(BasisNetworkCommons.ServerInfoQueryMagic);
                 writer.Put(BasisNetworkCommons.ServerInfoProtocolVersion);
@@ -117,55 +182,59 @@ namespace Basis.Scripts.Networking
 
                 rtt.Start();
                 if (!manager.SendUnconnectedMessage(writer, endpoint))
-                {
-                    result.Error = "Send failed";
-                    return result;
-                }
+                    return new ServerProbeResult { Error = "Send failed" };
 
                 using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
                 cts.CancelAfter(timeoutMs);
-                using CancellationTokenRegistration reg = cts.Token.Register(() => tcs.TrySetCanceled());
+                using CancellationTokenRegistration reg = cts.Token.Register(
+                    () => tcs.TrySetCanceled());
 
                 try
                 {
-                    ServerProbeResult probed = await tcs.Task.ConfigureAwait(false);
-                    return probed;
+                    return await tcs.Task.ConfigureAwait(false);
                 }
                 catch (OperationCanceledException)
                 {
-                    result.TimedOut = true;
-                    return result;
+                    return new ServerProbeResult { TimedOut = true };
                 }
-            }
-            catch (Exception ex)
-            {
-                result.Error = ex.Message;
             }
             finally
             {
                 listener.NetworkReceiveUnconnectedEvent -= OnReceiveUnconnected;
-                try { manager.Stop(); } catch { }
             }
-
-            return result;
         }
 
-        private static async Task<IPAddress> ResolveHostAsync(string host, CancellationToken ct)
+        private readonly struct ResolvedAddresses
+        {
+            public readonly IPAddress[] IPv6;
+            public readonly IPAddress[] IPv4;
+            public ResolvedAddresses(IPAddress[] ipv6, IPAddress[] ipv4)
+            { IPv6 = ipv6; IPv4 = ipv4; }
+        }
+
+        /// <summary>
+        /// Resolves <paramref name="host"/> and splits the results into IPv6 and IPv4 buckets.
+        /// Literal IP addresses are placed directly into the matching bucket without DNS.
+        /// </summary>
+        private static async Task<ResolvedAddresses> ResolveAllAsync(string host, CancellationToken ct)
         {
             if (IPAddress.TryParse(host, out IPAddress parsed))
-                return parsed;
+            {
+                if (parsed.AddressFamily == AddressFamily.InterNetworkV6)
+                    return new ResolvedAddresses(new[] { parsed }, Array.Empty<IPAddress>());
+                return new ResolvedAddresses(Array.Empty<IPAddress>(), new[] { parsed });
+            }
 
-            IPAddress[] addresses = await Dns.GetHostAddressesAsync(host).ConfigureAwait(false);
-            if (addresses == null || addresses.Length == 0)
-                return null;
+            IPAddress[] all = await Dns.GetHostAddressesAsync(host).ConfigureAwait(false);
 
-            foreach (IPAddress a in addresses)
-                if (a.AddressFamily == AddressFamily.InterNetwork) return a;
-
-            foreach (IPAddress a in addresses)
-                if (a.AddressFamily == AddressFamily.InterNetworkV6) return a;
-
-            return addresses[0];
+            List<IPAddress> v6 = new List<IPAddress>();
+            List<IPAddress> v4 = new List<IPAddress>();
+            foreach (IPAddress a in all)
+            {
+                if (a.AddressFamily == AddressFamily.InterNetworkV6) v6.Add(a);
+                else if (a.AddressFamily == AddressFamily.InterNetwork) v4.Add(a);
+            }
+            return new ResolvedAddresses(v6.ToArray(), v4.ToArray());
         }
     }
 }

--- a/Basis/Packages/com.basis.framework/Networking/SavedServersDirectorySource.cs
+++ b/Basis/Packages/com.basis.framework/Networking/SavedServersDirectorySource.cs
@@ -2,6 +2,8 @@ using Basis.BasisUI;
 using Basis.Network.Core;
 using System;
 using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using UnityEngine;
@@ -77,10 +79,17 @@ namespace Basis.Scripts.Networking
             };
         }
 
+        private static string FormatRaw(string address, ushort port)
+        {
+            return IPAddress.TryParse(address, out IPAddress ip) && ip.AddressFamily == AddressFamily.InterNetworkV6
+                ? $"[{address}]:{port}"
+                : $"{address}:{port}";
+        }
+
         private ServerDirectoryEntry BuildEntry(SavedServerEntry s)
         {
             string stackId = string.IsNullOrEmpty(s.NetworkStackId) ? BasisNetworkStackRegistry.DefaultId : s.NetworkStackId;
-            ConnectionTarget target = new ConnectionTarget(stackId, $"{s.Address}:{s.Port}");
+            ConnectionTarget target = new ConnectionTarget(stackId, FormatRaw(s.Address, s.Port));
             target.Set(ConnectionTarget.Keys.Address, s.Address);
             target.Set(ConnectionTarget.Keys.Port, s.Port.ToString(System.Globalization.CultureInfo.InvariantCulture));
             target.Set(ConnectionTarget.Keys.Password, s.HasPassword ? (s.Password ?? string.Empty) : string.Empty);

--- a/Basis/Packages/com.basis.framework/Streaming/BasisStreamingMetaServer.cs
+++ b/Basis/Packages/com.basis.framework/Streaming/BasisStreamingMetaServer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using System.Net;
+using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -36,9 +37,15 @@ namespace Basis.Streaming
 
         public string Prefix { get; }
 
+        // HttpListener URL prefixes require bracket notation for IPv6 address literals.
+        private static string FormatHost(string host) =>
+            IPAddress.TryParse(host, out IPAddress addr) && addr.AddressFamily == AddressFamily.InterNetworkV6
+                ? $"[{host}]"
+                : host;
+
         public BasisStreamingMetaServer(string host, int port)
         {
-            Prefix = $"http://{host}:{port}/";
+            Prefix = $"http://{FormatHost(host)}:{port}/";
             listener.Prefixes.Add(Prefix);
             listener.Start();
             listenTask = ListenLoopAsync(cts.Token);

--- a/Basis/Packages/com.basis.provider.servers/Runtime/ServersProvider.cs
+++ b/Basis/Packages/com.basis.provider.servers/Runtime/ServersProvider.cs
@@ -6,6 +6,8 @@ using Basis.Scripts.Drivers;
 using Basis.Scripts.Networking;
 using System;
 using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using UnityEngine;
@@ -826,7 +828,7 @@ namespace Basis.BasisUI
                     playerCount));
 
                 string description = string.Format("{0}  •  {1}",
-                    string.Format(BasisLocalization.Get("menu.servers.list.address"), address, port),
+                    DisplayAddress(address, port),
                     string.Format(BasisLocalization.Get("menu.servers.list.ping"), result.RoundTripMs));
                 if (!string.IsNullOrEmpty(result.Motd))
                 {
@@ -842,10 +844,18 @@ namespace Basis.BasisUI
                     name = string.Format(BasisLocalization.Get("menu.servers.list.defaultBadge"), name);
                 row.Group.SetTitle(name);
                 row.Group.SetDescription(string.Format("{0}  •  <color={1}>{2}</color>",
-                    string.Format(BasisLocalization.Get("menu.servers.list.address"), address, port),
+                    DisplayAddress(address, port),
                     OfflineColor,
                     BasisLocalization.Get("menu.servers.list.offline")));
             }
+        }
+
+        // Format address:port for display, using bracket notation for IPv6 literals.
+        private static string DisplayAddress(string address, ushort port)
+        {
+            if (IPAddress.TryParse(address, out IPAddress ip) && ip.AddressFamily == AddressFamily.InterNetworkV6)
+                return $"[{address}]:{port}";
+            return string.Format(BasisLocalization.Get("menu.servers.list.address"), address, port);
         }
 
         // TMP rich-text colors for the live online/offline indicators in each row.

--- a/Basis/Packages/com.basis.server/BasisNetworkCore/BasisNetworkStackRegistry.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkCore/BasisNetworkStackRegistry.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -17,6 +18,12 @@ namespace Basis.Network.Core
         public string Motd;
         public int RoundTripMs;
         public Dictionary<string, string> Extras = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        /// <summary>
+        /// The IP address that successfully responded to the probe. Null when unreachable.
+        /// Callers can use this to bypass DNS re-resolution and connect directly to the
+        /// confirmed-reachable address family (supporting IPv6→IPv4 fallback).
+        /// </summary>
+        public IPAddress ResolvedAddress;
     }
 
     public delegate Task<ServerProbeResult> StackProbeDelegate(ConnectionTarget target, int timeoutMs, CancellationToken ct);

--- a/Basis/Packages/com.basis.server/BasisNetworkCore/BasisServerConfiguration.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkCore/BasisServerConfiguration.cs
@@ -43,7 +43,7 @@ public class Configuration
     public float LowQualityDistance = 40f;
     public bool OverrideAutoDiscoveryOfIpv = false;
     public string IPv4Address = "0.0.0.0";
-    public string IPv6Address = "::1";
+    public string IPv6Address = "::";
     public string Password = "default_password";
     public bool UseAuth = true;
     public bool UseAuthIdentity = true;

--- a/Basis/Packages/com.basis.server/BasisNetworkCore/LNLConnectionTargetParser.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkCore/LNLConnectionTargetParser.cs
@@ -1,4 +1,6 @@
 using System.Globalization;
+using System.Net;
+using System.Net.Sockets;
 
 namespace Basis.Network.Core
 {
@@ -24,7 +26,9 @@ namespace Basis.Network.Core
             string portString = target.Get(ConnectionTarget.Keys.Port, DefaultPort.ToString(CultureInfo.InvariantCulture));
             string password = target.Get(ConnectionTarget.Keys.Password, string.Empty);
 
-            string s = $"{address}:{portString}";
+            bool isIPv6 = IPAddress.TryParse(address, out IPAddress ip)
+                && ip.AddressFamily == AddressFamily.InterNetworkV6;
+            string s = isIPv6 ? $"[{address}]:{portString}" : $"{address}:{portString}";
             if (!string.IsNullOrEmpty(password)) s += "#" + password;
             return s;
         }
@@ -46,23 +50,57 @@ namespace Basis.Network.Core
                 left = raw.Substring(0, hashIdx);
             }
 
-            int colonIdx = left.LastIndexOf(':');
-            if (colonIdx > 0
-                && colonIdx < left.Length - 1
-                && ushort.TryParse(left.Substring(colonIdx + 1), out ushort parsedPort)
-                && parsedPort > 0)
+            if (left.Length > 0 && left[0] == '[')
             {
-                address = left.Substring(0, colonIdx).Trim();
-                port = parsedPort;
-                portProvided = true;
+                // Bracketed IPv6 literal: [addr]:port or [addr]
+                int closeBracket = left.IndexOf(']');
+                if (closeBracket > 0)
+                {
+                    address = left.Substring(1, closeBracket - 1).Trim();
+                    string afterBracket = left.Substring(closeBracket + 1);
+                    if (afterBracket.Length > 1 && afterBracket[0] == ':')
+                    {
+                        if (ushort.TryParse(afterBracket.Substring(1), out ushort parsedPort) && parsedPort > 0)
+                        {
+                            port = parsedPort;
+                            portProvided = true;
+                        }
+                    }
+                }
+                else
+                {
+                    address = left.Trim(); // malformed bracket — treat whole string as address
+                }
             }
             else
             {
-                address = left.Trim();
+                int colonIdx = left.LastIndexOf(':');
+                if (colonIdx > 0
+                    && colonIdx < left.Length - 1
+                    && ushort.TryParse(left.Substring(colonIdx + 1), out ushort parsedPort)
+                    && parsedPort > 0)
+                {
+                    string candidateAddress = left.Substring(0, colonIdx).Trim();
+                    // If the candidate address still contains a colon it is a bare IPv6
+                    // literal (e.g. "::1", "2001:db8::1") being misread as host:port.
+                    // Leave it unsplit; the user must use [addr]:port notation for
+                    // an IPv6 address with an explicit port.
+                    if (candidateAddress.IndexOf(':') < 0)
+                    {
+                        address = candidateAddress;
+                        port = parsedPort;
+                        portProvided = true;
+                    }
+                    else
+                    {
+                        address = left.Trim();
+                    }
+                }
+                else
+                {
+                    address = left.Trim();
+                }
             }
-
-            if (address.StartsWith("[") && address.EndsWith("]") && address.Length >= 2)
-                address = address.Substring(1, address.Length - 2);
 
             return !string.IsNullOrEmpty(address);
         }

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/BasisNetworkHealthCheck.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/BasisNetworkHealthCheck.cs
@@ -1,6 +1,7 @@
 using Basis.Network.Core;
 using System;
 using System.Net;
+using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -30,15 +31,15 @@ namespace Basis.Network.Server
             // Normalize path: ensure leading slash, remove trailing slash (except root)
             pathNormalized = NormalizePath(config.HealthPath);
 
-            // Prefix must end with slash.
-            httpListener.Prefixes.Add($"http://{host}:{port}/");
+            // Prefix must end with slash. IPv6 address literals need bracket notation.
+            httpListener.Prefixes.Add($"http://{FormatHost(host)}:{port}/");
             httpListener.Start();
 
             startTimeUtc = DateTimeOffset.UtcNow;
 
             listenTask = ListenLoopAsync(cts.Token);
 
-            BNL.Log($"HTTP health check started at 'http://{host}:{port}{pathNormalized}'");
+            BNL.Log($"HTTP health check started at 'http://{FormatHost(host)}:{port}{pathNormalized}'");
         }
 
         private static string NormalizePath(string p)
@@ -164,6 +165,12 @@ namespace Basis.Network.Server
                 try { context?.Response?.Abort(); } catch { /* ignore */ }
             }
         }
+
+        // HttpListener URL prefixes require bracket notation for IPv6 address literals.
+        private static string FormatHost(string host) =>
+            IPAddress.TryParse(host, out IPAddress addr) && addr.AddressFamily == AddressFamily.InterNetworkV6
+                ? $"[{host}]"
+                : host;
 
         public void Stop() => Dispose();
 

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/BasisRestApiHandler.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/BasisRestApiHandler.cs
@@ -2,6 +2,7 @@
 using Basis.Network.Core;
 using System;
 using System.Net;
+using System.Net.Sockets;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
@@ -24,10 +25,10 @@ namespace Basis.Network.Server
             _keyHash = string.IsNullOrEmpty(_apiKey)
                 ? Array.Empty<byte>()
                 : HashBytes(Encoding.UTF8.GetBytes(_apiKey));
-            _listener.Prefixes.Add($"http://{config.ApiHost}:{config.ApiPort}/");
+            _listener.Prefixes.Add($"http://{FormatHost(config.ApiHost)}:{config.ApiPort}/");
             _listener.Start();
             _ = ListenLoopAsync(_cts.Token);
-            BNL.Log($"REST API started at http://{config.ApiHost}:{config.ApiPort}/api/");
+            BNL.Log($"REST API started at http://{FormatHost(config.ApiHost)}:{config.ApiPort}/api/");
         }
 
         private async Task ListenLoopAsync(CancellationToken token)
@@ -97,6 +98,12 @@ namespace Basis.Network.Server
             using var sha = SHA256.Create();
             return sha.ComputeHash(data);
         }
+
+        // HttpListener URL prefixes require bracket notation for IPv6 address literals.
+        private static string FormatHost(string host) =>
+            IPAddress.TryParse(host, out IPAddress addr) && addr.AddressFamily == AddressFamily.InterNetworkV6
+                ? $"[{host}]"
+                : host;
 
         public void Dispose()
         {

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/NetworkServer.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/NetworkServer.cs
@@ -187,29 +187,30 @@ public static class NetworkServer
 
     public static void StartListening(Configuration configuration)
     {
+        IPAddress ipv4, ipv6;
         if (configuration.OverrideAutoDiscoveryOfIpv)
         {
-            IPAddress? IPv4Address, IPv6Address;
-            if (!IPAddress.TryParse(Configuration.IPv4Address, out IPv4Address))
+            if (!IPAddress.TryParse(Configuration.IPv4Address, out ipv4))
             {
-                BNL.LogWarning("Failed to parse IPv4 bind address, falling back to 0.0.0.0");
-                IPv4Address = IPAddress.Parse("0.0.0.0");
+                BNL.LogWarning($"Failed to parse IPv4 bind address '{Configuration.IPv4Address}', falling back to 0.0.0.0");
+                ipv4 = IPAddress.Any;
             }
-
-            if (!IPAddress.TryParse(Configuration.IPv6Address, out IPv6Address))
+            if (!IPAddress.TryParse(Configuration.IPv6Address, out ipv6))
             {
-                BNL.LogWarning("Failed to parse IPv6 bind address, falling back to ::");
-                IPv6Address = IPAddress.IPv6Any;
+                BNL.LogWarning($"Failed to parse IPv6 bind address '{Configuration.IPv6Address}', falling back to [::]");
+                ipv6 = IPAddress.IPv6Any;
             }
-
-            BNL.Log($"Server Wiring up SetPort {Configuration.SetPort} IPv6Address {Configuration.IPv6Address}");
-            Server.Start(IPv4Address, IPv6Address, Configuration.SetPort);
         }
         else
         {
-            BNL.Log($"Server Wiring up SetPort {Configuration.SetPort}");
-            Server.Start(IPAddress.Any, IPAddress.IPv6Any, Configuration.SetPort);
+            ipv4 = IPAddress.Any;
+            ipv6 = IPAddress.IPv6Any;
         }
+
+        Server.Start(ipv4, ipv6, configuration.SetPort);
+        BNL.Log($"Listening on UDP port {configuration.SetPort}");
+        BNL.Log($"  IPv4 bind: {ipv4}");
+        BNL.Log($"  IPv6 bind: [{ipv6}]");
     }
     #endregion
     public static void BroadcastMessageToClients(NetDataWriter writer, byte channel, NetPeer sender, ReadOnlySpan<NetPeer> clients, DeliveryMethod deliveryMethod = DeliveryMethod.Sequenced, int maxMessages = 70)

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/NetworkServer.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/NetworkServer.cs
@@ -198,8 +198,8 @@ public static class NetworkServer
 
             if (!IPAddress.TryParse(Configuration.IPv6Address, out IPv6Address))
             {
-                BNL.LogWarning("Failed to parse IPv6 bind address, falling back to ::1");
-                IPv6Address = IPAddress.Parse("::1");
+                BNL.LogWarning("Failed to parse IPv6 bind address, falling back to ::");
+                IPv6Address = IPAddress.IPv6Any;
             }
 
             BNL.Log($"Server Wiring up SetPort {Configuration.SetPort} IPv6Address {Configuration.IPv6Address}");


### PR DESCRIPTION
## Summary
<!-- What does this PR change and why? Link related issues. -->

## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [X] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [X] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [X] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [X] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [X] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [X] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — `BasisEventDriver` runs the single per-frame tick that drives the whole framework (network apply, local player sim, blendshapes, JigglePhysics, nameplates, and more) as one sequential chain. An unhandled exception anywhere in that chain aborts the rest of the tick, so every step after the throwing one is silently skipped for that frame. New work added to the driver must either be guaranteed not to throw, or be wrapped in a `try`/`catch` that contains the failure and surfaces it through `BasisDebug` — logged once / rate-limited, never every frame (see the existing `HVRBasisBuiltInAddresses.Simulate()` guard for the pattern). Expect this to be scrutinized closely in review.
- [X] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [X] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [X] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [X] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [X] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [X] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [X] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [X] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [X] Windows
- [X] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [ ] Tested in VR (note headset under **Notes**)
- [ ] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [X] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [X] N/A — change does not touch any of the above

## Notes
<!-- Optional context for reviewers. Headset model, why a required box is N/A, anything else worth knowing. -->
# What is this PR?

IPv6 support in Basis was broken in a few ways.

By default, both Basis Server and Basis Client treated ::1 as the unspecified address, equivalent to 0.0.0.0 in IPv4. However, ::1 is actually the IPv6 loopback address, equivalent to 127.0.0.1. The IPv6 unspecified address is ::. Because of this, IPv6 connections could not be established correctly.

Connection attempts have been updated to follow the general IPv6/IPv4 behavior described in RFC 6724: try IPv6 first, and fall back to IPv4 if IPv6 fails.

Additional fixes include:

The UI now accepts IPv6 addresses in square-bracket format, for example: [2600:215::1d41]
Logging has been updated to parse IPv6 addresses correctly.
Existing Basis deployments should not be affected by this PR, since IPv4 continues to function as it did before.

For the Basis test server, dual-stack networking should be deployed as follows:

Deploy this update to both servers and clients.
Update config.xml and set <IPv6Address> to ::.
Create a AAAA DNS record pointing to the server’s IPv6 address.
I recommend setting a low TTL, such as 30 seconds, while testing so IPv6 DNS changes can be verified quickly.

<img width="1365" height="455" alt="Screenshot 2026-06-13 172316" src="https://github.com/user-attachments/assets/931e304d-e1ae-49e5-81d5-0c61eb61dfdd" />
<img width="1171" height="216" alt="Screenshot 2026-06-13 172351" src="https://github.com/user-attachments/assets/da8ee32d-e5d7-4847-9883-84f07bb63b2e" />
<img width="1552" height="362" alt="Screenshot 2026-06-13 173120" src="https://github.com/user-attachments/assets/47b6c487-f8a1-4597-819b-a078a612bcbc" />
