### PR TITLE
feat(integration.ltcgi): drive LTCGI realtime area light from the media player

### DIFF
--- a/Basis/Packages/com.basis.integration.ltcgi/README.md
+++ b/Basis/Packages/com.basis.integration.ltcgi/README.md
@@ -1,0 +1,119 @@
+# Basis LTCGI Integration
+
+Drives [LTCGI](https://ltcgi.dev/) realtime area lighting from a Basis Media Player, so a
+video screen casts coloured light that matches whatever is playing.
+
+The Basis Media Player exposes the current video frame as a `Texture`
+(`BasisMediaPlayer.OutputTexture`) and never owns a RenderTexture. LTCGI samples a single
+shared video texture through its blur chain. This package's `BasisLTCGIVideoAdapter`
+bridges the two: it copies each video frame into a RenderTexture and hands it to LTCGI, so
+the screen's light updates live with the video.
+
+## Requirements
+
+This package compiles only when both of these are present:
+
+- `com.basis.mediaplayer` — the Basis Media Player, which ships with Basis.
+- `at.pimaker.ltcgi` — [LTCGI](https://github.com/PiMaker/ltcgi). It isn't on a public
+  registry, so add it to your `Packages/manifest.json` (a git URL or a local `file:` clone)
+  before this package will build:
+
+  ```json
+  "at.pimaker.ltcgi": "https://github.com/PiMaker/ltcgi.git"
+  ```
+
+Until both are present the package is inert — its assembly compiles to nothing — so it is
+safe to leave in any project.
+
+Basis renders with URP. LTCGI's URP-compatible surface shaders (`LTCGI_Surface_v2_URP`,
+`LTCGI_Simple_URP`) let geometry lit by LTCGI render correctly under URP.
+
+## Setup
+
+The result is a video screen (the Media Player quad) that emits area light onto nearby
+surfaces. There are two halves: telling LTCGI the screen is a dynamic light source, and
+attaching the adapter that feeds it the video.
+
+### 1. Add and bake an LTCGI controller
+
+If your scene doesn't already have one, add an **LTCGI Controller** to the scene. It is the
+object that bakes lighting data and hosts the runtime adapter.
+
+### 2. Mark the Media Player screen as a dynamic LTCGI screen
+
+On the `MediaPlayerStreaming` object's quad (the renderer that displays the video):
+
+1. Add an **`LTCGI_Screen`** component.
+2. Tick **Dynamic** — the video changes every frame, so the screen must update at runtime.
+3. Set **Color Mode** to **Texture**, and leave the texture selection on **`[Live Video]`**
+   (index 0). This tells the screen to sample the live video feed rather than a solid
+   colour or a static texture.
+
+### 3. Bake
+
+On the LTCGI Controller, click **Force Update** (or press Ctrl-S). This bakes the screen in
+and wires up the runtime adapter. You must re-bake any time you change the screen's
+**Dynamic** flag or **Color Mode**.
+
+> The controller will show a *"Video Texture is not set!"* warning. **This is expected** —
+> the video is supplied at runtime by the adapter (next step), not assigned on the
+> controller. You can ignore the warning. There is no edit-mode preview; the screen only
+> emits light once the player is decoding frames in Play mode.
+
+### 4. Add the video adapter
+
+Add a **`Basis LTCGI Video Adapter`** (`BasisLTCGIVideoAdapter`) component to the
+`MediaPlayerStreaming` object. The two references resolve automatically:
+
+- **Player** — found on the same object / parents.
+- **Target** — the LTCGI runtime adapter in the scene.
+
+Assign them manually only if auto-resolve picks the wrong one (e.g. multiple players or
+controllers in the scene).
+
+### 5. Play
+
+Enter Play mode with a video loaded and playing. The screen should light the room with the
+video's colours. In the Console you'll see:
+
+```
+LTCGI adapter started for 1 (1 dynamic) screens ...
+```
+
+The `(1 dynamic)` confirms the screen registered. If it says *"going to sleep"*, the screen
+isn't registered as dynamic — re-check steps 2–3.
+
+## Component reference
+
+| Field | Default | Purpose |
+| --- | --- | --- |
+| **Player** | auto | The `BasisMediaPlayer` to read frames from. Falls back to `GetComponentInParent`. |
+| **Target** | auto | The `LTCGI_UdonAdapter` to feed. Falls back to the first one in the scene. |
+| **Flip Vertically** | On | Corrects native GPU textures, which arrive top-left origin (upside-down for Unity). |
+| **Flip Horizontally** | On | Together with Flip Vertically, matches the standard Basis media-player quad's UVs. |
+
+Both flips are **on by default** because that orientation is correct for the standard Basis
+media-player quad. If you use a differently-mapped mesh and the reflected image looks
+mirrored, toggle whichever axis is wrong.
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+| --- | --- |
+| Screen emits a solid colour, not the video | Color Mode is **Static**. Set it to **Texture** with **`[Live Video]`** selected, then **Force Update**. |
+| No light at all; Console logs *"going to sleep"* | Screen isn't dynamic. Tick **Dynamic** on the `LTCGI_Screen` and **Force Update**. |
+| Reflection is mirrored / upside-down | Adjust **Flip Vertically** / **Flip Horizontally** on the adapter. |
+| Console: *"no LTCGI_UdonAdapter in the scene"* | The controller hasn't been baked. Click **Force Update** first. |
+| Console: *"LTCGI_UdonAdapter has no BlurCRTInput"* | LTCGI's blur chain isn't available. This happens when **Fast Sampling** is on — which is **forced on for Android/Quest** build targets. The blur-chain video path requires a desktop/standalone target with Fast Sampling off. |
+| *"Video Texture is not set!"* on the controller | Expected — the adapter feeds the texture at runtime. Ignore it. |
+
+## How it works
+
+`BasisLTCGIVideoAdapter` subscribes to `BasisMediaPlayer.OnOutputTextureChanged`, blits each
+frame into a RenderTexture it owns (applying the configured flips), and pushes that texture
+into LTCGI via `LTCGI_UdonAdapter._SetVideoTexture`. The blur chain re-prefilters it every
+frame, so the emitted light tracks the video.
+
+If something resets LTCGI's global shader state at runtime — for example a Desktop/VR mode
+switch — the adapter detects the dropped binding and re-asserts the feed on the next frame,
+so the lighting recovers on its own.

--- a/Basis/Packages/com.basis.integration.ltcgi/README.md.meta
+++ b/Basis/Packages/com.basis.integration.ltcgi/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3d6a0a4d74d9b69488bf9ac08ff33bbf
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Basis/Packages/com.basis.integration.ltcgi/Runtime.meta
+++ b/Basis/Packages/com.basis.integration.ltcgi/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 259fa2264c2b3f246bf89ae5c6a4b1b1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Basis/Packages/com.basis.integration.ltcgi/Runtime/Basis.Integration.LTCGI.asmdef
+++ b/Basis/Packages/com.basis.integration.ltcgi/Runtime/Basis.Integration.LTCGI.asmdef
@@ -1,0 +1,40 @@
+{
+    "name": "Basis.Integration.LTCGI",
+    "rootNamespace": "Basis.Integration.LTCGI",
+    "references": [
+        "BasisMediaPlayer",
+        "LTCGI_Assembly"
+    ],
+    "includePlatforms": [
+        "Android",
+        "Editor",
+        "iOS",
+        "LinuxStandalone64",
+        "macOSStandalone",
+        "WebGL",
+        "WindowsStandalone32",
+        "WindowsStandalone64"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [
+        "BASIS_MEDIAPLAYER_EXISTS",
+        "LTCGI_EXISTS"
+    ],
+    "versionDefines": [
+        {
+            "name": "com.basis.mediaplayer",
+            "expression": "",
+            "define": "BASIS_MEDIAPLAYER_EXISTS"
+        },
+        {
+            "name": "at.pimaker.ltcgi",
+            "expression": "",
+            "define": "LTCGI_EXISTS"
+        }
+    ],
+    "noEngineReferences": false
+}

--- a/Basis/Packages/com.basis.integration.ltcgi/Runtime/Basis.Integration.LTCGI.asmdef
+++ b/Basis/Packages/com.basis.integration.ltcgi/Runtime/Basis.Integration.LTCGI.asmdef
@@ -3,7 +3,8 @@
     "rootNamespace": "Basis.Integration.LTCGI",
     "references": [
         "BasisMediaPlayer",
-        "LTCGI_Assembly"
+        "LTCGI_Assembly",
+        "BasisDebug"
     ],
     "includePlatforms": [
         "Android",

--- a/Basis/Packages/com.basis.integration.ltcgi/Runtime/Basis.Integration.LTCGI.asmdef.meta
+++ b/Basis/Packages/com.basis.integration.ltcgi/Runtime/Basis.Integration.LTCGI.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f7e8b61b105e5b14e94d3613336dbe42
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Basis/Packages/com.basis.integration.ltcgi/Runtime/BasisLTCGIVideoAdapter.cs
+++ b/Basis/Packages/com.basis.integration.ltcgi/Runtime/BasisLTCGIVideoAdapter.cs
@@ -1,0 +1,161 @@
+using UnityEngine;
+
+namespace Basis.Integration.LTCGI
+{
+    /// <summary>
+    /// Bridges a <see cref="BasisMediaPlayer"/> into LTCGI's dynamic video path so a
+    /// screen lit by the player emits matching realtime area light.
+    /// </summary>
+    /// <remarks>
+    /// The player surfaces the current frame as <see cref="BasisMediaPlayer.OutputTexture"/>
+    /// (a zero-copy native GPU texture on the OS-codec path, a CPU Texture2D on the
+    /// synthetic path) and swaps that texture's identity on start, resize, and reconnect.
+    /// LTCGI samples a single shared video texture, so this adapter owns a RenderTexture
+    /// with a stable handle, blits each frame into it, and hands it to
+    /// <c>LTCGI_UdonAdapter._SetVideoTexture</c> once per resize. The blit flips both
+    /// axes by default, which orients the feed correctly for the standard Basis
+    /// media-player quad (vertical handles native D3D top-left origin; horizontal
+    /// matches the quad's UVs). Requires a baked LTCGI controller with at least one
+    /// dynamic screen.
+    /// </remarks>
+    [DisallowMultipleComponent]
+    [DefaultExecutionOrder(200)] // after LTCGI_UdonAdapter has initialised its globals
+    public sealed class BasisLTCGIVideoAdapter : MonoBehaviour
+    {
+        [Tooltip("Player to read frames from. If unassigned, GetComponentInParent<BasisMediaPlayer>() is used.")]
+        public BasisMediaPlayer Player;
+
+        [Tooltip("LTCGI runtime adapter to feed. If unassigned, the first one in the scene is used.")]
+        public LTCGI_UdonAdapter Target;
+
+        [Tooltip("Flip the source vertically when blitting. On by default: native D3D textures are top-left origin and arrive upside-down.")]
+        public bool FlipVertically = true;
+
+        [Tooltip("Mirror the source horizontally when blitting. On by default: together with FlipVertically this matches the standard Basis media-player quad's UVs. Turn off for a differently-mapped mesh.")]
+        public bool FlipHorizontally = true;
+
+        private RenderTexture rt;
+        private Texture source;
+        private int sourceWidth;
+        private int sourceHeight;
+
+        private static readonly int IdMainTex = Shader.PropertyToID("_MainTex");
+        private static readonly int[] LodGlobalIds =
+        {
+            Shader.PropertyToID("_Udon_LTCGI_Texture_LOD1"),
+            Shader.PropertyToID("_Udon_LTCGI_Texture_LOD2"),
+            Shader.PropertyToID("_Udon_LTCGI_Texture_LOD3"),
+        };
+
+        private void Reset()
+        {
+            if (Player == null) Player = GetComponentInParent<BasisMediaPlayer>();
+        }
+
+        private void OnEnable()
+        {
+            if (Player == null) Player = GetComponentInParent<BasisMediaPlayer>();
+            if (Player == null)
+            {
+                Debug.LogWarning("BasisLTCGIVideoAdapter: no BasisMediaPlayer found; nothing to feed LTCGI.", this);
+                enabled = false;
+                return;
+            }
+            if (Target == null) Target = FindFirstObjectByType<LTCGI_UdonAdapter>();
+            if (Target == null)
+            {
+                Debug.LogWarning("BasisLTCGIVideoAdapter: no LTCGI_UdonAdapter in the scene. Bake an LTCGI controller with at least one dynamic screen.", this);
+                enabled = false;
+                return;
+            }
+            if (Target.BlurCRTInput == null)
+            {
+                Debug.LogWarning("BasisLTCGIVideoAdapter: LTCGI_UdonAdapter has no BlurCRTInput. The controller needs a dynamic screen baked before video can be fed.", this);
+                enabled = false;
+                return;
+            }
+
+            Player.OnOutputTextureChanged += HandleTextureChanged;
+            HandleTextureChanged(Player.OutputTexture);
+        }
+
+        private void OnDisable()
+        {
+            if (Player != null) Player.OnOutputTextureChanged -= HandleTextureChanged;
+            // Drop LTCGI's pointer before releasing the RT so the blur chain never
+            // samples a destroyed texture.
+            if (Target != null) Target._SetVideoTexture(null);
+            source = null;
+            ReleaseRT();
+        }
+
+        private void HandleTextureChanged(Texture texture)
+        {
+            source = texture;
+            if (texture == null) return;
+            EnsureRT(texture.width, texture.height);
+            if (rt == null) return;
+            Blit();
+            Target._SetVideoTexture(rt);
+        }
+
+        private void LateUpdate()
+        {
+            if (source == null || rt == null) return;
+            Blit();
+            EnsureBound();
+        }
+
+        // LTCGI sets its blur-chain globals once at init and the video feed is pushed
+        // once per resize; an external reset (asset unload, render-pipeline reinit, a
+        // Desktop/VR mode switch) can clear them with nothing to restore them. Detect a
+        // dropped binding and re-assert both the video feed and the LOD CRT globals so
+        // the reflection self-heals within a frame.
+        private void EnsureBound()
+        {
+            if (Target == null || Target.BlurCRTInput == null) return;
+            var mat = Target.BlurCRTInput.material;
+            if (mat == null || mat.GetTexture(IdMainTex) == rt) return;
+
+            Target._SetVideoTexture(rt);
+            var lods = Target._LTCGI_LODs;
+            if (lods == null) return;
+            for (int j = 1; j < lods.Length && j - 1 < LodGlobalIds.Length; j++)
+                if (lods[j] != null) Shader.SetGlobalTexture(LodGlobalIds[j - 1], lods[j]);
+        }
+
+        private void Blit()
+        {
+            var scale = new Vector2(FlipHorizontally ? -1f : 1f, FlipVertically ? -1f : 1f);
+            var offset = new Vector2(FlipHorizontally ? 1f : 0f, FlipVertically ? 1f : 0f);
+            Graphics.Blit(source, rt, scale, offset);
+        }
+
+        private void EnsureRT(int w, int h)
+        {
+            if (w <= 0 || h <= 0) return;
+            if (rt != null && sourceWidth == w && sourceHeight == h) return;
+            ReleaseRT();
+            rt = new RenderTexture(w, h, 0, RenderTextureFormat.ARGB32, RenderTextureReadWrite.sRGB)
+            {
+                name = "BasisLTCGIVideo",
+                wrapMode = TextureWrapMode.Clamp,
+                filterMode = FilterMode.Bilinear,
+                useMipMap = false,
+            };
+            rt.Create();
+            sourceWidth = w;
+            sourceHeight = h;
+        }
+
+        private void ReleaseRT()
+        {
+            if (rt == null) return;
+            rt.Release();
+            if (Application.isPlaying) Destroy(rt); else DestroyImmediate(rt);
+            rt = null;
+            sourceWidth = 0;
+            sourceHeight = 0;
+        }
+    }
+}

--- a/Basis/Packages/com.basis.integration.ltcgi/Runtime/BasisLTCGIVideoAdapter.cs
+++ b/Basis/Packages/com.basis.integration.ltcgi/Runtime/BasisLTCGIVideoAdapter.cs
@@ -57,20 +57,20 @@ namespace Basis.Integration.LTCGI
             if (Player == null) Player = GetComponentInParent<BasisMediaPlayer>();
             if (Player == null)
             {
-                Debug.LogWarning("BasisLTCGIVideoAdapter: no BasisMediaPlayer found; nothing to feed LTCGI.", this);
+                BasisDebug.LogWarning("BasisLTCGIVideoAdapter: no BasisMediaPlayer found; nothing to feed LTCGI.", BasisDebug.LogTag.Video);
                 enabled = false;
                 return;
             }
             if (Target == null) Target = FindFirstObjectByType<LTCGI_UdonAdapter>();
             if (Target == null)
             {
-                Debug.LogWarning("BasisLTCGIVideoAdapter: no LTCGI_UdonAdapter in the scene. Bake an LTCGI controller with at least one dynamic screen.", this);
+                BasisDebug.LogWarning("BasisLTCGIVideoAdapter: no LTCGI_UdonAdapter in the scene. Bake an LTCGI controller with at least one dynamic screen.", BasisDebug.LogTag.Video);
                 enabled = false;
                 return;
             }
             if (Target.BlurCRTInput == null)
             {
-                Debug.LogWarning("BasisLTCGIVideoAdapter: LTCGI_UdonAdapter has no BlurCRTInput. The controller needs a dynamic screen baked before video can be fed.", this);
+                BasisDebug.LogWarning("BasisLTCGIVideoAdapter: LTCGI_UdonAdapter has no BlurCRTInput. The controller needs a dynamic screen baked before video can be fed.", BasisDebug.LogTag.Video);
                 enabled = false;
                 return;
             }

--- a/Basis/Packages/com.basis.integration.ltcgi/Runtime/BasisLTCGIVideoAdapter.cs.meta
+++ b/Basis/Packages/com.basis.integration.ltcgi/Runtime/BasisLTCGIVideoAdapter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4a15924498a7a7b4598ff67be64fb2c6

--- a/Basis/Packages/com.basis.integration.ltcgi/package.json
+++ b/Basis/Packages/com.basis.integration.ltcgi/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "com.basis.integration.ltcgi",
+  "displayName": "Basis LTCGI Integration",
+  "version": "0.0.1",
+  "description": "Feeds a BasisMediaPlayer's live output texture into LTCGI's dynamic blur chain so a screen lit by the player emits matching realtime area light. Compiles only when both com.basis.mediaplayer and at.pimaker.ltcgi are present.",
+  "author": {
+    "name": "BasisVR",
+    "url": "https://github.com/BasisVR"
+  },
+  "license": "MIT"
+}

--- a/Basis/Packages/com.basis.integration.ltcgi/package.json.meta
+++ b/Basis/Packages/com.basis.integration.ltcgi/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ab684574fa981324591d771e9dd701c7
+PackageManifestImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
Adds `com.basis.integration.ltcgi` — an optional bolt-on that drives [LTCGI](https://ltcgi.dev/) realtime area lighting from a Basis Media Player, so a video screen casts coloured light that matches whatever is playing.

`BasisLTCGIVideoAdapter` subscribes to `BasisMediaPlayer.OnOutputTextureChanged`, blits each frame into a RenderTexture it owns (the player exposes a plain `Texture` and never owns a RenderTexture; LTCGI samples one shared video texture through its blur chain), and hands that RT to `LTCGI_UdonAdapter._SetVideoTexture`. LTCGI's blur chain re-prefilters it every frame, so the emitted light tracks the video live. It also re-asserts the feed if LTCGI's global shader state is reset at runtime (e.g. a Desktop/VR mode switch), so the lighting self-heals.

Modelled on the existing `com.basis.integration.audiolink` / `com.basis.integration.ytdlp` packages: an embedded package that is **inert until its dependencies are present** — the assembly compiles to nothing unless both `com.basis.mediaplayer` and `at.pimaker.ltcgi` are in the project (asmdef define constraints `BASIS_MEDIAPLAYER_EXISTS` + `LTCGI_EXISTS`). Safe to land without forcing LTCGI into the project.

**Scope:** package source only — no manifest change. `at.pimaker.ltcgi` is intentionally not wired into the project manifest yet; the URP-compatible LTCGI surface shaders this relies on are being upstreamed to PiMaker's repo, after which the dependency can be added separately.

## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [x] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — `BasisEventDriver` runs the single per-frame tick that drives the whole framework (network apply, local player sim, blendshapes, JigglePhysics, nameplates, and more) as one sequential chain. An unhandled exception anywhere in that chain aborts the rest of the tick, so every step after the throwing one is silently skipped for that frame. New work added to the driver must either be guaranteed not to throw, or be wrapped in a `try`/`catch` that contains the failure and surfaces it through `BasisDebug` — logged once / rate-limited, never every frame (see the existing `HVRBasisBuiltInAddresses.Simulate()` guard for the pattern). Expect this to be scrutinized closely in review.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [x] Windows
- [ ] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [x] Tested in VR (note headset under **Notes**)
- [x] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [ ] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [x] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [ ] N/A — change does not touch any of the above

## Notes

**Per-frame check (`BasisEventDriver`).** The adapter's per-frame Blit/rebind runs in a standalone `LateUpdate`, matching the established pattern for leaf per-frame components in directly comparable packages — `com.basis.integration.audiolink` (`BasisAudioLinkReactiveLight`, `BasisAudioLinkReactiveMaterial`) and several `com.basis.mediaplayer` runtime scripts all use `Update`/`LateUpdate`. `BasisEventDriver` is a core, hard-wired call chain with no registration API; hooking a leaf, optional, inert-until-deps integration into it would mean editing core to reference an assembly that may not compile. Happy to move it onto the driver if you'd prefer that for this class of component — flag it and I'll wire it in.

**`BasisEventDriver` bulletproofing — N/A:** nothing is added to the driver (see above).

**Scene discovery.** The dependencies are serialized references (`Player`, `Target`) and are the primary path. The single `FindFirstObjectByType<LTCGI_UdonAdapter>()` is a one-shot fallback in `OnEnable`, used only when `Target` is left unassigned in the inspector; the result is cached. No per-frame scanning. Can make the reference mandatory and drop the fallback if you'd rather forbid the scan entirely.

**`GetComponent`.** The only lookup is `GetComponentInParent<BasisMediaPlayer>()`, once in `OnEnable`/`Reset`, cached on the `Player` field. No bare `GetComponent`, nothing on a per-frame path.

**Allocations / hot path.** The `LateUpdate` path (`Blit` + `EnsureBound`) is GC-free: `Blit` constructs only `Vector2` structs (stack, no heap), and the LOD-rebind loop runs solely on a detected reset, not the steady per-frame path.

**Transform / Addressables / Camera — N/A:** the package touches no transforms, loads no assets, and accesses no camera.

**Jobification — N/A:** the per-frame work is a single `Graphics.Blit` (GPU); there is no CPU-side work to move to a Burst job.

**Testing.** Verified on Windows in both desktop and VR. Specifically exercised the desktop↔VR runtime mode switch: LTCGI's globals get cleared on the switch and the adapter's `EnsureBound` self-heal re-asserts the feed within a frame, so the screen keeps lighting the room after the swap. Avatar/server swapping are unrelated to this change. Headset: Quest Pro over Virtual Desktop (PCVR streaming).
