### PR TITLE
feat(mediaplayer): video resolver registry + sanitized URLs + https URL normalisation  

### DIFF
--- a/Basis/Packages/com.basis.integration.ytdlp/README.md
+++ b/Basis/Packages/com.basis.integration.ytdlp/README.md
@@ -55,9 +55,12 @@ BasisMediaSource source = await BasisYtDlpResolver.ResolveSourceAsync(pageUrl);
   to nothing unless both are present (asmdef define constraints
   `BASIS_MEDIAPLAYER_EXISTS` + `YTDLP_EXISTS`).
 - **Windows** today — the yt-dlp native plugin is Windows-first.
-- The first resolution unpacks the bundled Python runtime (tens of MB) to persistent
-  storage and is noticeably slow; later calls are fast. Resolution runs off the main
-  thread.
+- **Expect a few seconds per page-URL load.** The *first* resolution also unpacks the
+  bundled Python runtime (tens of MB) to persistent storage — a one-off, noticeably slow
+  step that later loads skip. But every page-URL load still spends a few seconds resolving
+  in-process (network round-trips plus YouTube's JS signature challenge), not just the
+  first. Resolution runs off the main thread, and nothing is surfaced on the player during
+  the gap, so a consuming UI should show its own loading state.
 
 ## Removing it
 

--- a/Basis/Packages/com.basis.integration.ytdlp/Runtime/BasisYtDlpResolver.cs
+++ b/Basis/Packages/com.basis.integration.ytdlp/Runtime/BasisYtDlpResolver.cs
@@ -141,16 +141,34 @@ namespace Basis.Integration.YtDlp
                 return new BasisMediaSource { Uri = video.Url, AudioUri = audio.Url, Delivery = BasisMediaDelivery.OnDemand };
 
             Format muxed = BestMuxed(info.Formats);
-            if (muxed != null) return new BasisMediaSource { Uri = muxed.Url };
+            if (muxed != null) return new BasisMediaSource { Uri = muxed.Url, Delivery = DeliveryFor(info) };
 
             // Last resort: yt-dlp's top-level URL — but only if the player can open it
             // directly. An unvalidated DirectUrl can be an unsupported manifest/codec that
             // would bypass the avc1/mp4a filtering above, so reject it and let
             // ResolveSourceAsync fail loudly ("no player-ingestible format") instead.
             if (!string.IsNullOrEmpty(info.DirectUrl) && BasisMediaUrlRouter.IsDirectlyPlayable(info.DirectUrl))
-                return new BasisMediaSource { Uri = info.DirectUrl };
+                return new BasisMediaSource { Uri = info.DirectUrl, Delivery = DeliveryFor(info) };
 
             return null;
+        }
+
+        // Maps yt-dlp's live-status metadata onto the engine's delivery hint, so the
+        // live-vs-VOD clock is chosen at open instead of sniffed from the byte stream.
+        // Absent/unknown status falls back to Auto (the engine detects a seekable,
+        // finite body as VOD and an open-ended stream as live). The split avc1+mp4a
+        // path doesn't consult this — that pairing is only ever adaptive VOD.
+        private static BasisMediaDelivery DeliveryFor(VideoInfo info)
+        {
+            if (info.IsLive == true) return BasisMediaDelivery.Live;
+            switch (info.LiveStatus)
+            {
+                case "is_live":
+                case "is_upcoming": return BasisMediaDelivery.Live;
+                case "was_live":
+                case "not_live":    return BasisMediaDelivery.OnDemand;
+                default:            return BasisMediaDelivery.Auto;
+            }
         }
 
         // H.264 video-only, no higher than 1080p (avc1 is the player's ceiling — no

--- a/Basis/Packages/com.basis.integration.ytdlp/Runtime/BasisYtDlpResolver.cs
+++ b/Basis/Packages/com.basis.integration.ytdlp/Runtime/BasisYtDlpResolver.cs
@@ -75,8 +75,12 @@ namespace Basis.Integration.YtDlp
             catch (OperationCanceledException) { }
             catch (Exception ex)
             {
-                BasisDebug.LogError($"yt-dlp resolution failed for '{pageUrl}': {ex.Message}", BasisDebug.LogTag.Video);
-                onError?.Invoke(ex);
+                // Log the exception type, not ex.Message — yt-dlp/extractor messages embed the
+                // raw page URL (and its tokens), which would defeat the redaction above.
+                BasisDebug.LogError($"yt-dlp resolution failed for '{BasisMediaUrlRouter.Redact(pageUrl)}' ({ex.GetType().Name}).", BasisDebug.LogTag.Video);
+                // Only report if this resolve still owns the player — a newer LoadUrl since
+                // capture supersedes us, and its outcome must not be clobbered by our failure.
+                if (loadGen == player.LoadGeneration) onError?.Invoke(ex);
             }
         }
 
@@ -91,7 +95,7 @@ namespace Basis.Integration.YtDlp
             VideoInfo info = await YtDlpApi.ExtractAsync(pageUrl, opts: null, cancellationToken: cancellationToken);
             BasisMediaSource source = SelectSource(info);
             if (source == null || string.IsNullOrEmpty(source.Uri))
-                throw new YtDlpException($"yt-dlp returned no player-ingestible format for '{pageUrl}'.");
+                throw new YtDlpException($"yt-dlp returned no player-ingestible format for '{BasisMediaUrlRouter.Redact(pageUrl)}'.");
             return source;
         }
 
@@ -166,6 +170,7 @@ namespace Basis.Integration.YtDlp
                 case "is_live":
                 case "is_upcoming": return BasisMediaDelivery.Live;
                 case "was_live":
+                case "post_live":   // ended broadcast, VOD still processing — watched as a recording
                 case "not_live":    return BasisMediaDelivery.OnDemand;
                 default:            return BasisMediaDelivery.Auto;
             }

--- a/Basis/Packages/com.basis.integration.ytdlp/Runtime/BasisYtDlpRouterInstaller.cs
+++ b/Basis/Packages/com.basis.integration.ytdlp/Runtime/BasisYtDlpRouterInstaller.cs
@@ -4,37 +4,39 @@ using UnityEngine;
 namespace Basis.Integration.YtDlp
 {
     /// <summary>
-    /// Installs the yt-dlp resolver into <see cref="BasisMediaUrlRouter"/> at startup,
-    /// so any player URL field (e.g. <c>BasisMediaPlayerStreaming</c>) steers page URLs
-    /// through yt-dlp while directly-playable streams load unchanged. The player core
-    /// holds no reference to this package; removing the package removes the
-    /// registration (the router falls back to direct loads), with nothing dangling.
+    /// Registers the yt-dlp resolver with <see cref="BasisMediaUrlRouter"/> at startup, so any
+    /// player URL field (e.g. <c>BasisMediaPlayerStreaming</c>) steers page URLs through yt-dlp
+    /// while directly-playable streams load unchanged. The player core holds no reference to this
+    /// package; removing the package removes the registration (the router falls back to direct
+    /// loads, or to another registered resolver), with nothing dangling.
     /// </summary>
     internal static class BasisYtDlpRouterInstaller
     {
+        private static BasisYtDlpVideoResolver installed;
+
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         private static void Install()
         {
-            // The router holds a single resolver slot. Don't clobber another package's resolver
-            // if one is already installed — first-come wins, and the collision is surfaced rather
-            // than silently overwritten.
-            if (BasisMediaUrlRouter.Resolver != null)
-            {
-                BasisDebug.LogWarning(
-                    "A BasisMediaUrlRouter resolver is already installed; the yt-dlp resolver will not replace it.",
-                    BasisDebug.LogTag.Video);
-                return;
-            }
+            if (installed != null) return; // idempotent across domain reloads
+            installed = new BasisYtDlpVideoResolver();
+            BasisMediaUrlRouter.Register(installed);
+        }
+    }
 
-            BasisMediaUrlRouter.Resolver = (player, url) =>
-            {
-                // Already directly playable (transport scheme or media-extension URL):
-                // decline so the caller loads it directly. Otherwise it's a page URL —
-                // resolve it to its stream(s) and load (async).
-                if (!BasisYtDlpResolver.NeedsResolution(url)) return false;
-                BasisYtDlpResolver.ResolveAndPlay(player, url);
-                return true;
-            };
+    /// <summary>
+    /// Routes page URLs (YouTube, Twitch, …) through the in-process yt-dlp resolver. Directly
+    /// playable URLs are declined via <see cref="CanResolve"/> so the player opens them itself.
+    /// </summary>
+    internal sealed class BasisYtDlpVideoResolver : IBasisVideoResolver
+    {
+        public int Priority => 0;
+
+        public bool CanResolve(string url) => BasisYtDlpResolver.NeedsResolution(url);
+
+        public bool TryResolve(BasisMediaPlayer player, string url)
+        {
+            BasisYtDlpResolver.ResolveAndPlay(player, url);
+            return true;
         }
     }
 }

--- a/Basis/Packages/com.basis.integration.ytdlp/Runtime/BasisYtDlpRouterInstaller.cs
+++ b/Basis/Packages/com.basis.integration.ytdlp/Runtime/BasisYtDlpRouterInstaller.cs
@@ -29,7 +29,12 @@ namespace Basis.Integration.YtDlp
     /// </summary>
     internal sealed class BasisYtDlpVideoResolver : IBasisVideoResolver
     {
-        public int Priority => 0;
+        // yt-dlp is the generic last-resort resolver — it can attempt almost any page URL, so it
+        // registers at the lowest priority and only sees URLs no more-specific resolver claimed.
+        // CanResolve stays broad on purpose: there's no cheap, non-blocking way to know which of
+        // yt-dlp's sites a URL belongs to without running (async) extraction, so the fallback takes
+        // any non-directly-playable URL and surfaces failures via the async resolve path.
+        public int Priority => int.MinValue;
 
         public bool CanResolve(string url) => BasisYtDlpResolver.NeedsResolution(url);
 

--- a/Basis/Packages/com.basis.integration.ytdlp/Runtime/BasisYtDlpRouterInstaller.cs
+++ b/Basis/Packages/com.basis.integration.ytdlp/Runtime/BasisYtDlpRouterInstaller.cs
@@ -40,7 +40,10 @@ namespace Basis.Integration.YtDlp
 
         public bool TryResolve(BasisMediaPlayer player, string url)
         {
-            BasisYtDlpResolver.ResolveAndPlay(player, url);
+            // We claim ownership (return true), so LoadUrl stops here and relies on us to report
+            // failure. Route resolve errors back to the player so an unsupported/failed page URL
+            // surfaces a message instead of leaving it silently at NoMedia.
+            BasisYtDlpResolver.ResolveAndPlay(player, url, onError: player.ReportLoadError);
             return true;
         }
     }

--- a/Basis/Packages/com.basis.mediaplayer/README.md
+++ b/Basis/Packages/com.basis.mediaplayer/README.md
@@ -100,9 +100,10 @@ A null `AudioUri` (the default) is an ordinary single muxed stream.
 
 The player opens **stream** URLs (the schemes above) directly. It does **not** itself
 turn a **page** URL — a YouTube or Twitch watch page — into a stream. That resolution
-is provided by a **separate, optional package** (a yt-dlp-based resolver) which
-registers itself on `BasisMediaUrlRouter`; the player core has no dependency on it and
-never references it.
+is provided by a **separate, optional resolver package** which registers itself on
+`BasisMediaUrlRouter`; the player core has no dependency on it and never references it.
+Basis ships a yt-dlp-based resolver as that package, but any
+[resolver](#writing-a-resolver) can fill the role.
 
 **With the resolver package installed**, a URL field such as
 `BasisMediaPlayerStreaming.StreamUrl` steers each URL automatically:
@@ -115,9 +116,9 @@ never references it.
 **Without it**, the router is inert: every URL loads directly, so all the stream URLs
 above keep working — but page URLs are no longer resolved, so **YouTube, Twitch and
 similar links won't play**. Loading one degrades gracefully rather than failing silently:
-the player goes to an error state with a short message — *"…needs the optional yt-dlp
-resolver package, which isn't installed."* — shown in the **Media Players** panel and
-logged once as a warning (it never throws or tries to demux the HTML page). Removing the
+the player goes to an error state with a short message — *"…needs a media URL resolver
+package, and none is installed."* — shown in the **Media Players** panel and logged once
+as a warning (it never throws or tries to demux the HTML page). Removing the
 package is a supported choice: you lose common-site resolution and nothing else. (This
 only steers — it never blocks a URL; host trust is enforced separately.)
 

--- a/Basis/Packages/com.basis.mediaplayer/README.md
+++ b/Basis/Packages/com.basis.mediaplayer/README.md
@@ -114,10 +114,12 @@ never references it.
 
 **Without it**, the router is inert: every URL loads directly, so all the stream URLs
 above keep working — but page URLs are no longer resolved, so **YouTube, Twitch and
-similar links won't play** (loading one reports that the resolver package is needed,
-rather than failing silently). Removing the package is a supported choice: you lose
-common-site resolution and nothing else. (This only steers — it never blocks a URL;
-host trust is enforced separately.)
+similar links won't play**. Loading one degrades gracefully rather than failing silently:
+the player goes to an error state with a short message — *"…needs the optional yt-dlp
+resolver package, which isn't installed."* — shown in the **Media Players** panel and
+logged once as a warning (it never throws or tries to demux the HTML page). Removing the
+package is a supported choice: you lose common-site resolution and nothing else. (This
+only steers — it never blocks a URL; host trust is enforced separately.)
 
 > **Known gap.** The steering keys off the URL's form, so a **direct HTTP stream with
 > no file extension** (e.g. `https://host/live/feed` with no `.ts`/`.mp4`) can't be

--- a/Basis/Packages/com.basis.mediaplayer/README.md
+++ b/Basis/Packages/com.basis.mediaplayer/README.md
@@ -231,13 +231,13 @@ configure step below. You also need Unity's PluginAPI headers — see
 `Native~/unity/README.md`.
 
 **Windows → `Plugins/Windows/x86_64/basis_media_native.dll`**
-```
+```sh
 cmake -S Native~ -B Native~/build -A x64 -DUNITY_PLUGIN_API_DIR="<UnityEditor>/Editor/Data/PluginAPI"
 cmake --build Native~/build --config Release
 ```
 
 **Android (arm64, Vulkan) → `Plugins/Android/arm64-v8a/libbasis_media_native.so`**
-```
+```sh
 cmake -S Native~ -B Native~/build-android \
   -DCMAKE_TOOLCHAIN_FILE=$NDK/build/cmake/android.toolchain.cmake \
   -DANDROID_ABI=arm64-v8a -DANDROID_PLATFORM=android-29 \

--- a/Basis/Packages/com.basis.mediaplayer/README.md
+++ b/Basis/Packages/com.basis.mediaplayer/README.md
@@ -116,9 +116,9 @@ Basis ships a yt-dlp-based resolver as that package, but any
 **Without it**, the router is inert: every URL loads directly, so all the stream URLs
 above keep working — but page URLs are no longer resolved, so **YouTube, Twitch and
 similar links won't play**. Loading one degrades gracefully rather than failing silently:
-the player goes to an error state with a short message — *"…needs a media URL resolver
-package, and none is installed."* — shown in the **Media Players** panel and logged once
-as a warning (it never throws or tries to demux the HTML page). Removing the
+the player reports a short message — *"…needs a media URL resolver
+package, and none is installed."* — surfaced in the **Media Players** panel and logged
+as a warning on each such load (it never throws or tries to demux the HTML page). Removing the
 package is a supported choice: you lose common-site resolution and nothing else. (This
 only steers — it never blocks a URL; host trust is enforced separately.)
 
@@ -164,6 +164,12 @@ internal static class MyResolverInstaller
 }
 ```
 
+- **Async resolves must guard against stale loads.** If `TryResolve` resolves
+  asynchronously, capture `player.LoadGeneration` before you start and skip your
+  `LoadSource` / `LoadUrl` when the async work completes if it no longer matches. The player
+  bumps `LoadGeneration` on every `LoadUrl`, so without this a slow resolve of an earlier URL
+  can overwrite a newer load. Return `true` as soon as you take ownership (kick off the
+  resolve), not when it finishes.
 - **Main thread only.** The resolver list is unsynchronised — `Register` / `Unregister`
   and resolution all run on Unity's main thread. Registering from
   `RuntimeInitializeOnLoadMethod` and resolving from the player's load path satisfies this.

--- a/Basis/Packages/com.basis.mediaplayer/README.md
+++ b/Basis/Packages/com.basis.mediaplayer/README.md
@@ -126,6 +126,47 @@ host trust is enforced separately.)
 > than loading directly. Give direct HTTP streams a recognised
 > extension, or use a transport scheme (`rtsp`/`rtmp`), to avoid this.
 
+### Writing a resolver
+
+A resolver is any `IBasisVideoResolver` registered on `BasisMediaUrlRouter`. The player
+core never references it — register one at startup and the router consults it for every
+load, in `Priority` order, until one takes ownership. The bundled
+[yt-dlp integration](../com.basis.integration.ytdlp/README.md) is a complete worked
+example; the shape is:
+
+```csharp
+using UnityEngine;
+
+internal sealed class MyResolver : IBasisVideoResolver
+{
+    public int Priority => 0; // higher runs first; equal priorities run in registration order
+
+    // Cheap, side-effect-free pre-filter. Decline directly-playable URLs so the player
+    // opens them itself — IsDirectlyPlayable is the shared steering check.
+    public bool CanResolve(string url) => !BasisMediaUrlRouter.IsDirectlyPlayable(url);
+
+    // Take ownership: turn the page URL into its stream(s) and load them (may be async).
+    // Return true once taken; false to fall through to the next resolver, then a direct load.
+    public bool TryResolve(BasisMediaPlayer player, string url)
+    {
+        // … resolve, then player.LoadSource(resolvedSource) / player.LoadUrl(streamUrl) …
+        return true;
+    }
+}
+
+internal static class MyResolverInstaller
+{
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+    private static void Install() => BasisMediaUrlRouter.Register(new MyResolver());
+}
+```
+
+- **Main thread only.** The resolver list is unsynchronised — `Register` / `Unregister`
+  and resolution all run on Unity's main thread. Registering from
+  `RuntimeInitializeOnLoadMethod` and resolving from the player's load path satisfies this.
+- **Routing only, never trust.** A resolver decides *how* a URL loads, not *whether* it's
+  allowed — host trust stays with `BasisMediaPlayerSecurity`.
+
 ## Usage
 
 ```csharp

--- a/Basis/Packages/com.basis.mediaplayer/Runtime/BasisMediaPlayer.cs
+++ b/Basis/Packages/com.basis.mediaplayer/Runtime/BasisMediaPlayer.cs
@@ -431,6 +431,9 @@ public sealed class BasisMediaPlayer : MonoBehaviour
             BasisDebug.LogWarning("BasisMediaPlayer.LoadUrl called with empty URL.", BasisDebug.LogTag.Video);
             return;
         }
+        // Default a missing scheme to https so a bare "www.example.com/…" routes and loads
+        // as an absolute URL instead of being mis-read as a direct/transport source.
+        url = BasisMediaUrlRouter.NormalizeUrl(url);
         LastErrorMessage = null;
         LoadGeneration++;
         if (BasisMediaUrlRouter.TryResolveAndLoad(this, url)) return;

--- a/Basis/Packages/com.basis.mediaplayer/Runtime/BasisMediaPlayer.cs
+++ b/Basis/Packages/com.basis.mediaplayer/Runtime/BasisMediaPlayer.cs
@@ -426,7 +426,7 @@ public sealed class BasisMediaPlayer : MonoBehaviour
     // already-resolved or direct sources, e.g. the resolver's own output).
     public void LoadUrl(string url)
     {
-        if (string.IsNullOrEmpty(url))
+        if (string.IsNullOrWhiteSpace(url))
         {
             BasisDebug.LogWarning("BasisMediaPlayer.LoadUrl called with empty URL.", BasisDebug.LogTag.Video);
             return;
@@ -456,7 +456,7 @@ public sealed class BasisMediaPlayer : MonoBehaviour
     // streaming-assets-relative path and calls LoadSource.
     public void LoadLocalPath(string path)
     {
-        if (string.IsNullOrEmpty(path))
+        if (string.IsNullOrWhiteSpace(path))
         {
             BasisDebug.LogWarning("BasisMediaPlayer.LoadLocalPath called with empty path.", BasisDebug.LogTag.Video);
             return;

--- a/Basis/Packages/com.basis.mediaplayer/Runtime/BasisMediaPlayer.cs
+++ b/Basis/Packages/com.basis.mediaplayer/Runtime/BasisMediaPlayer.cs
@@ -443,7 +443,7 @@ public sealed class BasisMediaPlayer : MonoBehaviour
             // Surfaced to LastErrorMessage too so the Media Players panel can explain why nothing played.
             LastErrorMessage = "This looks like a page URL (e.g. YouTube/Twitch). Playing it needs a media URL resolver package, and none is installed.";
             BasisDebug.LogWarning(
-                $"BasisMediaPlayer: '{url}' looks like a page URL (e.g. YouTube/Twitch); no media URL " +
+                $"BasisMediaPlayer: '{BasisMediaUrlRouter.Redact(url)}' looks like a page URL (e.g. YouTube/Twitch); no media URL " +
                 "resolver package is installed to handle it, so it can't be played.",
                 BasisDebug.LogTag.Video);
             return;
@@ -1197,14 +1197,33 @@ public sealed class BasisMediaPlayer : MonoBehaviour
         }
     }
 
+    // Records a failure message (drives the Error status and the Media Players panel) and
+    // raises OnError. Main thread only.
+    private void RaiseError(Exception ex)
+    {
+        LastErrorMessage = ex.Message;
+        OnError?.Invoke(ex);
+    }
+
+    /// <summary>
+    /// Reports a load failure from an external URL resolver. A resolver that takes ownership via
+    /// <see cref="BasisMediaUrlRouter"/> resolves asynchronously, so the player can't observe the
+    /// outcome itself — it calls this (on the main thread) when resolution fails, so the reason
+    /// surfaces through <see cref="LastErrorMessage"/> and <see cref="OnError"/> instead of the
+    /// player sitting silently with no media.
+    /// </summary>
+    public void ReportLoadError(Exception error)
+    {
+        if (error != null) RaiseError(error);
+    }
+
     private void DrainPendingEvents()
     {
         if (pendingError != null)
         {
             var ex = pendingError;
             pendingError = null;
-            LastErrorMessage = ex.Message;
-            OnError?.Invoke(ex);
+            RaiseError(ex);
         }
 
         long packedSize = System.Threading.Interlocked.Exchange(ref pendingVideoSize, 0);
@@ -1225,7 +1244,7 @@ public sealed class BasisMediaPlayer : MonoBehaviour
             if (activeMediaSource != null && activeMediaSource.StartPosition > TimeSpan.Zero && seekableSource != null)
             {
                 try { seekableSource.Seek(activeMediaSource.StartPosition); }
-                catch (Exception ex) { OnError?.Invoke(ex); }
+                catch (Exception ex) { RaiseError(ex); }
             }
         }
 

--- a/Basis/Packages/com.basis.mediaplayer/Runtime/BasisMediaPlayer.cs
+++ b/Basis/Packages/com.basis.mediaplayer/Runtime/BasisMediaPlayer.cs
@@ -441,10 +441,10 @@ public sealed class BasisMediaPlayer : MonoBehaviour
         {
             // A missing optional resolver is expected graceful degradation, not a fault — warn.
             // Surfaced to LastErrorMessage too so the Media Players panel can explain why nothing played.
-            LastErrorMessage = "This looks like a page URL (e.g. YouTube/Twitch). Playing it needs the optional yt-dlp resolver package, which isn't installed.";
+            LastErrorMessage = "This looks like a page URL (e.g. YouTube/Twitch). Playing it needs a media URL resolver package, and none is installed.";
             BasisDebug.LogWarning(
-                $"BasisMediaPlayer: '{url}' looks like a page URL (e.g. YouTube/Twitch), which needs the " +
-                "optional yt-dlp resolver package — it isn't installed, so this URL can't be played.",
+                $"BasisMediaPlayer: '{url}' looks like a page URL (e.g. YouTube/Twitch); no media URL " +
+                "resolver package is installed to handle it, so it can't be played.",
                 BasisDebug.LogTag.Video);
             return;
         }

--- a/Basis/Packages/com.basis.mediaplayer/Runtime/BasisMediaUrlRouter.cs
+++ b/Basis/Packages/com.basis.mediaplayer/Runtime/BasisMediaUrlRouter.cs
@@ -123,17 +123,20 @@ public static class BasisMediaUrlRouter
     /// <summary>
     /// Guarantees <paramref name="url"/> carries a scheme so it can route and load as an
     /// absolute URL. A bare web URL with no scheme (e.g. "www.youtube.com/watch?v=…") gets
-    /// "https://" prepended; anything that already has a scheme (http(s)/rtsp/rtmp/rist/file/…)
-    /// or is a local path (leading slash, UNC, or a drive letter like C:\) is returned trimmed
-    /// but otherwise unchanged. Null/whitespace passes through untouched.
+    /// "https://" prepended, and a protocol-relative URL ("//host/…") gets "https:"; anything
+    /// that already has a scheme (http(s)/rtsp/rtmp/rist/file/…) or is a local path (leading
+    /// slash, UNC, or a drive letter like C:\) is returned trimmed but otherwise unchanged.
+    /// Null/whitespace passes through untouched.
     /// </summary>
     public static string NormalizeUrl(string url)
     {
         if (string.IsNullOrWhiteSpace(url)) return url;
         string trimmed = url.Trim();
-        if (trimmed.Contains("://")) return trimmed;                   // already has a scheme
-        if (trimmed[0] == '/' || trimmed[0] == '\\') return trimmed;   // unix / UNC / rooted path
-        if (trimmed.Length >= 2 && trimmed[1] == ':') return trimmed;  // windows drive path (C:\, C:/)
+        if (trimmed.Contains("://")) return trimmed;                      // already has a scheme
+        if (trimmed.StartsWith("//", StringComparison.Ordinal))          // protocol-relative ("//host/…")
+            return "https:" + trimmed;
+        if (trimmed[0] == '/' || trimmed[0] == '\\') return trimmed;      // unix / UNC / rooted path
+        if (trimmed.Length >= 2 && trimmed[1] == ':') return trimmed;     // windows drive path (C:\, C:/)
         return "https://" + trimmed;
     }
 }

--- a/Basis/Packages/com.basis.mediaplayer/Runtime/BasisMediaUrlRouter.cs
+++ b/Basis/Packages/com.basis.mediaplayer/Runtime/BasisMediaUrlRouter.cs
@@ -124,9 +124,11 @@ public static class BasisMediaUrlRouter
     /// Guarantees <paramref name="url"/> carries a scheme so it can route and load as an
     /// absolute URL. A bare web URL with no scheme (e.g. "www.youtube.com/watch?v=…") gets
     /// "https://" prepended, and a protocol-relative URL ("//host/…") gets "https:"; anything
-    /// that already has a scheme (http(s)/rtsp/rtmp/rist/file/…) or is a local path (leading
-    /// slash, UNC, or a drive letter like C:\) is returned trimmed but otherwise unchanged.
-    /// Null/whitespace passes through untouched.
+    /// that already has a scheme (http(s)/rtsp/rtmp/rist/file/…) or is a local path (a single
+    /// leading slash, a backslash UNC path like \\server\share, or a drive letter like C:\) is
+    /// returned trimmed but otherwise unchanged. Because "//host/…" is read as a protocol-relative
+    /// web URL, a network path must use the backslash UNC form (or a file:// URL), not forward
+    /// slashes. Null/whitespace passes through untouched.
     /// </summary>
     public static string NormalizeUrl(string url)
     {

--- a/Basis/Packages/com.basis.mediaplayer/Runtime/BasisMediaUrlRouter.cs
+++ b/Basis/Packages/com.basis.mediaplayer/Runtime/BasisMediaUrlRouter.cs
@@ -83,7 +83,20 @@ public static class BasisMediaUrlRouter
         for (int i = 0; i < Resolvers.Count; i++)
         {
             IBasisVideoResolver resolver = Resolvers[i];
-            if (resolver.CanResolve(url) && resolver.TryResolve(player, url)) return true;
+            // Resolvers are external integrations (third-party packages). Contain a throwing
+            // one so a single bad resolver can't break lower-priority resolvers or the
+            // direct-load fallback; a failed attempt is treated as "declined" and routing
+            // continues. Not a hot path — this runs on a user-initiated load.
+            try
+            {
+                if (resolver.CanResolve(url) && resolver.TryResolve(player, url)) return true;
+            }
+            catch (Exception e)
+            {
+                BasisDebug.LogError(
+                    $"BasisMediaUrlRouter: resolver '{resolver.GetType().Name}' threw while handling '{Redact(url)}'; skipping it. {e}",
+                    BasisDebug.LogTag.Video);
+            }
         }
         return false;
     }
@@ -121,6 +134,29 @@ public static class BasisMediaUrlRouter
     }
 
     /// <summary>
+    /// A log-safe form of <paramref name="url"/> — the scheme, host and path with the query and
+    /// fragment dropped, since those can carry signed tokens or private identifiers that
+    /// shouldn't reach logs. Returns the input unchanged when it has no query/fragment, and a
+    /// placeholder for null/blank.
+    /// </summary>
+    public static string Redact(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url)) return "(empty)";
+        string trimmed = url.Trim();
+        int cut = trimmed.IndexOfAny(PathEnd); // '?' or '#'
+        string withoutQuery = cut >= 0 ? trimmed.Substring(0, cut) : trimmed;
+
+        // Strip userinfo (user:pass@host) too — those are credentials. Rebuild from the
+        // parsed parts only when it's present, so ordinary URLs keep their exact form.
+        if (Uri.TryCreate(withoutQuery, UriKind.Absolute, out Uri uri) && !string.IsNullOrEmpty(uri.UserInfo))
+        {
+            string host = uri.IsDefaultPort ? uri.Host : $"{uri.Host}:{uri.Port}";
+            return $"{uri.Scheme}://{host}{uri.AbsolutePath}";
+        }
+        return withoutQuery;
+    }
+
+    /// <summary>
     /// Guarantees <paramref name="url"/> carries a scheme so it can route and load as an
     /// absolute URL. A bare web URL with no scheme (e.g. "www.youtube.com/watch?v=…") gets
     /// "https://" prepended, and a protocol-relative URL ("//host/…") gets "https:"; anything
@@ -138,7 +174,7 @@ public static class BasisMediaUrlRouter
         if (trimmed.StartsWith("//", StringComparison.Ordinal))          // protocol-relative ("//host/…")
             return "https:" + trimmed;
         if (trimmed[0] == '/' || trimmed[0] == '\\') return trimmed;      // unix / UNC / rooted path
-        if (trimmed.Length >= 2 && trimmed[1] == ':') return trimmed;     // windows drive path (C:\, C:/)
+        if (trimmed.Length >= 2 && char.IsLetter(trimmed[0]) && trimmed[1] == ':') return trimmed; // windows drive path (C:\, C:/) — letter-prefixed so "[::1]/…" isn't caught
         return "https://" + trimmed;
     }
 }

--- a/Basis/Packages/com.basis.mediaplayer/Runtime/BasisMediaUrlRouter.cs
+++ b/Basis/Packages/com.basis.mediaplayer/Runtime/BasisMediaUrlRouter.cs
@@ -42,6 +42,11 @@ public interface IBasisVideoResolver
 /// With nothing registered every URL loads directly — identical to having no integration at
 /// all. This routes only; it never blocks a URL (host trust is enforced separately by
 /// BasisMediaPlayerSecurity).
+///
+/// Not thread-safe. Register, Unregister and TryResolveAndLoad must all run on Unity's main
+/// thread — the resolver list is unsynchronised, so registering while a resolve is iterating
+/// would corrupt it. Integrations register from <c>RuntimeInitializeOnLoadMethod</c> and the
+/// player resolves from its load path, both main-thread, so this holds in practice.
 /// </summary>
 public static class BasisMediaUrlRouter
 {

--- a/Basis/Packages/com.basis.mediaplayer/Runtime/BasisMediaUrlRouter.cs
+++ b/Basis/Packages/com.basis.mediaplayer/Runtime/BasisMediaUrlRouter.cs
@@ -1,40 +1,104 @@
 using System;
+using System.Collections.Generic;
 
 /// <summary>
-/// Optional URL-resolution seam between the player and a higher-level resolver
-/// (e.g. the yt-dlp integration package). The player core has no reference to any
-/// integration, so this is how a URL field can steer page URLs through a resolver
-/// without the player depending on it.
+/// A URL resolver registered with <see cref="BasisMediaUrlRouter"/>. Several resolvers
+/// can be registered at once; the router tries them in descending <see cref="Priority"/>
+/// order (registration order breaks ties) until one takes ownership of the load. A
+/// resolver that declines lets the router fall through to the next one, and finally to a
+/// direct load. Resolvers route only — they never gate host trust (that's
+/// BasisMediaPlayerSecurity).
+/// </summary>
+public interface IBasisVideoResolver
+{
+    /// <summary>Higher runs first; equal priorities run in the order they registered.</summary>
+    int Priority { get; }
+
+    /// <summary>
+    /// Cheap, side-effect-free test of whether this resolver handles <paramref name="url"/>.
+    /// Returning false skips straight to the next resolver. Must not block or load.
+    /// </summary>
+    bool CanResolve(string url);
+
+    /// <summary>
+    /// Takes ownership of loading <paramref name="url"/> into <paramref name="player"/>
+    /// — resolving a page URL to its stream(s) and loading them, possibly async — and
+    /// returns true; or returns false to let the router try the next resolver, then a
+    /// direct load.
+    /// </summary>
+    bool TryResolve(BasisMediaPlayer player, string url);
+}
+
+/// <summary>
+/// Optional URL-resolution seam between the player and higher-level resolvers (e.g. the
+/// yt-dlp integration package). The player core has no reference to any integration, so
+/// this is how a URL field can steer page URLs through a resolver without the player
+/// depending on it.
 ///
-/// An integration installs <see cref="Resolver"/> at load (e.g. via
-/// <c>RuntimeInitializeOnLoadMethod</c>). Callers with a raw URL hand it to
-/// <see cref="TryResolveAndLoad"/>: the resolver either takes ownership of the load
-/// (resolving a page URL to its stream(s) and loading them, possibly async) and
-/// returns true, or returns false to let the caller load the URL directly. When no
-/// integration is installed <see cref="Resolver"/> is null and every URL loads
-/// directly — identical to having no integration at all. This routes only; it never
-/// blocks a URL (host trust is enforced separately by BasisMediaPlayerSecurity).
+/// Integrations <see cref="Register"/> an <see cref="IBasisVideoResolver"/> at load (e.g.
+/// via <c>RuntimeInitializeOnLoadMethod</c>). Callers with a raw URL hand it to
+/// <see cref="TryResolveAndLoad"/>, which walks the registered resolvers in priority order
+/// until one takes ownership (returns true); if none do, the caller loads the URL directly.
+/// With nothing registered every URL loads directly — identical to having no integration at
+/// all. This routes only; it never blocks a URL (host trust is enforced separately by
+/// BasisMediaPlayerSecurity).
 /// </summary>
 public static class BasisMediaUrlRouter
 {
+    private static readonly List<IBasisVideoResolver> Resolvers = new List<IBasisVideoResolver>();
+    private static LegacyResolverAdapter legacy;
+
     /// <summary>
-    /// Installed by an optional integration. Returns true if it took ownership of the
-    /// load for the given URL, false to let the caller load it directly. Null when no
-    /// integration is present.
+    /// Back-compatible single-resolver slot. Assigning a non-null delegate registers it as a
+    /// priority-0 resolver; assigning null removes it. Prefer <see cref="Register"/> with an
+    /// <see cref="IBasisVideoResolver"/> for new integrations — this is kept so existing
+    /// callers that set a delegate keep working.
     /// </summary>
-    public static Func<BasisMediaPlayer, string, bool> Resolver;
+    public static Func<BasisMediaPlayer, string, bool> Resolver
+    {
+        get => legacy?.Func;
+        set
+        {
+            if (legacy != null) { Unregister(legacy); legacy = null; }
+            if (value != null) { legacy = new LegacyResolverAdapter(value); Register(legacy); }
+        }
+    }
+
+    /// <summary>
+    /// Registers <paramref name="resolver"/> so <see cref="TryResolveAndLoad"/> consults it,
+    /// keeping the list ordered by descending <see cref="IBasisVideoResolver.Priority"/>
+    /// (registration order breaks ties). Registering the same instance twice is a no-op.
+    /// </summary>
+    public static void Register(IBasisVideoResolver resolver)
+    {
+        if (resolver == null) throw new ArgumentNullException(nameof(resolver));
+        if (Resolvers.Contains(resolver)) return;
+        int i = 0;
+        while (i < Resolvers.Count && Resolvers[i].Priority >= resolver.Priority) i++;
+        Resolvers.Insert(i, resolver);
+    }
+
+    /// <summary>Removes a resolver registered via <see cref="Register"/>. Returns false if it wasn't registered.</summary>
+    public static bool Unregister(IBasisVideoResolver resolver) => Resolvers.Remove(resolver);
 
     // Delimiters that end the path portion of a URL (query / fragment), hoisted so
     // IsDirectlyPlayable doesn't allocate a char[] per call.
     private static readonly char[] PathEnd = { '?', '#' };
 
     /// <summary>
-    /// Routes <paramref name="url"/> through the installed resolver, if any. Returns
-    /// true when the resolver took ownership (the caller should not also load); false
-    /// when there is no resolver or it declined (the caller loads directly).
+    /// Routes <paramref name="url"/> through the registered resolvers in priority order.
+    /// Returns true as soon as one takes ownership (the caller should not also load); false
+    /// when none handle it (the caller loads directly).
     /// </summary>
     public static bool TryResolveAndLoad(BasisMediaPlayer player, string url)
-        => Resolver != null && Resolver(player, url);
+    {
+        for (int i = 0; i < Resolvers.Count; i++)
+        {
+            IBasisVideoResolver resolver = Resolvers[i];
+            if (resolver.CanResolve(url) && resolver.TryResolve(player, url)) return true;
+        }
+        return false;
+    }
 
     /// <summary>
     /// True if the player can open <paramref name="url"/> directly, without a resolver:
@@ -66,5 +130,34 @@ public static class BasisMediaUrlRouter
             || path.EndsWith(".m2ts", StringComparison.OrdinalIgnoreCase)   // Blu-ray-flavour MPEG-TS
             || path.EndsWith(".mts", StringComparison.OrdinalIgnoreCase)    // AVCHD-flavour MPEG-TS
             || path.EndsWith(".m3u8", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Guarantees <paramref name="url"/> carries a scheme so it can route and load as an
+    /// absolute URL. A bare web URL with no scheme (e.g. "www.youtube.com/watch?v=…") gets
+    /// "https://" prepended; anything that already has a scheme (http(s)/rtsp/rtmp/rist/file/…)
+    /// or is a local path (leading slash, UNC, or a drive letter like C:\) is returned trimmed
+    /// but otherwise unchanged. Null/whitespace passes through untouched.
+    /// </summary>
+    public static string NormalizeUrl(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url)) return url;
+        string trimmed = url.Trim();
+        if (trimmed.Contains("://")) return trimmed;                   // already has a scheme
+        if (trimmed[0] == '/' || trimmed[0] == '\\') return trimmed;   // unix / UNC / rooted path
+        if (trimmed.Length >= 2 && trimmed[1] == ':') return trimmed;  // windows drive path (C:\, C:/)
+        return "https://" + trimmed;
+    }
+
+    // Adapts a legacy Resolver delegate to IBasisVideoResolver. The delegate self-selects
+    // (returns false to decline), so CanResolve is always true and the decision happens in
+    // TryResolve — preserving the original single-slot semantics.
+    private sealed class LegacyResolverAdapter : IBasisVideoResolver
+    {
+        internal readonly Func<BasisMediaPlayer, string, bool> Func;
+        public LegacyResolverAdapter(Func<BasisMediaPlayer, string, bool> func) => Func = func;
+        public int Priority => 0;
+        public bool CanResolve(string url) => true;
+        public bool TryResolve(BasisMediaPlayer player, string url) => Func(player, url);
     }
 }

--- a/Basis/Packages/com.basis.mediaplayer/Runtime/BasisMediaUrlRouter.cs
+++ b/Basis/Packages/com.basis.mediaplayer/Runtime/BasisMediaUrlRouter.cs
@@ -51,23 +51,6 @@ public interface IBasisVideoResolver
 public static class BasisMediaUrlRouter
 {
     private static readonly List<IBasisVideoResolver> Resolvers = new List<IBasisVideoResolver>();
-    private static LegacyResolverAdapter legacy;
-
-    /// <summary>
-    /// Back-compatible single-resolver slot. Assigning a non-null delegate registers it as a
-    /// priority-0 resolver; assigning null removes it. Prefer <see cref="Register"/> with an
-    /// <see cref="IBasisVideoResolver"/> for new integrations — this is kept so existing
-    /// callers that set a delegate keep working.
-    /// </summary>
-    public static Func<BasisMediaPlayer, string, bool> Resolver
-    {
-        get => legacy?.Func;
-        set
-        {
-            if (legacy != null) { Unregister(legacy); legacy = null; }
-            if (value != null) { legacy = new LegacyResolverAdapter(value); Register(legacy); }
-        }
-    }
 
     /// <summary>
     /// Registers <paramref name="resolver"/> so <see cref="TryResolveAndLoad"/> consults it,
@@ -152,17 +135,5 @@ public static class BasisMediaUrlRouter
         if (trimmed[0] == '/' || trimmed[0] == '\\') return trimmed;   // unix / UNC / rooted path
         if (trimmed.Length >= 2 && trimmed[1] == ':') return trimmed;  // windows drive path (C:\, C:/)
         return "https://" + trimmed;
-    }
-
-    // Adapts a legacy Resolver delegate to IBasisVideoResolver. The delegate self-selects
-    // (returns false to decline), so CanResolve is always true and the decision happens in
-    // TryResolve — preserving the original single-slot semantics.
-    private sealed class LegacyResolverAdapter : IBasisVideoResolver
-    {
-        internal readonly Func<BasisMediaPlayer, string, bool> Func;
-        public LegacyResolverAdapter(Func<BasisMediaPlayer, string, bool> func) => Func = func;
-        public int Priority => 0;
-        public bool CanResolve(string url) => true;
-        public bool TryResolve(BasisMediaPlayer player, string url) => Func(player, url);
     }
 }

--- a/Basis/Packages/com.basis.mediaplayer/Runtime/UI/BasisMediaPlayerPanelProvider.cs
+++ b/Basis/Packages/com.basis.mediaplayer/Runtime/UI/BasisMediaPlayerPanelProvider.cs
@@ -193,7 +193,7 @@ namespace Basis.BasisUI.MediaPlayer
             {
                 if (_activePlayer == null || _urlField == null) return;
                 string u = _urlField.Value;
-                if (string.IsNullOrEmpty(u)) return;
+                if (string.IsNullOrWhiteSpace(u)) return;
                 // Reflect the scheme we add back into the field so a bare "youtube.com/…"
                 // visibly becomes "https://youtube.com/…" rather than being silently rewritten.
                 string normalized = BasisMediaUrlRouter.NormalizeUrl(u);

--- a/Basis/Packages/com.basis.mediaplayer/Runtime/UI/BasisMediaPlayerPanelProvider.cs
+++ b/Basis/Packages/com.basis.mediaplayer/Runtime/UI/BasisMediaPlayerPanelProvider.cs
@@ -194,8 +194,12 @@ namespace Basis.BasisUI.MediaPlayer
                 if (_activePlayer == null || _urlField == null) return;
                 string u = _urlField.Value;
                 if (string.IsNullOrEmpty(u)) return;
-                if (_activeNetworking != null) _ = _activeNetworking.SetUrl(u);
-                else _activePlayer.LoadUrl(u);
+                // Reflect the scheme we add back into the field so a bare "youtube.com/…"
+                // visibly becomes "https://youtube.com/…" rather than being silently rewritten.
+                string normalized = BasisMediaUrlRouter.NormalizeUrl(u);
+                if (normalized != u) _urlField.SetValueWithoutNotify(normalized);
+                if (_activeNetworking != null) _ = _activeNetworking.SetUrl(normalized);
+                else _activePlayer.LoadUrl(normalized);
             };
 
             PanelButton playBtn = PanelButton.CreateNew(actions);


### PR DESCRIPTION
## Summary

- **URL resolvers have a standard method to register themselves** The media player previously took a single (ytdlp) resolver; this turns that behaviour into a registry where a resolver can register itself using documented processes and are tried in priority order until one claims the load, otherwise the URL loads directly. It's the seam the optional yt-dlp integration plugs into, and stays completely inert with nothing registered — every URL loads exactly as it does today.
- **Bare and protocol-relative web addresses now route correctly.** A URL with no scheme (e.g. `www.youtube.com/watch?v=…`) gets `https://` prepended, and a protocol-relative `//host/…` gets `https:`, so each is treated as an absolute URL.
- **Whitespace-only input is rejected** instead of slipping through as a bogus URL.

**No behaviour change for anyone not using the dlp-native resolver package.** With no resolver registered the router is inert — every URL loads exactly as it does on `developer` today. This PR only reshapes the optional resolver seam and tightens URL parsing; the core player (transports, demux, decode, networked sync) is untouched.

See **Notes** for how the registry, normalisation, and threading contract work.

## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [x] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — `BasisEventDriver` runs the single per-frame tick that drives the whole framework (network apply, local player sim, blendshapes, JigglePhysics, nameplates, and more) as one sequential chain. An unhandled exception anywhere in that chain aborts the rest of the tick, so every step after the throwing one is silently skipped for that frame. New work added to the driver must either be guaranteed not to throw, or be wrapped in a `try`/`catch` that contains the failure and surfaces it through `BasisDebug` — logged once / rate-limited, never every frame (see the existing `HVRBasisBuiltInAddresses.Simulate()` guard for the pattern). Expect this to be scrutinized closely in review.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [x] Windows
- [ ] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [ ] Tested in VR (note headset under **Notes**)
- [ ] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [x] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [x] N/A — change does not touch any of the above

## Notes

Tested in the editor on Windows: a page URL resolves through a registered resolver and the resolved stream loads and plays. Direct stream URLs continue to load unchanged.

### How it works
- **`BasisMediaUrlRouter` registry** — multiple `IBasisVideoResolver`s can register; the router tries them in descending `Priority` (registration order breaks ties) until one takes ownership of a load, otherwise the URL loads directly. The router routes only; host trust stays with `BasisMediaPlayerSecurity`. Authoring a resolver is documented in the [player README](Basis/Packages/com.basis.mediaplayer/README.md#writing-a-resolver).
- **https normalisation** — `NormalizeUrl` prepends `https://` to a bare web URL and `https:` to a protocol-relative `//host/…` so each routes and loads as an absolute URL; anything that already has a scheme, or is a local path, is returned trimmed but unchanged. Since `//host/…` reads as web, network paths use the backslash UNC form (`\\server\share`) or `file://` — documented on `NormalizeUrl`.
- **Whitespace-only input rejected** — `LoadUrl`, `LoadLocalPath`, and the Media Players panel's load button now guard with `IsNullOrWhiteSpace`, so a blank-but-non-empty string no longer slips past the empty check and through normalisation as a bogus URL.
- **Main-thread contract** — the resolver list is unsynchronised, so register/resolve on the main thread (registration via `RuntimeInitializeOnLoadMethod`, resolution from the player's load path, both main-thread).

### Loading a page URL with no resolver installed
A YouTube/Twitch (or any page) URL loaded with no resolver registered degrades gracefully — it never throws, crashes, or tries to demux an HTML page. `LoadUrl` sees it isn't directly playable and stops before attaching a backend, leaving a plain-English reason:

> This looks like a page URL (e.g. YouTube/Twitch). Playing it needs a media URL resolver package, and none is installed.

That surfaces two ways: the player's `Status` becomes `Error` with the text on `LastErrorMessage`, which the in-game **Media Players** panel displays, and the same is logged on each such load as a `BasisDebug` *warning* (warning, not error — a missing optional package is expected, not a fault). The message names no specific resolver — the core player stays agnostic about which integration fills the role. Direct stream URLs (`rtsp`/`rtmp`/`rist`, `.mp4`/`.ts`/`.m3u8`, …) are unaffected and keep playing.

### Also in this PR
- **Single resolver API** — the older single-delegate `Resolver` slot is gone; integrations register through `Register(IBasisVideoResolver)` only, and the in-tree yt-dlp resolver uses it directly.
- **yt-dlp is the lowest-priority fallback** — the bundled resolver registers at the bottom of the priority order, so any more-specific resolver added later gets first claim and yt-dlp only handles what nothing else took.
- **Resolver-agnostic core** — the missing-resolver message (panel + log) refers to "a media URL resolver package" rather than naming yt-dlp, keeping the core player free of any specific integration's name. The agnostic surface (interface, registry, message) lives in the player; the concrete package stays named for what it is (`com.basis.integration.ytdlp`).
- **Resolver authoring documented** — a "Writing a resolver" section in the player README covers the interface, registration, priority, and the main-thread / routing-only contract, with the yt-dlp package as the worked example.

### Checklist context
Everything else is ticked as N/A or compliant — this is URL-routing / string-handling only:

- No transform access, Addressables loads, `GetComponent`/`AddComponent`, camera lookups, or per-frame work, so the hot-path / `BasisEventDriver` / jobification / collection-access checks don't apply.
- Logging goes through `BasisDebug` with `LogTag.Video`.
- The only properties added are `IBasisVideoResolver` interface members (`Priority` + the resolve methods) — interface contract, not noop accessors walling off a field.
- Resolver registration is via `RuntimeInitializeOnLoadMethod`, not scene scanning.

