### PR TITLE
fix(mediaplayer): mute audio with an error when source rate differs from output

### DIFF
--- a/Basis/Packages/com.basis.mediaplayer/Runtime/BasisMediaPlayer.cs
+++ b/Basis/Packages/com.basis.mediaplayer/Runtime/BasisMediaPlayer.cs
@@ -274,6 +274,7 @@ public sealed class BasisMediaPlayer : MonoBehaviour
     private BasisAudioTrack pendingAudioTrack;
     private Exception pendingError;
     private bool firstFrameEmittedThisPlay;
+    private bool audioRateMismatchReported;
 
     public long HeadFramePtsUs => videoQueue.TryPeek(out var head) ? head.PresentationTimeUs : -1;
     public long TailFramePtsUs => System.Threading.Interlocked.Read(ref lastEnqueuedPtsUs);
@@ -756,6 +757,7 @@ public sealed class BasisMediaPlayer : MonoBehaviour
         pendingBitrateTrack = null;
         pendingError = null;
         pendingVideoSize = 0;
+        audioRateMismatchReported = false;
     }
 
     private void ResetCounters()
@@ -989,7 +991,25 @@ public sealed class BasisMediaPlayer : MonoBehaviour
 
         if (nativeEngine.TryGetPcmFormat(out int sr, out int ch) && sr > 0 && ch > 0)
         {
-            audioComponent?.SetExpectedFormat(sr, ch);
+            // The streaming AudioClip is consumed at the output device rate
+            // regardless of its declared frequency, so a source whose rate differs
+            // plays sharp/flat and over-drains its buffer. Guard it: on a mismatch
+            // leave the audio path unbuilt (silent) and surface why, so the stream
+            // is muted cleanly rather than played wrong. Video is unaffected.
+            int outputRate = AudioSettings.outputSampleRate;
+            if (sr != outputRate)
+            {
+                if (!audioRateMismatchReported)
+                {
+                    audioRateMismatchReported = true;
+                    HandleError(new Exception(
+                        $"Audio muted: source sample rate {sr} Hz does not match the audio output rate {outputRate} Hz. Re-encode the audio to {outputRate} Hz."));
+                }
+            }
+            else
+            {
+                audioComponent?.SetExpectedFormat(sr, ch);
+            }
         }
 
         Texture tex = nativeEngine.OutputTexture;


### PR DESCRIPTION
## Summary

Audio fed through the streaming `AudioClip` path is consumed by Unity at the audio **output device** rate (typically 48 kHz) regardless of the clip's declared frequency. A source whose audio sample rate differs — 44.1 kHz is the common case — plays ~8.8% sharp and over-drains its PCM buffer, giving periodic dropouts.

This guards that mismatch. When the decoder reports the PCM format and the source rate doesn't match `AudioSettings.outputSampleRate`, the player leaves the audio path unbuilt — so the stream is cleanly silent instead of played wrong — and raises `OnError` once with a message telling the user to re-encode to the output rate. Video is unaffected.

A few notes on shape:
- **One choke point.** `BasisMediaPlayerAudio` is fed only by the native engine's PCM ring, so the single check at the format-report point in `PollNativeEngineStatus` covers every audio path.
- **Compares against the real output rate**, not a literal 48000 — so it's correct on a machine whose output device runs at 44.1 kHz too (there a 44.1 kHz source plays fine and a 48 kHz one would be the mismatch).
- **Reuses the existing `OnError` surface** — no new API. A per-source flag keeps it to one error per source rather than firing every frame.
- It fires just after playback starts (the rate isn't known until the decoder opens the stream), not as a pre-flight block — video shows, then audio drops to silence with the error within a frame or two.

## Proof of tested

Loading a VRCDN **RTSPT** live stream whose audio sample rate doesn't match the project's 48 kHz output: the guard fires — audio is muted and the `OnError` message is logged to the console.

<img width="1072" height="194" alt="{2804D9C2-49B4-44BE-90FF-68228C017462}" src="https://github.com/user-attachments/assets/c23df0d3-dc77-4939-8d72-8d4d3d8c2c66" />

## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [x] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — `BasisEventDriver` runs the single per-frame tick that drives the whole framework (network apply, local player sim, blendshapes, JigglePhysics, nameplates, and more) as one sequential chain. An unhandled exception anywhere in that chain aborts the rest of the tick, so every step after the throwing one is silently skipped for that frame. New work added to the driver must either be guaranteed not to throw, or be wrapped in a `try`/`catch` that contains the failure and surfaces it through `BasisDebug` — logged once / rate-limited, never every frame (see the existing `HVRBasisBuiltInAddresses.Simulate()` guard for the pattern). Expect this to be scrutinized closely in review.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [x] Windows
- [ ] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [ ] Tested in VR (note headset under **Notes**)
- [ ] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [x] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [x] N/A — change does not touch any of the above

## Notes

**Most required boxes are N/A** — this is a single guarded branch on the audio format-report path, not gameplay/transform/asset/camera code. Specifics for the ones worth a word:

- **Per-frame / hot-path boxes:** the check lives inside the existing `PollNativeEngineStatus` (already driven per-frame by the player) — it adds no new `Update`/driver callback. The steady-state per-frame cost is an `int` compare (`sr != AudioSettings.outputSampleRate`); the only allocation and the only log call (the `OnError` exception + its message string, via `BasisDebug.LogError` in the existing `HandleError`) sit behind a `audioRateMismatchReported` guard that fires **once per source**, not every frame.
- **Logging:** routes through the existing `HandleError` → `BasisDebug.LogError` (LogTag.Video).
- **Jobification:** N/A — a one-shot conditional, nothing to parallelise.

**Verification:** runtime-tested on a Windows build — streaming a 44.1 kHz source against a 48 kHz output mutes audio and raises the error in the console as expected; a 48 kHz source is unchanged. Compiles clean (no IDE diagnostics).
