### PR TITLE
Vr throw fix

### DIFF
--- a/Basis/Packages/com.basis.framework/Interactions/BasisPickupInteractable.cs
+++ b/Basis/Packages/com.basis.framework/Interactions/BasisPickupInteractable.cs
@@ -607,12 +607,16 @@ namespace Basis.Scripts.BasisSdk.Interactions
                 if (wrapper.GetState() == BasisInteractInputState.Interacting)
                 {
                     UpdateHeldPoseFromInput(wrapper, false);
+                    if (_pickupUseLastEffectiveState)
+                    {
+                        OnPickupUse?.Invoke(BasisPickUpUseMode.OnPickUpUseUp);
+                    }
+                    _pickupUseLastEffectiveState = false;
+                    _pickupUsePendingReleaseAfterUI = false;
 
                     Inputs.ChangeStateByRole(wrapper.Role, BasisInteractInputState.Ignored);
 
                     RequiresUpdateLoop = false;
-                    _pickupUseLastEffectiveState = false;
-                    _pickupUsePendingReleaseAfterUI = false;
                     // cleanup Desktop Manipulation since InputUpdate isn't run again till next pickup
                     targetOffset = Vector3.zero;
                     if (pauseHead)

--- a/Basis/Packages/com.basis.framework/Interactions/BasisPickupInteractable.cs
+++ b/Basis/Packages/com.basis.framework/Interactions/BasisPickupInteractable.cs
@@ -756,7 +756,7 @@ namespace Basis.Scripts.BasisSdk.Interactions
 
         private void UpdateHeldPoseFromInput(BasisInputWrapper interactingInput, bool pollControls)
         {
-            if (_lerping)
+            if (pollControls && _lerping)
             {
                 _lerpElapsed += Time.deltaTime;
                 float t = Mathf.Clamp01(_lerpElapsed / lerpToHandDuration);

--- a/Basis/Packages/com.basis.framework/Interactions/BasisPickupInteractable.cs
+++ b/Basis/Packages/com.basis.framework/Interactions/BasisPickupInteractable.cs
@@ -534,6 +534,10 @@ namespace Basis.Scripts.BasisSdk.Interactions
                     InputConstraint.SetRestPositionAndRotation(restPos, restRot);
 
                     transform.GetPositionAndRotation(out Vector3 ActivePosition, out Quaternion ActiveRotation);
+                    _previousPosition = ActivePosition;
+                    _previousRotation = ActiveRotation;
+                    linearVelocity = Vector3.zero;
+                    angularVelocity = Vector3.zero;
 
                     Vector3 offsetPos;
                     bool inDesktop = BasisDeviceManagement.IsUserInDesktop();
@@ -602,6 +606,8 @@ namespace Basis.Scripts.BasisSdk.Interactions
             {
                 if (wrapper.GetState() == BasisInteractInputState.Interacting)
                 {
+                    UpdateHeldPoseFromInput(wrapper, false);
+
                     Inputs.ChangeStateByRole(wrapper.Role, BasisInteractInputState.Ignored);
 
                     RequiresUpdateLoop = false;
@@ -741,6 +747,11 @@ namespace Basis.Scripts.BasisSdk.Interactions
         {
             if (!GetActiveInteracting(out BasisInputWrapper interactingInput)) return;
 
+            UpdateHeldPoseFromInput(interactingInput, true);
+        }
+
+        private void UpdateHeldPoseFromInput(BasisInputWrapper interactingInput, bool pollControls)
+        {
             if (_lerping)
             {
                 _lerpElapsed += Time.deltaTime;
@@ -766,9 +777,12 @@ namespace Basis.Scripts.BasisSdk.Interactions
 
             if (inDesktop)
             {
-                PollDesktopControl(Inputs.desktopCenterEye.Source);
+                if (pollControls)
+                {
+                    PollDesktopControl(Inputs.desktopCenterEye.Source);
+                }
             }
-            else
+            else if (pollControls)
             {
                 // If trigger pulled on opposing input, scale object based on hand distance
                 if (enableScaleWithGesture && GetOppositeInteracting(out BasisInputWrapper opposingInput))
@@ -807,47 +821,10 @@ namespace Basis.Scripts.BasisSdk.Interactions
                 }
             }
 
-            // Trigger state machine for OnPickupUse.
-            // Suppressed while the holding input is targeting UI (ray or direct touch) so
-            // clicking a UI panel with a pickup in hand doesn't fire the pickup's use action.
-            BasisInput useSource = interactingInput.Source;
-            bool uiActive =
-                (useSource.BasisUIRaycast != null && useSource.BasisUIRaycast.HadRaycastUITarget) ||
-                (BasisDirectTouch.Instance != null && BasisDirectTouch.Instance.IsDeviceTouching(useSource));
-            bool rawState = HasState(useSource.CurrentInputState, InputKey);
-
-            bool effectiveState;
-            if (uiActive)
+            if (pollControls)
             {
-                // If the button is held while entering/on UI, require a release before the next use fire
-                // so dragging the hand off UI while still held doesn't phantom-fire UseDown.
-                if (rawState) _pickupUsePendingReleaseAfterUI = true;
-                effectiveState = false;
+                PollPickupUse(interactingInput.Source);
             }
-            else if (_pickupUsePendingReleaseAfterUI)
-            {
-                if (!rawState) _pickupUsePendingReleaseAfterUI = false;
-                effectiveState = false;
-            }
-            else
-            {
-                effectiveState = rawState;
-            }
-
-            bool lastEffective = _pickupUseLastEffectiveState;
-            if (effectiveState && !lastEffective)
-            {
-                OnPickupUse?.Invoke(BasisPickUpUseMode.OnPickUpUseDown);
-            }
-            else if (!effectiveState && lastEffective)
-            {
-                OnPickupUse?.Invoke(BasisPickUpUseMode.OnPickUpUseUp);
-            }
-            else if (effectiveState)
-            {
-                OnPickupUse?.Invoke(BasisPickUpUseMode.OnPickUpStillDown);
-            }
-            _pickupUseLastEffectiveState = effectiveState;
 
             InputConstraint.UpdateSourcePositionAndRotation(0, inPos, inRot);
 
@@ -926,6 +903,50 @@ namespace Basis.Scripts.BasisSdk.Interactions
                 }
                 CalculateVelocity(pos, rot);
             }
+        }
+
+        private void PollPickupUse(BasisInput useSource)
+        {
+            // Trigger state machine for OnPickupUse.
+            // Suppressed while the holding input is targeting UI (ray or direct touch) so
+            // clicking a UI panel with a pickup in hand doesn't fire the pickup's use action.
+            bool uiActive =
+                (useSource.BasisUIRaycast != null && useSource.BasisUIRaycast.HadRaycastUITarget) ||
+                (BasisDirectTouch.Instance != null && BasisDirectTouch.Instance.IsDeviceTouching(useSource));
+            bool rawState = HasState(useSource.CurrentInputState, InputKey);
+
+            bool effectiveState;
+            if (uiActive)
+            {
+                // If the button is held while entering/on UI, require a release before the next use fire
+                // so dragging the hand off UI while still held doesn't phantom-fire UseDown.
+                if (rawState) _pickupUsePendingReleaseAfterUI = true;
+                effectiveState = false;
+            }
+            else if (_pickupUsePendingReleaseAfterUI)
+            {
+                if (!rawState) _pickupUsePendingReleaseAfterUI = false;
+                effectiveState = false;
+            }
+            else
+            {
+                effectiveState = rawState;
+            }
+
+            bool lastEffective = _pickupUseLastEffectiveState;
+            if (effectiveState && !lastEffective)
+            {
+                OnPickupUse?.Invoke(BasisPickUpUseMode.OnPickUpUseDown);
+            }
+            else if (!effectiveState && lastEffective)
+            {
+                OnPickupUse?.Invoke(BasisPickUpUseMode.OnPickUpUseUp);
+            }
+            else if (effectiveState)
+            {
+                OnPickupUse?.Invoke(BasisPickUpUseMode.OnPickUpStillDown);
+            }
+            _pickupUseLastEffectiveState = effectiveState;
         }
 
         /// <summary>

--- a/Basis/Packages/com.basis.framework/Interactions/BasisPickupInteractable.cs
+++ b/Basis/Packages/com.basis.framework/Interactions/BasisPickupInteractable.cs
@@ -827,7 +827,46 @@ namespace Basis.Scripts.BasisSdk.Interactions
 
             if (pollControls)
             {
-                PollPickupUse(interactingInput.Source);
+                // Pickup use is normal input polling, so release-time pose sampling skips it.
+                // UI interaction suppresses use until the input is released away from UI.
+                BasisInput useSource = interactingInput.Source;
+                bool uiActive =
+                    (useSource.BasisUIRaycast != null && useSource.BasisUIRaycast.HadRaycastUITarget) ||
+                    (BasisDirectTouch.Instance != null && BasisDirectTouch.Instance.IsDeviceTouching(useSource));
+                bool rawState = HasState(useSource.CurrentInputState, InputKey);
+
+                bool effectiveState;
+                if (uiActive)
+                {
+                    // If the button is held while entering/on UI, require a release before the next use fire
+                    // so dragging the hand off UI while still held doesn't phantom-fire UseDown.
+                    if (rawState) _pickupUsePendingReleaseAfterUI = true;
+                    effectiveState = false;
+                }
+                else if (_pickupUsePendingReleaseAfterUI)
+                {
+                    if (!rawState) _pickupUsePendingReleaseAfterUI = false;
+                    effectiveState = false;
+                }
+                else
+                {
+                    effectiveState = rawState;
+                }
+
+                bool lastEffective = _pickupUseLastEffectiveState;
+                if (effectiveState && !lastEffective)
+                {
+                    OnPickupUse?.Invoke(BasisPickUpUseMode.OnPickUpUseDown);
+                }
+                else if (!effectiveState && lastEffective)
+                {
+                    OnPickupUse?.Invoke(BasisPickUpUseMode.OnPickUpUseUp);
+                }
+                else if (effectiveState)
+                {
+                    OnPickupUse?.Invoke(BasisPickUpUseMode.OnPickUpStillDown);
+                }
+                _pickupUseLastEffectiveState = effectiveState;
             }
 
             InputConstraint.UpdateSourcePositionAndRotation(0, inPos, inRot);
@@ -907,50 +946,6 @@ namespace Basis.Scripts.BasisSdk.Interactions
                 }
                 CalculateVelocity(pos, rot);
             }
-        }
-
-        private void PollPickupUse(BasisInput useSource)
-        {
-            // Trigger state machine for OnPickupUse.
-            // Suppressed while the holding input is targeting UI (ray or direct touch) so
-            // clicking a UI panel with a pickup in hand doesn't fire the pickup's use action.
-            bool uiActive =
-                (useSource.BasisUIRaycast != null && useSource.BasisUIRaycast.HadRaycastUITarget) ||
-                (BasisDirectTouch.Instance != null && BasisDirectTouch.Instance.IsDeviceTouching(useSource));
-            bool rawState = HasState(useSource.CurrentInputState, InputKey);
-
-            bool effectiveState;
-            if (uiActive)
-            {
-                // If the button is held while entering/on UI, require a release before the next use fire
-                // so dragging the hand off UI while still held doesn't phantom-fire UseDown.
-                if (rawState) _pickupUsePendingReleaseAfterUI = true;
-                effectiveState = false;
-            }
-            else if (_pickupUsePendingReleaseAfterUI)
-            {
-                if (!rawState) _pickupUsePendingReleaseAfterUI = false;
-                effectiveState = false;
-            }
-            else
-            {
-                effectiveState = rawState;
-            }
-
-            bool lastEffective = _pickupUseLastEffectiveState;
-            if (effectiveState && !lastEffective)
-            {
-                OnPickupUse?.Invoke(BasisPickUpUseMode.OnPickUpUseDown);
-            }
-            else if (!effectiveState && lastEffective)
-            {
-                OnPickupUse?.Invoke(BasisPickUpUseMode.OnPickUpUseUp);
-            }
-            else if (effectiveState)
-            {
-                OnPickupUse?.Invoke(BasisPickUpUseMode.OnPickUpStillDown);
-            }
-            _pickupUseLastEffectiveState = effectiveState;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
* Fixes the velocity retention while in VR when letting go of pickup objects.
* `UpdateHeldPoseFromInput` as a function to be called when item is let go and while actively controlling an controller input.

## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [x] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — `BasisEventDriver` runs the single per-frame tick that drives the whole framework (network apply, local player sim, blendshapes, JigglePhysics, nameplates, and more) as one sequential chain. An unhandled exception anywhere in that chain aborts the rest of the tick, so every step after the throwing one is silently skipped for that frame. New work added to the driver must either be guaranteed not to throw, or be wrapped in a `try`/`catch` that contains the failure and surfaces it through `BasisDebug` — logged once / rate-limited, never every frame (see the existing `HVRBasisBuiltInAddresses.Simulate()` guard for the pattern). Expect this to be scrutinized closely in review.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [x] Windows
- [ ] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [x] Tested in VR (note headset under **Notes**)
- [x] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [ ] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [x] N/A — change does not touch any of the above

## Notes
<!-- Optional context for reviewers. Headset model, why a required box is N/A, anything else worth knowing. -->
