### PR TITLE
tweak BasisDesktopEye & BasisUIRaycast

### DIFF
--- a/Basis/Packages/com.basis.framework/Device Management/Devices/Desktop/BasisDesktopEye.cs
+++ b/Basis/Packages/com.basis.framework/Device Management/Devices/Desktop/BasisDesktopEye.cs
@@ -121,6 +121,7 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
                     BasisPointRaycaster.UseWorldPosition = false;
                 }
                 BasisVirtualSpine.Initialize();
+                BasisLocalPlayer.AfterSimulateOnRender.AddAction(100, DoRenderRaycast);
                 HasEyeEvents = true;
             }
             LockEye();
@@ -174,6 +175,7 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
             {
                 BasisLocalPlayer.OnLocalAvatarChanged -= PlayerInitialized;
                 BasisCursorManagement.OnCursorStateChange -= OnCursorStateChange;
+                BasisLocalPlayer.AfterSimulateOnRender.RemoveAction(100, DoRenderRaycast);
                 HasEyeEvents = false;
                 BasisVirtualSpine.DeInitialize();
             }
@@ -313,8 +315,17 @@ namespace Basis.Scripts.Device_Management.Devices.Desktop
             if (IsComputingRaycast)
             {
                 ComputeRaycastDirection(ScaledDeviceCoord.position, ScaledDeviceCoord.rotation, Quaternion.identity);
-                UpdateInputEvents();
+                UpdateInputEvents(HasPlayerControlSupport: true, hasPlayerRaycastSupport: false); // control raycast
             }
+        }
+        private void DoRenderRaycast()
+        {
+            if (!hasRoleAssigned || !IsComputingRaycast)
+            {
+                return;
+            }
+
+            UpdateInputEvents(HasPlayerControlSupport: false, hasPlayerRaycastSupport: true); // ui raycast
         }
         public bool IsComputingRaycast = true;
         /// <summary>

--- a/Basis/Packages/com.basis.framework/UI/BasisGraphicUIRayCaster.cs
+++ b/Basis/Packages/com.basis.framework/UI/BasisGraphicUIRayCaster.cs
@@ -44,6 +44,17 @@ namespace Basis.Scripts.UI
         }
 
         /// <summary>
+        /// Unity OnValidate hook. Attempts to set the canvas on the same GameObject if not already assigned.
+        /// </summary>
+        private void OnValidate()
+        {
+            if (Canvas == null)
+            {
+                TryGetComponent(out Canvas);
+            }
+        }
+
+        /// <summary>
         /// Callback for when a <see cref="BasisLocalCameraDriver"/> instance becomes available.
         /// </summary>
         private void InstanceExists()

--- a/Basis/Packages/com.basis.framework/UI/BasisUIRaycast.cs
+++ b/Basis/Packages/com.basis.framework/UI/BasisUIRaycast.cs
@@ -28,7 +28,18 @@ namespace Basis.Scripts.UI
         public static string LoadMaterialAddress = "Assets/UI/Material/RayCastMaterial.mat";
         public static string LoadUIRedicalAddress = "Assets/UI/Prefabs/highlightQuad.prefab";
         public GameObject highlightQuadInstance;
-        public ActiveStateOfHightlight HighlightState;
+        private ActiveStateOfHightlight _highlightState;
+        public ActiveStateOfHightlight HighlightState
+        {
+            get => _highlightState;
+            set
+            {
+                if (_highlightState == value) return;
+                _highlightState = value;
+                highlightQuadInstance?.SetActive(value == ActiveStateOfHightlight.On);
+            }
+        }
+
         public enum ActiveStateOfHightlight
         {
             On,
@@ -42,6 +53,8 @@ namespace Basis.Scripts.UI
 
         public bool CachedLinerRenderState = false;
         public RaycastHit PhysicHit;
+        public bool DidPhysicHit = false;
+        public Collider HitCollider;
         public Canvas FoundCanvas;
         public RaycastResult RaycastResult = new RaycastResult();
 
@@ -130,7 +143,6 @@ namespace Basis.Scripts.UI
                     Canvas.worldCamera = BasisLocalCameraDriver.Instance.Camera;
                 }
                 ReticleRenderer = highlightQuadInstance.GetComponentInChildren<Renderer>();
-                highlightQuadInstance.gameObject.SetActive(false);
                 HighlightState = ActiveStateOfHightlight.NA;
                 HasRedicalRenderer = true;
             }
@@ -243,6 +255,8 @@ namespace Basis.Scripts.UI
                 SortedGraphics.Clear();
                 SortedRays.Clear();
                 PhysicHit = hits[hitIndex];
+                DidPhysicHit = true;
+                HitCollider = PhysicHit.collider;
 
                 if (RaycastToUI())
                 {
@@ -299,6 +313,8 @@ namespace Basis.Scripts.UI
             ResetCursorType();
             RaycastResult = new RaycastResult();
             PhysicHit = new RaycastHit();
+            DidPhysicHit = false;
+            HitCollider = null;
         }
 
         bool ContainsLayer(LayerMask mask, int layer)
@@ -308,7 +324,7 @@ namespace Basis.Scripts.UI
 
         private void HandleDidHit()
         {
-            WasCorrectLayer = ContainsLayer(UILayers, PhysicHit.transform.gameObject.layer);
+            WasCorrectLayer = ContainsLayer(UILayers, HitCollider.gameObject.layer);
             if (WasCorrectLayer)
             {
                 UpdateRayCastResult();   // sets all RaycastResult data
@@ -325,8 +341,7 @@ namespace Basis.Scripts.UI
 
         private void UpdateRayCastResult()
         {
-            var physicshit = PhysicHit.transform.gameObject;
-            RaycastResult.gameObject = physicshit;
+            RaycastResult.gameObject = HitCollider.gameObject;
             RaycastResult.distance = PhysicHit.distance;
             if (BasisPointRaycaster.UseWorldPosition)
             {
@@ -337,7 +352,7 @@ namespace Basis.Scripts.UI
                 // we assign screenpoint manually example in BasisLocalCameraDriver
             }
             RaycastResult.screenPosition = BasisPointRaycaster.ScreenPoint;
-            FoundCanvas = physicshit.GetComponentInParent<Canvas>();
+            FoundCanvas = HitCollider.GetComponentInParent<Canvas>();
             if (FoundCanvas != null)
             {
                 RaycastResult.sortingLayer = FoundCanvas.sortingLayerID;
@@ -374,36 +389,22 @@ namespace Basis.Scripts.UI
 
         private void UpdateReticleRenderer()
         {
-            if (HasRedicalRenderer)
+            if (!HasRedicalRenderer)
             {
-                if (PhysicHit.transform != null)
-                {
-                    if (BasisDeviceManagement.IsUserInDesktop() && BasisCursorManagement.ActiveLockState() != CursorLockMode.Locked)
-                    {
-                        if (HighlightState != ActiveStateOfHightlight.Off)
-                        {
-                            highlightQuadInstance.SetActive(false);
-                            HighlightState = ActiveStateOfHightlight.Off;
-                        }
-                    }
-                    else
-                    {
-                        if (HighlightState != ActiveStateOfHightlight.On)
-                        {
-                            highlightQuadInstance.SetActive(true);
-                            HighlightState = ActiveStateOfHightlight.On;
-                        }
-                        highlightQuadInstance.transform.SetPositionAndRotation(PhysicHit.point, Quaternion.LookRotation(PhysicHit.normal));
-                    }
-                }
-                else
-                {
-                    if (HighlightState != ActiveStateOfHightlight.Off)
-                    {
-                        highlightQuadInstance.SetActive(false);
-                        HighlightState = ActiveStateOfHightlight.Off;
-                    }
-                }
+                return;
+            }
+
+            // Hide on desktop while the cursor is unlocked (free mouse uses the OS cursor, not this reticle).
+            bool show = DidPhysicHit && !(BasisDeviceManagement.IsUserInDesktop() && BasisCursorManagement.ActiveLockState() != CursorLockMode.Locked);
+
+            if (show)
+            {
+                HighlightState = ActiveStateOfHightlight.On;
+                highlightQuadInstance.transform.SetPositionAndRotation(PhysicHit.point, Quaternion.LookRotation(PhysicHit.normal));
+            }
+            else
+            {
+                HighlightState = ActiveStateOfHightlight.Off;
             }
         }
 
@@ -508,7 +509,6 @@ namespace Basis.Scripts.UI
 
             if (HasRedicalRenderer)
             {
-                highlightQuadInstance.SetActive(false);
                 HighlightState = ActiveStateOfHightlight.Off;
             }
         }


### PR DESCRIPTION
## Summary
This PR fixes the stuttering of the Basis UI reticle on desktop by moving the UI raycast from `LateDoPollData` to `AfterSimulateOnRender` Action 100.

Before (somewhat hard to capture due to the low framerate of my screen recorder):

https://github.com/user-attachments/assets/aa568692-5d16-4843-8490-0feded8c2b56

After:

https://github.com/user-attachments/assets/8d768339-8aa4-4ed1-b8ce-7be4de99a3b3


Additionally, I did a minor refactor in `BasisUIRaycast` surrounding raycast hit access; functionality is entirely unchanged, it just reads a little easier to me and slightly reduces encapsulation.


## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [x] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — `BasisEventDriver` runs the single per-frame tick that drives the whole framework (network apply, local player sim, blendshapes, JigglePhysics, nameplates, and more) as one sequential chain. An unhandled exception anywhere in that chain aborts the rest of the tick, so every step after the throwing one is silently skipped for that frame. New work added to the driver must either be guaranteed not to throw, or be wrapped in a `try`/`catch` that contains the failure and surfaces it through `BasisDebug` — logged once / rate-limited, never every frame (see the existing `HVRBasisBuiltInAddresses.Simulate()` guard for the pattern). Expect this to be scrutinized closely in review.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [x] Windows
- [ ] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [x] Tested in VR (note headset under **Notes**)
- [x] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [ ] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [ ] N/A — change does not touch any of the above

## Notes
<!-- Optional context for reviewers. Headset model, why a required box is N/A, anything else worth knowing. -->
