### PR TITLE
Feature/dropdown arrow

### DIFF
--- a/Basis/Assets/AddressableAssetsData/AssetGroups/Basis UI Assets.asset
+++ b/Basis/Assets/AddressableAssetsData/AssetGroups/Basis UI Assets.asset
@@ -273,6 +273,11 @@ MonoBehaviour:
     m_ReadOnly: 0
     m_SerializedLabels: []
     FlaggedDuringContentUpdateRestriction: 0
+  - m_GUID: 91d6c9e2a4fa4ff28d51ab0d8788b99e
+    m_Address: Packages/com.basis.sdk/Prefabs/Panel Elements/PE Section Toggle.prefab
+    m_ReadOnly: 0
+    m_SerializedLabels: []
+    FlaggedDuringContentUpdateRestriction: 0
   - m_GUID: 7e571c64d9cdd834a90133d8db72c649
     m_Address: Packages/com.basis.sdk/Textures/Runtime/search.png
     m_ReadOnly: 0
@@ -488,6 +493,11 @@ MonoBehaviour:
     FlaggedDuringContentUpdateRestriction: 0
   - m_GUID: ec70b894fa918244fa23d2bbd2f1b5bd
     m_Address: Packages/com.basis.sdk/Prefabs/Panel Elements/PE Toggle - Entry Variant.prefab
+    m_ReadOnly: 0
+    m_SerializedLabels: []
+    FlaggedDuringContentUpdateRestriction: 0
+  - m_GUID: 9b76bc86253e4a7c9d6c9f8a0b1e2d3c
+    m_Address: Packages/com.basis.sdk/Prefabs/Panel Elements/PE Section Toggle - Entry Variant.prefab
     m_ReadOnly: 0
     m_SerializedLabels: []
     FlaggedDuringContentUpdateRestriction: 0

--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/ar.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/ar.json
@@ -960,7 +960,7 @@
     { "key": "settings.graphics.poseLod.bias", "value": "انحياز LOD الوضعية" },
     { "key": "settings.graphics.poseLod.bias.description", "value": "يقلل من تكلفة المعالج عن طريق تحديث وضعيات اللاعبين البعيدين بشكل أقل تكرارًا.\n0 = متوقف (يتم تحديث جميع اللاعبين كل إطار).\n1-2 = تقليل طفيف، بالكاد يُرى.\n3-5 = ملحوظ على اللاعبين البعيدين، توفير كبير في المعالج." },
     { "key": "settings.graphics.advanced.description", "value": "اضبط خيارات التصيير و LOD والأداء بدقة." },
-    { "key": "settings.graphics.advanced.showAdvanced", "value": "إظهار الإعدادات المتقدمة" },
+    { "key": "settings.graphics.advanced.showAdvanced", "value": "الإعدادات المتقدمة" },
     { "key": "settings.graphics.renderScale", "value": "مقياس التصيير" },
     { "key": "settings.graphics.hdrSupport", "value": "دعم HDR" },
     { "key": "settings.graphics.foveated", "value": "نسبة التصيير المركّز" },

--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/bn.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/bn.json
@@ -960,7 +960,7 @@
     { "key": "settings.graphics.poseLod.bias", "value": "পোজ LOD পক্ষপাত" },
     { "key": "settings.graphics.poseLod.bias.description", "value": "দূরবর্তী খেলোয়াড় পোজ কম ঘন ঘন আপডেট করে CPU খরচ কমায়।\n0 = বন্ধ (সমস্ত খেলোয়াড় প্রতি ফ্রেমে আপডেট হয়)।\n1-2 = সূক্ষ্ম হ্রাস, সবে দৃশ্যমান।\n3-5 = দূরবর্তী খেলোয়াড়দের উপর লক্ষণীয়, উল্লেখযোগ্য CPU সঞ্চয়।" },
     { "key": "settings.graphics.advanced.description", "value": "রেন্ডারিং, LOD, এবং কর্মক্ষমতা বিকল্প সূক্ষ্ম-টিউন করুন।" },
-    { "key": "settings.graphics.advanced.showAdvanced", "value": "উন্নত সেটিংস দেখান" },
+    { "key": "settings.graphics.advanced.showAdvanced", "value": "উন্নত সেটিংস" },
     { "key": "settings.graphics.renderScale", "value": "রেন্ডার স্কেল" },
     { "key": "settings.graphics.hdrSupport", "value": "HDR সমর্থন" },
     { "key": "settings.graphics.foveated", "value": "ফোভিয়েটেড শতাংশ" },

--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/de.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/de.json
@@ -960,7 +960,7 @@
     { "key": "settings.graphics.poseLod.bias", "value": "Posen-LOD-Bias" },
     { "key": "settings.graphics.poseLod.bias.description", "value": "Reduziert die CPU-Last, indem entfernte Spieler-Posen seltener aktualisiert werden.\n0 = aus (alle Spieler aktualisieren jeden Frame).\n1-2 = subtile Reduktion, kaum sichtbar.\n3-5 = bei entfernten Spielern erkennbar, deutliche CPU-Einsparung." },
     { "key": "settings.graphics.advanced.description", "value": "Feinabstimmung von Rendering, LOD und Leistungsoptionen." },
-    { "key": "settings.graphics.advanced.showAdvanced", "value": "Erweiterte Einstellungen anzeigen" },
+    { "key": "settings.graphics.advanced.showAdvanced", "value": "Erweiterte Einstellungen" },
     { "key": "settings.graphics.renderScale", "value": "Render-Skalierung" },
     { "key": "settings.graphics.hdrSupport", "value": "HDR-Unterstützung" },
     { "key": "settings.graphics.foveated", "value": "Foveated-Anteil" },

--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/en.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/en.json
@@ -4120,7 +4120,7 @@
     },
     {
       "key": "settings.graphics.advanced.showAdvanced",
-      "value": "Show Advanced Settings"
+      "value": "Advanced Settings"
     },
     {
       "key": "settings.graphics.renderScale",

--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/es-MX.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/es-MX.json
@@ -960,7 +960,7 @@
     { "key": "settings.graphics.poseLod.bias", "value": "Sesgo del LOD de pose" },
     { "key": "settings.graphics.poseLod.bias.description", "value": "Reduce el uso de CPU actualizando con menor frecuencia las poses de jugadores lejanos.\n0 = desactivado (todos los jugadores se actualizan cada frame).\n1-2 = reducción sutil, apenas visible.\n3-5 = notable en jugadores lejanos, ahorro significativo de CPU." },
     { "key": "settings.graphics.advanced.description", "value": "Ajusta a detalle el renderizado, el LOD y las opciones de rendimiento." },
-    { "key": "settings.graphics.advanced.showAdvanced", "value": "Mostrar ajustes avanzados" },
+    { "key": "settings.graphics.advanced.showAdvanced", "value": "Ajustes avanzados" },
     { "key": "settings.graphics.renderScale", "value": "Escala de renderizado" },
     { "key": "settings.graphics.hdrSupport", "value": "Soporte HDR" },
     { "key": "settings.graphics.foveated", "value": "Porcentaje foveado" },

--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/es.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/es.json
@@ -947,7 +947,7 @@
     { "key": "settings.graphics.poseLod.bias", "value": "Sesgo del LOD de pose" },
     { "key": "settings.graphics.poseLod.bias.description", "value": "Reduce el coste de CPU actualizando con menor frecuencia las poses de jugadores lejanos.\n0 = desactivado (todos los jugadores se actualizan cada frame).\n1-2 = reducción sutil, apenas visible.\n3-5 = notable en jugadores lejanos, ahorro significativo de CPU." },
     { "key": "settings.graphics.advanced.description", "value": "Ajusta con detalle el renderizado, el LOD y las opciones de rendimiento." },
-    { "key": "settings.graphics.advanced.showAdvanced", "value": "Mostrar ajustes avanzados" },
+    { "key": "settings.graphics.advanced.showAdvanced", "value": "Ajustes avanzados" },
     { "key": "settings.graphics.renderScale", "value": "Escala de renderizado" },
     { "key": "settings.graphics.hdrSupport", "value": "Compatibilidad con HDR" },
     { "key": "settings.graphics.foveated", "value": "Porcentaje foveado" },

--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/fr.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/fr.json
@@ -960,7 +960,7 @@
     { "key": "settings.graphics.poseLod.bias", "value": "Biais du LOD de pose" },
     { "key": "settings.graphics.poseLod.bias.description", "value": "Réduit le coût CPU en mettant à jour les poses des joueurs distants moins fréquemment.\n0 = désactivé (tous les joueurs se mettent à jour à chaque image).\n1-2 = réduction subtile, à peine visible.\n3-5 = perceptible sur les joueurs distants, économies CPU significatives." },
     { "key": "settings.graphics.advanced.description", "value": "Ajustez finement le rendu, le LOD et les options de performance." },
-    { "key": "settings.graphics.advanced.showAdvanced", "value": "Afficher les paramètres avancés" },
+    { "key": "settings.graphics.advanced.showAdvanced", "value": "Paramètres avancés" },
     { "key": "settings.graphics.renderScale", "value": "Échelle de rendu" },
     { "key": "settings.graphics.hdrSupport", "value": "Prise en charge HDR" },
     { "key": "settings.graphics.foveated", "value": "Pourcentage fovéal" },

--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/hi.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/hi.json
@@ -960,7 +960,7 @@
     { "key": "settings.graphics.poseLod.bias", "value": "पोज़ LOD बायस" },
     { "key": "settings.graphics.poseLod.bias.description", "value": "दूर के खिलाड़ियों के पोज़ को कम बार अद्यतन करके CPU लागत कम करता है।\n0 = बंद (सभी खिलाड़ी हर फ़्रेम अद्यतन होते हैं)।\n1-2 = सूक्ष्म कमी, मुश्किल से दिखने वाली।\n3-5 = दूर के खिलाड़ियों पर ध्यान देने योग्य, महत्वपूर्ण CPU बचत।" },
     { "key": "settings.graphics.advanced.description", "value": "रेंडरिंग, LOD, और प्रदर्शन विकल्पों को बारीकी से समायोजित करें।" },
-    { "key": "settings.graphics.advanced.showAdvanced", "value": "उन्नत सेटिंग्स दिखाएँ" },
+    { "key": "settings.graphics.advanced.showAdvanced", "value": "उन्नत सेटिंग्स" },
     { "key": "settings.graphics.renderScale", "value": "रेंडर स्केल" },
     { "key": "settings.graphics.hdrSupport", "value": "HDR समर्थन" },
     { "key": "settings.graphics.foveated", "value": "फ़ोवियेटेड प्रतिशत" },

--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/it.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/it.json
@@ -960,7 +960,7 @@
     { "key": "settings.graphics.poseLod.bias", "value": "Bias LOD pose" },
     { "key": "settings.graphics.poseLod.bias.description", "value": "Riduce il costo della CPU aggiornando meno frequentemente le pose dei giocatori lontani.\n0 = disattivato (tutti i giocatori si aggiornano ogni frame).\n1-2 = riduzione sottile, appena visibile.\n3-5 = evidente sui giocatori lontani, risparmio CPU significativo." },
     { "key": "settings.graphics.advanced.description", "value": "Regola con precisione rendering, LOD e opzioni di prestazioni." },
-    { "key": "settings.graphics.advanced.showAdvanced", "value": "Mostra impostazioni avanzate" },
+    { "key": "settings.graphics.advanced.showAdvanced", "value": "Impostazioni avanzate" },
     { "key": "settings.graphics.renderScale", "value": "Scala rendering" },
     { "key": "settings.graphics.hdrSupport", "value": "Supporto HDR" },
     { "key": "settings.graphics.foveated", "value": "Percentuale foveata" },

--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/ja.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/ja.json
@@ -960,7 +960,7 @@
     { "key": "settings.graphics.poseLod.bias", "value": "ポーズLODバイアス" },
     { "key": "settings.graphics.poseLod.bias.description", "value": "遠方プレイヤーのポーズ更新頻度を下げてCPU負荷を削減。\n0 = 無効（全プレイヤーが毎フレーム更新）。\n1-2 = 軽微な削減、ほぼ見えない。\n3-5 = 遠方プレイヤーで顕著、CPU大幅節約。" },
     { "key": "settings.graphics.advanced.description", "value": "描画・LOD・パフォーマンスを詳細調整。" },
-    { "key": "settings.graphics.advanced.showAdvanced", "value": "詳細設定を表示" },
+    { "key": "settings.graphics.advanced.showAdvanced", "value": "詳細設定" },
     { "key": "settings.graphics.renderScale", "value": "描画スケール" },
     { "key": "settings.graphics.hdrSupport", "value": "HDRサポート" },
     { "key": "settings.graphics.foveated", "value": "フォービエイト率" },

--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/nl.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/nl.json
@@ -960,7 +960,7 @@
     { "key": "settings.graphics.poseLod.bias", "value": "Pose LOD Bias" },
     { "key": "settings.graphics.poseLod.bias.description", "value": "Vermindert CPU-kosten door houdingen van verre spelers minder vaak bij te werken.\n0 = uit (alle spelers updaten elk frame).\n1-2 = subtiele vermindering, nauwelijks zichtbaar.\n3-5 = merkbaar bij verre spelers, aanzienlijke CPU-besparing." },
     { "key": "settings.graphics.advanced.description", "value": "Fijnafstellen van rendering, LOD en prestatie-opties." },
-    { "key": "settings.graphics.advanced.showAdvanced", "value": "Geavanceerde Instellingen Tonen" },
+    { "key": "settings.graphics.advanced.showAdvanced", "value": "Geavanceerde instellingen" },
     { "key": "settings.graphics.renderScale", "value": "Renderschaal" },
     { "key": "settings.graphics.hdrSupport", "value": "HDR Ondersteuning" },
     { "key": "settings.graphics.foveated", "value": "Foveated Percentage" },

--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/pt.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/pt.json
@@ -947,7 +947,7 @@
     { "key": "settings.graphics.poseLod.bias", "value": "Viés de LOD de Pose" },
     { "key": "settings.graphics.poseLod.bias.description", "value": "Reduz o custo de CPU atualizando poses de jogadores distantes com menos frequência.\n0 = desligado (todos os jogadores atualizam a cada quadro).\n1-2 = redução sutil, quase imperceptível.\n3-5 = perceptível em jogadores distantes, economia significativa de CPU." },
     { "key": "settings.graphics.advanced.description", "value": "Ajustar renderização, LOD e opções de desempenho." },
-    { "key": "settings.graphics.advanced.showAdvanced", "value": "Mostrar Configurações Avançadas" },
+    { "key": "settings.graphics.advanced.showAdvanced", "value": "Configurações Avançadas" },
     { "key": "settings.graphics.renderScale", "value": "Escala de Renderização" },
     { "key": "settings.graphics.hdrSupport", "value": "Suporte HDR" },
     { "key": "settings.graphics.foveated", "value": "Porcentagem Foveada" },

--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/ru.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/ru.json
@@ -960,7 +960,7 @@
     { "key": "settings.graphics.poseLod.bias", "value": "Смещение LOD поз" },
     { "key": "settings.graphics.poseLod.bias.description", "value": "Снижает нагрузку на CPU, обновляя позы отдалённых игроков реже.\n0 = выкл. (все игроки обновляются каждый кадр).\n1-2 = слабое снижение, едва заметно.\n3-5 = заметно для отдалённых игроков, значительная экономия CPU." },
     { "key": "settings.graphics.advanced.description", "value": "Тонкая настройка рендеринга, LOD и параметров производительности." },
-    { "key": "settings.graphics.advanced.showAdvanced", "value": "Показать расширенные настройки" },
+    { "key": "settings.graphics.advanced.showAdvanced", "value": "Расширенные настройки" },
     { "key": "settings.graphics.renderScale", "value": "Масштаб рендеринга" },
     { "key": "settings.graphics.hdrSupport", "value": "Поддержка HDR" },
     { "key": "settings.graphics.foveated", "value": "Процент фовеации" },

--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/ur.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/ur.json
@@ -960,7 +960,7 @@
     { "key": "settings.graphics.poseLod.bias", "value": "پوز LOD بائیس" },
     { "key": "settings.graphics.poseLod.bias.description", "value": "دور کے کھلاڑی پوزز کو کم بار اپ ڈیٹ کر کے CPU لاگت کم کرتا ہے۔\n0 = بند (تمام کھلاڑی ہر فریم اپ ڈیٹ کرتے ہیں)۔\n1-2 = ہلکی کمی، بمشکل نظر آتی ہے۔\n3-5 = دور کے کھلاڑیوں پر قابل غور، اہم CPU بچت۔" },
     { "key": "settings.graphics.advanced.description", "value": "رینڈرنگ، LOD، اور کارکردگی کے اختیارات کو باریک بینی سے ٹیون کریں۔" },
-    { "key": "settings.graphics.advanced.showAdvanced", "value": "اعلی درجے کی ترتیبات دکھائیں" },
+    { "key": "settings.graphics.advanced.showAdvanced", "value": "اعلی درجے کی ترتیبات" },
     { "key": "settings.graphics.renderScale", "value": "رینڈر اسکیل" },
     { "key": "settings.graphics.hdrSupport", "value": "HDR سپورٹ" },
     { "key": "settings.graphics.foveated", "value": "فوویٹڈ فیصد" },

--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/zh-CN.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/zh-CN.json
@@ -960,7 +960,7 @@
     { "key": "settings.graphics.poseLod.bias", "value": "姿势 LOD 偏移" },
     { "key": "settings.graphics.poseLod.bias.description", "value": "通过降低远处玩家姿势的更新频率来减少 CPU 开销。\n0 = 关闭（所有玩家每帧更新）。\n1-2 = 轻微减少，几乎不可见。\n3-5 = 远处玩家明显，CPU 显著节省。" },
     { "key": "settings.graphics.advanced.description", "value": "细致调整渲染、LOD 和性能选项。" },
-    { "key": "settings.graphics.advanced.showAdvanced", "value": "显示高级设置" },
+    { "key": "settings.graphics.advanced.showAdvanced", "value": "高级设置" },
     { "key": "settings.graphics.renderScale", "value": "渲染缩放" },
     { "key": "settings.graphics.hdrSupport", "value": "HDR 支持" },
     { "key": "settings.graphics.foveated", "value": "注视点渲染百分比" },

--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/zh-Hans.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/zh-Hans.json
@@ -960,7 +960,7 @@
     { "key": "settings.graphics.poseLod.bias", "value": "姿势 LOD 偏移" },
     { "key": "settings.graphics.poseLod.bias.description", "value": "通过降低远处玩家姿势的更新频率来减少 CPU 开销。\n0 = 关闭（所有玩家每帧更新）。\n1-2 = 轻微减少，几乎不可见。\n3-5 = 远处玩家明显，CPU 显著节省。" },
     { "key": "settings.graphics.advanced.description", "value": "细致调整渲染、LOD 和性能选项。" },
-    { "key": "settings.graphics.advanced.showAdvanced", "value": "显示高级设置" },
+    { "key": "settings.graphics.advanced.showAdvanced", "value": "高级设置" },
     { "key": "settings.graphics.renderScale", "value": "渲染缩放" },
     { "key": "settings.graphics.hdrSupport", "value": "HDR 支持" },
     { "key": "settings.graphics.foveated", "value": "注视点渲染百分比" },

--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/zh-Hant.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/zh-Hant.json
@@ -960,7 +960,7 @@
     { "key": "settings.graphics.poseLod.bias", "value": "姿态 LOD 偏移" },
     { "key": "settings.graphics.poseLod.bias.description", "value": "通过降低远处玩家姿态更新频率来减少 CPU 开销。\n0 = 关闭（所有玩家每帧更新）。\n1-2 = 轻微减少，几乎不可见。\n3-5 = 远处玩家明显，CPU 节省显著。" },
     { "key": "settings.graphics.advanced.description", "value": "微调渲染、LOD 和性能选项。" },
-    { "key": "settings.graphics.advanced.showAdvanced", "value": "显示高级设置" },
+    { "key": "settings.graphics.advanced.showAdvanced", "value": "進階設定" },
     { "key": "settings.graphics.renderScale", "value": "渲染缩放" },
     { "key": "settings.graphics.hdrSupport", "value": "HDR 支持" },
     { "key": "settings.graphics.foveated", "value": "注视点渲染百分比" },

--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/zh.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/zh.json
@@ -947,7 +947,7 @@
     { "key": "settings.graphics.poseLod.bias", "value": "姿态 LOD 偏移" },
     { "key": "settings.graphics.poseLod.bias.description", "value": "通过降低远处玩家姿态更新频率来减少 CPU 开销。\n0 = 关闭（所有玩家每帧更新）。\n1-2 = 轻微减少，几乎不可见。\n3-5 = 远处玩家明显，CPU 节省显著。" },
     { "key": "settings.graphics.advanced.description", "value": "微调渲染、LOD 和性能选项。" },
-    { "key": "settings.graphics.advanced.showAdvanced", "value": "显示高级设置" },
+    { "key": "settings.graphics.advanced.showAdvanced", "value": "高级设置" },
     { "key": "settings.graphics.renderScale", "value": "渲染缩放" },
     { "key": "settings.graphics.hdrSupport", "value": "HDR 支持" },
     { "key": "settings.graphics.foveated", "value": "注视点渲染百分比" },

--- a/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProvider.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProvider.cs
@@ -1636,7 +1636,7 @@ namespace Basis.BasisUI
 
             // Performance limits live in the same tab — formerly its own page,
             // merged here so users see all rendering / quality / cost controls together.
-            SettingsProviderPerformanceLimits.BuildPerformanceLimitsContent(container);
+            SettingsProviderPerformanceLimits.BuildPerformanceLimitsContent(container, true);
 
             // One reset button for this whole page
             AddResetPageButton(container, "settings.tab.graphics", ResetGraphicsDefaults);

--- a/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProvider.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProvider.cs
@@ -415,6 +415,7 @@ namespace Basis.BasisUI
             toggleAvatarPreviewMirror.AssignBinding(BasisSettingsDefaults.AvatarPreviewMirror);
             toggleAvatarPreviewMirror.Descriptor.SetTitle(BasisLocalization.Get("settings.general.avatarPreviewMirror"));
             toggleAvatarPreviewMirror.Descriptor.SetTooltip(BasisLocalization.Get("settings.general.avatarPreviewMirror.tooltip"));
+            toggleAvatarPreview.RegisterContentContainer(toggleAvatarPreviewMirror);
 
             toggleAvatarPreviewMirror.Descriptor.SetActive(toggleAvatarPreview.Expanded);
             toggleAvatarPreview.OnExpandedChanged += (val) =>
@@ -445,6 +446,7 @@ namespace Basis.BasisUI
                 toggleAudioFromHead.AssignBinding(BasisSettingsDefaults.AudioListenerFollowsHead);
                 toggleAudioFromHead.Descriptor.SetTitle(BasisLocalization.Get("settings.general.thirdPerson.audioFromHead"));
                 toggleAudioFromHead.Descriptor.SetTooltip(BasisLocalization.Get("settings.general.thirdPerson.audioFromHead.tooltip"));
+                toggleThirdPerson.RegisterContentContainer(toggleAudioFromHead);
 
                 toggleAudioFromHead.Descriptor.SetActive(toggleThirdPerson.Expanded);
                 toggleThirdPerson.OnExpandedChanged += (val) =>
@@ -1603,6 +1605,13 @@ namespace Basis.BasisUI
             toggleLocalHeadBlendShapes.AssignBinding(BasisSettingsDefaults.LocalHeadBlendShapes);
             toggleLocalHeadBlendShapes.Descriptor.SetTitle(BasisLocalization.Get("settings.graphics.localHeadBlendShapes"));
             toggleLocalHeadBlendShapes.Descriptor.SetTooltip(BasisLocalization.Get("settings.graphics.localHeadBlendShapes.tooltip"));
+            toggleAdvanced.RegisterContentContainer(sliderRenderResolution);
+            toggleAdvanced.RegisterContentContainer(dropdownHDR);
+            toggleAdvanced.RegisterContentContainer(sliderFoveatedRendering);
+            toggleAdvanced.RegisterContentContainer(sliderFieldOfView);
+            toggleAdvanced.RegisterContentContainer(sliderMeshLOD);
+            toggleAdvanced.RegisterContentContainer(sliderGlobalMeshLOD);
+            toggleAdvanced.RegisterContentContainer(toggleLocalHeadBlendShapes);
 
             sliderRenderResolution.Descriptor.SetActive(false);
             dropdownHDR.Descriptor.SetActive(false);

--- a/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProvider.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProvider.cs
@@ -415,15 +415,12 @@ namespace Basis.BasisUI
             toggleAvatarPreviewMirror.AssignBinding(BasisSettingsDefaults.AvatarPreviewMirror);
             toggleAvatarPreviewMirror.Descriptor.SetTitle(BasisLocalization.Get("settings.general.avatarPreviewMirror"));
             toggleAvatarPreviewMirror.Descriptor.SetTooltip(BasisLocalization.Get("settings.general.avatarPreviewMirror.tooltip"));
-            toggleAvatarPreview.RegisterContentContainer(toggleAvatarPreviewMirror);
 
-            toggleAvatarPreviewMirror.Descriptor.SetActive(toggleAvatarPreview.Expanded);
-            toggleAvatarPreview.OnExpandedChanged += (val) =>
+            PanelSectionToggleHelpers.FinalizeCollapsibleContents(toggleAvatarPreview, toggleAvatarPreview.Expanded, _ =>
             {
-                toggleAvatarPreviewMirror.Descriptor.SetActive(val);
                 hudGroup.ForceRebuild();
                 descriptor.ForceRebuild();
-            };
+            }, toggleAvatarPreviewMirror);
 
             PanelToggle toggleCameraHud = PanelToggle.CreateNewEntry(hudGroup);
             toggleCameraHud.AssignBinding(BasisSettingsDefaults.CameraHud);
@@ -446,15 +443,12 @@ namespace Basis.BasisUI
                 toggleAudioFromHead.AssignBinding(BasisSettingsDefaults.AudioListenerFollowsHead);
                 toggleAudioFromHead.Descriptor.SetTitle(BasisLocalization.Get("settings.general.thirdPerson.audioFromHead"));
                 toggleAudioFromHead.Descriptor.SetTooltip(BasisLocalization.Get("settings.general.thirdPerson.audioFromHead.tooltip"));
-                toggleThirdPerson.RegisterContentContainer(toggleAudioFromHead);
 
-                toggleAudioFromHead.Descriptor.SetActive(toggleThirdPerson.Expanded);
-                toggleThirdPerson.OnExpandedChanged += (val) =>
+                PanelSectionToggleHelpers.FinalizeCollapsibleContents(toggleThirdPerson, toggleThirdPerson.Expanded, _ =>
                 {
-                    toggleAudioFromHead.Descriptor.SetActive(val);
                     cameraGroup.ForceRebuild();
                     descriptor.ForceRebuild();
-                };
+                }, toggleAudioFromHead);
             }
 
             BuildNetworkingSection(container);
@@ -1553,7 +1547,6 @@ namespace Basis.BasisUI
 
             PanelSectionToggle toggleAdvanced = PanelSectionToggle.CreateNewEntry(advancedGroup.ContentParent);
             toggleAdvanced.SetTitle(BasisLocalization.Get("settings.graphics.advanced.showAdvanced"));
-            toggleAdvanced.SetExpandedWithoutNotify(false);
 
             PanelSlider sliderRenderResolution = PanelSlider.CreateEntryAndBind(
                 advancedGroup.ContentParent,
@@ -1605,34 +1598,19 @@ namespace Basis.BasisUI
             toggleLocalHeadBlendShapes.AssignBinding(BasisSettingsDefaults.LocalHeadBlendShapes);
             toggleLocalHeadBlendShapes.Descriptor.SetTitle(BasisLocalization.Get("settings.graphics.localHeadBlendShapes"));
             toggleLocalHeadBlendShapes.Descriptor.SetTooltip(BasisLocalization.Get("settings.graphics.localHeadBlendShapes.tooltip"));
-            toggleAdvanced.RegisterContentContainer(sliderRenderResolution);
-            toggleAdvanced.RegisterContentContainer(dropdownHDR);
-            toggleAdvanced.RegisterContentContainer(sliderFoveatedRendering);
-            toggleAdvanced.RegisterContentContainer(sliderFieldOfView);
-            toggleAdvanced.RegisterContentContainer(sliderMeshLOD);
-            toggleAdvanced.RegisterContentContainer(sliderGlobalMeshLOD);
-            toggleAdvanced.RegisterContentContainer(toggleLocalHeadBlendShapes);
 
-            sliderRenderResolution.Descriptor.SetActive(false);
-            dropdownHDR.Descriptor.SetActive(false);
-            sliderFoveatedRendering.Descriptor.SetActive(false);
-            sliderFieldOfView.Descriptor.SetActive(false);
-            sliderMeshLOD.Descriptor.SetActive(false);
-            sliderGlobalMeshLOD.Descriptor.SetActive(false);
-            toggleLocalHeadBlendShapes.Descriptor.SetActive(false);
-
-            toggleAdvanced.OnExpandedChanged += (val) =>
+            PanelSectionToggleHelpers.FinalizeCollapsibleContents(toggleAdvanced, false, _ =>
             {
-                sliderRenderResolution.Descriptor.SetActive(val);
-                dropdownHDR.Descriptor.SetActive(val);
-                sliderFoveatedRendering.Descriptor.SetActive(val);
-                sliderFieldOfView.Descriptor.SetActive(val);
-                sliderMeshLOD.Descriptor.SetActive(val);
-                sliderGlobalMeshLOD.Descriptor.SetActive(val);
-                toggleLocalHeadBlendShapes.Descriptor.SetActive(val);
                 advancedGroup.ForceRebuild();
                 descriptor.ForceRebuild();
-            };
+            },
+                sliderRenderResolution,
+                dropdownHDR,
+                sliderFoveatedRendering,
+                sliderFieldOfView,
+                sliderMeshLOD,
+                sliderGlobalMeshLOD,
+                toggleLocalHeadBlendShapes);
 
             // Performance limits live in the same tab — formerly its own page,
             // merged here so users see all rendering / quality / cost controls together.

--- a/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProvider.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProvider.cs
@@ -1541,12 +1541,12 @@ namespace Basis.BasisUI
                 BasisSettingsDefaults.PoseLOD);
             sliderPoseLod.Descriptor.SetTooltip(BasisLocalization.Get("settings.graphics.poseLod.bias.tooltip"));
 
-            PanelElementDescriptor advancedGroup =
-                PanelElementDescriptor.CreateNew(PanelElementDescriptor.ElementStyles.Group, container);
-            advancedGroup.SetTitle(BasisLocalization.Get("ui.advanced"));
-
-            PanelSectionToggle toggleAdvanced = PanelSectionToggle.CreateNewEntry(advancedGroup.ContentParent);
-            toggleAdvanced.SetTitle(BasisLocalization.Get("settings.graphics.advanced.showAdvanced"));
+            PanelSectionToggle toggleAdvanced = PanelSectionToggle.CreateNewEntry(container);
+            PanelElementDescriptor advancedGroup = PanelSectionToggleHelpers.CreateCollapsibleContentGroup(
+                toggleAdvanced,
+                container,
+                BasisLocalization.Get("settings.graphics.advanced.showAdvanced"),
+                false);
 
             PanelSlider sliderRenderResolution = PanelSlider.CreateEntryAndBind(
                 advancedGroup.ContentParent,
@@ -1599,18 +1599,11 @@ namespace Basis.BasisUI
             toggleLocalHeadBlendShapes.Descriptor.SetTitle(BasisLocalization.Get("settings.graphics.localHeadBlendShapes"));
             toggleLocalHeadBlendShapes.Descriptor.SetTooltip(BasisLocalization.Get("settings.graphics.localHeadBlendShapes.tooltip"));
 
-            PanelSectionToggleHelpers.FinalizeCollapsibleContents(toggleAdvanced, false, _ =>
+            PanelSectionToggleHelpers.FinalizeCollapsibleGroup(toggleAdvanced, advancedGroup, false, _ =>
             {
                 advancedGroup.ForceRebuild();
                 descriptor.ForceRebuild();
-            },
-                sliderRenderResolution,
-                dropdownHDR,
-                sliderFoveatedRendering,
-                sliderFieldOfView,
-                sliderMeshLOD,
-                sliderGlobalMeshLOD,
-                toggleLocalHeadBlendShapes);
+            });
 
             // Performance limits live in the same tab — formerly its own page,
             // merged here so users see all rendering / quality / cost controls together.

--- a/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProvider.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProvider.cs
@@ -406,9 +406,9 @@ namespace Basis.BasisUI
             toggleDesktopReticle.Descriptor.SetTitle(BasisLocalization.Get("settings.general.desktopReticle"));
             toggleDesktopReticle.Descriptor.SetTooltip(BasisLocalization.Get("settings.general.desktopReticle.tooltip"));
 
-            PanelToggle toggleAvatarPreview = PanelToggle.CreateNewEntry(hudGroup);
-            toggleAvatarPreview.AssignBinding(BasisSettingsDefaults.AvatarPreview);
-            toggleAvatarPreview.Descriptor.SetTitle(BasisLocalization.Get("settings.general.avatarPreview"));
+            PanelSectionToggle toggleAvatarPreview = PanelSectionToggle.CreateNewEntry(hudGroup);
+            toggleAvatarPreview.BindToToggle(BasisSettingsDefaults.AvatarPreview);
+            toggleAvatarPreview.SetTitle(BasisLocalization.Get("settings.general.avatarPreview"));
             toggleAvatarPreview.Descriptor.SetTooltip(BasisLocalization.Get("settings.general.avatarPreview.tooltip"));
 
             PanelToggle toggleAvatarPreviewMirror = PanelToggle.CreateNewEntry(hudGroup);
@@ -416,8 +416,8 @@ namespace Basis.BasisUI
             toggleAvatarPreviewMirror.Descriptor.SetTitle(BasisLocalization.Get("settings.general.avatarPreviewMirror"));
             toggleAvatarPreviewMirror.Descriptor.SetTooltip(BasisLocalization.Get("settings.general.avatarPreviewMirror.tooltip"));
 
-            toggleAvatarPreviewMirror.Descriptor.SetActive(toggleAvatarPreview.Value);
-            toggleAvatarPreview.OnValueChanged += (val) =>
+            toggleAvatarPreviewMirror.Descriptor.SetActive(toggleAvatarPreview.Expanded);
+            toggleAvatarPreview.OnExpandedChanged += (val) =>
             {
                 toggleAvatarPreviewMirror.Descriptor.SetActive(val);
                 hudGroup.ForceRebuild();
@@ -436,9 +436,9 @@ namespace Basis.BasisUI
                     PanelElementDescriptor.CreateNew(PanelElementDescriptor.ElementStyles.Group, container);
                 cameraGroup.SetTitle(BasisLocalization.Get("settings.general.camera.title"));
 
-                PanelToggle toggleThirdPerson = PanelToggle.CreateNewEntry(cameraGroup);
-                toggleThirdPerson.AssignBinding(BasisSettingsDefaults.EnableThirdPersonCamera);
-                toggleThirdPerson.Descriptor.SetTitle(BasisLocalization.Get("settings.general.thirdPerson"));
+                PanelSectionToggle toggleThirdPerson = PanelSectionToggle.CreateNewEntry(cameraGroup);
+                toggleThirdPerson.BindToToggle(BasisSettingsDefaults.EnableThirdPersonCamera);
+                toggleThirdPerson.SetTitle(BasisLocalization.Get("settings.general.thirdPerson"));
                 toggleThirdPerson.Descriptor.SetTooltip(BasisLocalization.Get("settings.general.thirdPerson.tooltip"));
 
                 PanelToggle toggleAudioFromHead = PanelToggle.CreateNewEntry(cameraGroup);
@@ -446,8 +446,8 @@ namespace Basis.BasisUI
                 toggleAudioFromHead.Descriptor.SetTitle(BasisLocalization.Get("settings.general.thirdPerson.audioFromHead"));
                 toggleAudioFromHead.Descriptor.SetTooltip(BasisLocalization.Get("settings.general.thirdPerson.audioFromHead.tooltip"));
 
-                toggleAudioFromHead.Descriptor.SetActive(toggleThirdPerson.Value);
-                toggleThirdPerson.OnValueChanged += (val) =>
+                toggleAudioFromHead.Descriptor.SetActive(toggleThirdPerson.Expanded);
+                toggleThirdPerson.OnExpandedChanged += (val) =>
                 {
                     toggleAudioFromHead.Descriptor.SetActive(val);
                     cameraGroup.ForceRebuild();
@@ -1549,9 +1549,9 @@ namespace Basis.BasisUI
                 PanelElementDescriptor.CreateNew(PanelElementDescriptor.ElementStyles.Group, container);
             advancedGroup.SetTitle(BasisLocalization.Get("ui.advanced"));
 
-            PanelToggle toggleAdvanced = PanelToggle.CreateNewEntry(advancedGroup.ContentParent);
-            toggleAdvanced.Descriptor.SetTitle(BasisLocalization.Get("settings.graphics.advanced.showAdvanced"));
-            toggleAdvanced.SetValueWithoutNotify(false);
+            PanelSectionToggle toggleAdvanced = PanelSectionToggle.CreateNewEntry(advancedGroup.ContentParent);
+            toggleAdvanced.SetTitle(BasisLocalization.Get("settings.graphics.advanced.showAdvanced"));
+            toggleAdvanced.SetExpandedWithoutNotify(false);
 
             PanelSlider sliderRenderResolution = PanelSlider.CreateEntryAndBind(
                 advancedGroup.ContentParent,
@@ -1612,7 +1612,7 @@ namespace Basis.BasisUI
             sliderGlobalMeshLOD.Descriptor.SetActive(false);
             toggleLocalHeadBlendShapes.Descriptor.SetActive(false);
 
-            toggleAdvanced.OnValueChanged += (val) =>
+            toggleAdvanced.OnExpandedChanged += (val) =>
             {
                 sliderRenderResolution.Descriptor.SetActive(val);
                 dropdownHDR.Descriptor.SetActive(val);

--- a/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/SettingsProviderIK.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/SettingsProviderIK.cs
@@ -185,6 +185,7 @@ public static class SettingsProviderIK
 
         colliderGroup.SetTitle(BasisLocalization.Get("settings.bodyTracking.colliders.title"));
         colliderGroup.SetIcon(AddressableAssets.Sprites.Settings);
+        advancedToggle.RegisterContentContainer(colliderGroup);
 
         var colliderParent = colliderGroup.ContentParent;
 
@@ -990,6 +991,7 @@ public static class SettingsProviderIK
 
         debugGroup.SetTitle(BasisLocalization.Get("settings.bodyTracking.heightDebug.title"));
         debugGroup.SetIcon(AddressableAssets.Sprites.Settings);
+        debugToggle.RegisterContentContainer(debugGroup);
 
         var debugParent = debugGroup.ContentParent;
 

--- a/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/SettingsProviderIK.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/SettingsProviderIK.cs
@@ -174,10 +174,10 @@ public static class SettingsProviderIK
         // ------------------
         // Advanced IK toggle
         // ------------------
-        var advancedToggle = PanelToggle.CreateNewEntry(tabDesc.ContentParent);
-        advancedToggle.Descriptor.SetTitle(BasisLocalization.Get("settings.bodyTracking.advanced"));
+        var advancedToggle = PanelSectionToggle.CreateNewEntry(tabDesc.ContentParent);
+        advancedToggle.SetTitle(BasisLocalization.Get("settings.bodyTracking.advanced"));
         advancedToggle.Descriptor.SetTooltip(BasisLocalization.Get("settings.bodyTracking.advanced.tooltip"));
-        advancedToggle.AssignBinding(BasisSettingsDefaults.FBIKAdvancedVisible);
+        advancedToggle.BindToToggle(BasisSettingsDefaults.FBIKAdvancedVisible);
 
         var colliderGroup = PanelElementDescriptor.CreateNew(
             PanelElementDescriptor.ElementStyles.Group,
@@ -945,7 +945,7 @@ public static class SettingsProviderIK
 
 
         colliderGroup.gameObject.SetActive(BasisSettingsDefaults.FBIKAdvancedVisible.RawValue);
-        advancedToggle.OnValueChanged += visible =>
+        advancedToggle.OnExpandedChanged += visible =>
         {
             colliderGroup.gameObject.SetActive(visible);
             tabDesc.ForceRebuild();
@@ -980,8 +980,8 @@ public static class SettingsProviderIK
 
     private static void BuildDebugSection(PanelElementDescriptor tabDesc)
     {
-        var debugToggle = PanelToggle.CreateNewEntry(tabDesc.ContentParent);
-        debugToggle.Descriptor.SetTitle(BasisLocalization.Get("settings.bodyTracking.debugInfo"));
+        var debugToggle = PanelSectionToggle.CreateNewEntry(tabDesc.ContentParent);
+        debugToggle.SetTitle(BasisLocalization.Get("settings.bodyTracking.debugInfo"));
         debugToggle.Descriptor.SetTooltip(BasisLocalization.Get("settings.bodyTracking.debugInfo.tooltip"));
 
         var debugGroup = PanelElementDescriptor.CreateNew(
@@ -1021,8 +1021,8 @@ public static class SettingsProviderIK
         RefreshDebugData();
 
         debugGroup.gameObject.SetActive(false);
-        debugToggle.SetValueWithoutNotify(false);
-        debugToggle.OnValueChanged += visible =>
+        debugToggle.SetExpandedWithoutNotify(false);
+        debugToggle.OnExpandedChanged += visible =>
         {
             debugGroup.gameObject.SetActive(visible);
             if (visible)
@@ -1372,8 +1372,8 @@ public static class SettingsProviderIK
     {
         var parent = parentGroup.ContentParent;
 
-        var sectionToggle = PanelToggle.CreateNewEntry(parent);
-        sectionToggle.Descriptor.SetTitle(title);
+        var sectionToggle = PanelSectionToggle.CreateNewEntry(parent);
+        sectionToggle.SetTitle(title);
         // Section blurb on hover (tooltip) instead of inline, to keep the page compact.
         sectionToggle.Descriptor.SetTooltip(description);
 
@@ -1388,9 +1388,9 @@ public static class SettingsProviderIK
         addContent(sectionGroup.ContentParent);
 
         sectionGroup.gameObject.SetActive(defaultOpen);
-        sectionToggle.SetValueWithoutNotify(defaultOpen);
+        sectionToggle.SetExpandedWithoutNotify(defaultOpen);
 
-        sectionToggle.OnValueChanged += visible =>
+        sectionToggle.OnExpandedChanged += visible =>
         {
             sectionGroup.gameObject.SetActive(visible);
             tabDesc.ForceRebuild();

--- a/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/SettingsProviderIK.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/SettingsProviderIK.cs
@@ -1382,6 +1382,7 @@ public static class SettingsProviderIK
             parent);
         sectionGroup.SetTitle(title);
         sectionGroup.SetIcon(AddressableAssets.Sprites.Settings);
+        sectionToggle.RegisterContentContainer(sectionGroup);
 
         // Add content while the group is still active so child component Awake/Start runs and
         // their text initializes. SetActive(false) before attach would orphan their lifecycle.

--- a/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/SettingsProviderIK.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/SettingsProviderIK.cs
@@ -1375,30 +1375,21 @@ public static class SettingsProviderIK
         var parent = parentGroup.ContentParent;
 
         var sectionToggle = PanelSectionToggle.CreateNewEntry(parent);
-        sectionToggle.SetTitle(title);
         // Section blurb on hover (tooltip) instead of inline, to keep the page compact.
         sectionToggle.Descriptor.SetTooltip(description);
 
-        var sectionGroup = PanelElementDescriptor.CreateNew(
-            PanelElementDescriptor.ElementStyles.Group,
-            parent);
-        sectionGroup.SetTitle(title);
+        var sectionGroup = PanelSectionToggleHelpers.CreateCollapsibleContentGroup(sectionToggle, parent, title);
         sectionGroup.SetIcon(AddressableAssets.Sprites.Settings);
-        sectionToggle.RegisterContentContainer(sectionGroup);
 
         // Add content while the group is still active so child component Awake/Start runs and
         // their text initializes. SetActive(false) before attach would orphan their lifecycle.
         addContent(sectionGroup.ContentParent);
 
-        sectionGroup.gameObject.SetActive(defaultOpen);
-        sectionToggle.SetExpandedWithoutNotify(defaultOpen);
-
-        sectionToggle.OnExpandedChanged += visible =>
+        PanelSectionToggleHelpers.FinalizeCollapsibleGroup(sectionToggle, sectionGroup, defaultOpen, _ =>
         {
-            sectionGroup.gameObject.SetActive(visible);
             tabDesc.ForceRebuild();
             parentGroup.ForceRebuild();
-        };
+        });
     }
 
 }

--- a/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/SettingsProviderPerformanceLimits.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/SettingsProviderPerformanceLimits.cs
@@ -22,12 +22,26 @@ public static class SettingsProviderPerformanceLimits
         descriptor.ForceRebuild();
         return tab;
     }
-    public static void BuildPerformanceLimitsContent(RectTransform container)
+    public static void BuildPerformanceLimitsContent(RectTransform container, bool wrapInSection = false)
     {
         _layoutRoot = container;
+        RectTransform contentParent = container;
+
+        PanelSectionToggle performanceToggle = null;
+        PanelElementDescriptor performanceGroup = null;
+        if (wrapInSection)
+        {
+            performanceToggle = PanelSectionToggle.CreateNewEntry(container);
+            performanceGroup = CreateCollapsibleContentGroup(
+                performanceToggle,
+                container,
+                "settings.perf.intro.title",
+                false);
+            contentParent = performanceGroup.ContentParent;
+        }
 
         PanelElementDescriptor bypassGroup =
-            PanelElementDescriptor.CreateNew(PanelElementDescriptor.ElementStyles.Group, container);
+            PanelElementDescriptor.CreateNew(PanelElementDescriptor.ElementStyles.Group, contentParent);
         bypassGroup.SetTitle(BasisLocalization.Get("settings.perf.sessionBypass.title"));
 
         PanelToggle bypassToggle = PanelToggle.CreateNewEntry(bypassGroup.ContentParent);
@@ -39,13 +53,11 @@ public static class SettingsProviderPerformanceLimits
             BasisAvatarPerformanceLimits.BypassAllLimits = on;
         };
 
-        PanelElementDescriptor intro =
-            PanelElementDescriptor.CreateNew(PanelElementDescriptor.ElementStyles.Group, container);
-        intro.SetTitle(BasisLocalization.Get("settings.perf.intro.title"));
-
-        PanelElementDescriptor geometry =
-            PanelElementDescriptor.CreateNew(PanelElementDescriptor.ElementStyles.Group, container);
-        geometry.SetTitle(BasisLocalization.Get("settings.perf.group.geometry"));
+        PanelSectionToggle geometryToggle = PanelSectionToggle.CreateNewEntry(contentParent);
+        PanelElementDescriptor geometry = CreateCollapsibleContentGroup(
+            geometryToggle,
+            contentParent,
+            "settings.perf.group.geometry");
 
         AddLimitPair(geometry.ContentParent,
             BasisLocalization.Get("settings.perf.triangles.toggle"),
@@ -74,9 +86,13 @@ public static class SettingsProviderPerformanceLimits
             toggleTooltip: BasisLocalization.Get("settings.perf.bones.toggle.tooltip"),
             sliderTooltip: BasisLocalization.Get("settings.perf.bones.slider.tooltip"));
 
-        PanelElementDescriptor meshes =
-            PanelElementDescriptor.CreateNew(PanelElementDescriptor.ElementStyles.Group, container);
-        meshes.SetTitle(BasisLocalization.Get("settings.perf.group.meshesMaterials"));
+        FinalizeCollapsibleGroup(geometryToggle, geometry, false);
+
+        PanelSectionToggle meshesToggle = PanelSectionToggle.CreateNewEntry(contentParent);
+        PanelElementDescriptor meshes = CreateCollapsibleContentGroup(
+            meshesToggle,
+            contentParent,
+            "settings.perf.group.meshesMaterials");
 
         AddLimitPair(meshes.ContentParent,
             BasisLocalization.Get("settings.perf.skinnedMeshes.toggle"),
@@ -114,9 +130,13 @@ public static class SettingsProviderPerformanceLimits
             toggleTooltip: BasisLocalization.Get("settings.perf.textureMemory.toggle.tooltip"),
             sliderTooltip: BasisLocalization.Get("settings.perf.textureMemory.slider.tooltip"));
 
-        PanelElementDescriptor physics =
-            PanelElementDescriptor.CreateNew(PanelElementDescriptor.ElementStyles.Group, container);
-        physics.SetTitle(BasisLocalization.Get("settings.perf.group.physics"));
+        FinalizeCollapsibleGroup(meshesToggle, meshes, false);
+
+        PanelSectionToggle physicsToggle = PanelSectionToggle.CreateNewEntry(contentParent);
+        PanelElementDescriptor physics = CreateCollapsibleContentGroup(
+            physicsToggle,
+            contentParent,
+            "settings.perf.group.physics");
 
         AddLimitPair(physics.ContentParent,
             BasisLocalization.Get("settings.perf.jiggleBones.toggle"),
@@ -159,9 +179,13 @@ public static class SettingsProviderPerformanceLimits
             toggleTooltip: BasisLocalization.Get("settings.perf.jiggleDistanceCull.toggle.tooltip"),
             sliderTooltip: BasisLocalization.Get("settings.perf.jiggleDistanceCull.slider.tooltip"));
 
-        PanelElementDescriptor effects =
-            PanelElementDescriptor.CreateNew(PanelElementDescriptor.ElementStyles.Group, container);
-        effects.SetTitle(BasisLocalization.Get("settings.perf.group.effects"));
+        FinalizeCollapsibleGroup(physicsToggle, physics, false);
+
+        PanelSectionToggle effectsToggle = PanelSectionToggle.CreateNewEntry(contentParent);
+        PanelElementDescriptor effects = CreateCollapsibleContentGroup(
+            effectsToggle,
+            contentParent,
+            "settings.perf.group.effects");
 
         AddLimitPair(effects.ContentParent,
             BasisLocalization.Get("settings.perf.particleSystems.toggle"),
@@ -190,9 +214,13 @@ public static class SettingsProviderPerformanceLimits
             toggleTooltip: BasisLocalization.Get("settings.perf.lineRenderers.toggle.tooltip"),
             sliderTooltip: BasisLocalization.Get("settings.perf.lineRenderers.slider.tooltip"));
 
-        PanelElementDescriptor runtime =
-            PanelElementDescriptor.CreateNew(PanelElementDescriptor.ElementStyles.Group, container);
-        runtime.SetTitle(BasisLocalization.Get("settings.perf.group.runtime"));
+        FinalizeCollapsibleGroup(effectsToggle, effects, false);
+
+        PanelSectionToggle runtimeToggle = PanelSectionToggle.CreateNewEntry(contentParent);
+        PanelElementDescriptor runtime = CreateCollapsibleContentGroup(
+            runtimeToggle,
+            contentParent,
+            "settings.perf.group.runtime");
 
         AddLimitPair(runtime.ContentParent,
             BasisLocalization.Get("settings.perf.animators.toggle"),
@@ -212,8 +240,67 @@ public static class SettingsProviderPerformanceLimits
             toggleTooltip: BasisLocalization.Get("settings.perf.cilboxBehaviours.toggle.tooltip"),
             sliderTooltip: BasisLocalization.Get("settings.perf.cilboxBehaviours.slider.tooltip"));
 
+        FinalizeCollapsibleGroup(runtimeToggle, runtime, false);
+
         SettingsProviderContentTags.BuildContentTagsContent(container);
+
+        if (performanceToggle != null)
+        {
+            FinalizeCollapsibleGroup(performanceToggle, performanceGroup, false);
+        }
     }
+
+    private static PanelElementDescriptor CreateCollapsibleContentGroup(
+        PanelSectionToggle sectionToggle,
+        RectTransform parent,
+        string titleKey,
+        bool showGroupTitle = true)
+    {
+        string title = BasisLocalization.Get(titleKey);
+        sectionToggle.SetTitle(title);
+
+        PanelElementDescriptor group =
+            PanelElementDescriptor.CreateNew(PanelElementDescriptor.ElementStyles.Group, parent);
+        if (showGroupTitle)
+        {
+            group.SetTitle(title);
+        }
+        else if (group.Header != null)
+        {
+            group.Header.gameObject.SetActive(false);
+        }
+
+        sectionToggle.RegisterContentContainer(group);
+        return group;
+    }
+
+    private static void FinalizeCollapsibleGroup(
+        PanelSectionToggle sectionToggle,
+        PanelElementDescriptor group,
+        bool defaultOpen)
+    {
+        if (sectionToggle == null || group == null)
+        {
+            return;
+        }
+
+        group.gameObject.SetActive(defaultOpen);
+        sectionToggle.SetExpandedWithoutNotify(defaultOpen);
+        sectionToggle.OnExpandedChanged += visible =>
+        {
+            group.gameObject.SetActive(visible);
+            ForceLayout();
+        };
+    }
+
+    private static void ForceLayout()
+    {
+        if (_layoutRoot != null)
+        {
+            LayoutRebuilder.ForceRebuildLayoutImmediate(_layoutRoot);
+        }
+    }
+
     private static void AddLimitPair(
         Component parent,
         string toggleTitle,
@@ -243,10 +330,7 @@ public static class SettingsProviderPerformanceLimits
             {
                 if (slider == null) return;
                 slider.gameObject.SetActive(on);
-                if (_layoutRoot != null)
-                {
-                    LayoutRebuilder.ForceRebuildLayoutImmediate(_layoutRoot);
-                }
+                ForceLayout();
             }
 
             Sync(useBinding.RawValue);

--- a/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/SettingsProviderPerformanceLimits.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/SettingsProviderPerformanceLimits.cs
@@ -32,10 +32,10 @@ public static class SettingsProviderPerformanceLimits
         if (wrapInSection)
         {
             performanceToggle = PanelSectionToggle.CreateNewEntry(container);
-            performanceGroup = CreateCollapsibleContentGroup(
+            performanceGroup = PanelSectionToggleHelpers.CreateCollapsibleContentGroup(
                 performanceToggle,
                 container,
-                "settings.perf.intro.title",
+                BasisLocalization.Get("settings.perf.intro.title"),
                 false);
             contentParent = performanceGroup.ContentParent;
         }
@@ -54,10 +54,10 @@ public static class SettingsProviderPerformanceLimits
         };
 
         PanelSectionToggle geometryToggle = PanelSectionToggle.CreateNewEntry(contentParent);
-        PanelElementDescriptor geometry = CreateCollapsibleContentGroup(
+        PanelElementDescriptor geometry = PanelSectionToggleHelpers.CreateCollapsibleContentGroup(
             geometryToggle,
             contentParent,
-            "settings.perf.group.geometry");
+            BasisLocalization.Get("settings.perf.group.geometry"));
 
         AddLimitPair(geometry.ContentParent,
             BasisLocalization.Get("settings.perf.triangles.toggle"),
@@ -86,13 +86,13 @@ public static class SettingsProviderPerformanceLimits
             toggleTooltip: BasisLocalization.Get("settings.perf.bones.toggle.tooltip"),
             sliderTooltip: BasisLocalization.Get("settings.perf.bones.slider.tooltip"));
 
-        FinalizeCollapsibleGroup(geometryToggle, geometry, false);
+        PanelSectionToggleHelpers.FinalizeCollapsibleGroup(geometryToggle, geometry, false, _ => ForceLayout());
 
         PanelSectionToggle meshesToggle = PanelSectionToggle.CreateNewEntry(contentParent);
-        PanelElementDescriptor meshes = CreateCollapsibleContentGroup(
+        PanelElementDescriptor meshes = PanelSectionToggleHelpers.CreateCollapsibleContentGroup(
             meshesToggle,
             contentParent,
-            "settings.perf.group.meshesMaterials");
+            BasisLocalization.Get("settings.perf.group.meshesMaterials"));
 
         AddLimitPair(meshes.ContentParent,
             BasisLocalization.Get("settings.perf.skinnedMeshes.toggle"),
@@ -130,13 +130,13 @@ public static class SettingsProviderPerformanceLimits
             toggleTooltip: BasisLocalization.Get("settings.perf.textureMemory.toggle.tooltip"),
             sliderTooltip: BasisLocalization.Get("settings.perf.textureMemory.slider.tooltip"));
 
-        FinalizeCollapsibleGroup(meshesToggle, meshes, false);
+        PanelSectionToggleHelpers.FinalizeCollapsibleGroup(meshesToggle, meshes, false, _ => ForceLayout());
 
         PanelSectionToggle physicsToggle = PanelSectionToggle.CreateNewEntry(contentParent);
-        PanelElementDescriptor physics = CreateCollapsibleContentGroup(
+        PanelElementDescriptor physics = PanelSectionToggleHelpers.CreateCollapsibleContentGroup(
             physicsToggle,
             contentParent,
-            "settings.perf.group.physics");
+            BasisLocalization.Get("settings.perf.group.physics"));
 
         AddLimitPair(physics.ContentParent,
             BasisLocalization.Get("settings.perf.jiggleBones.toggle"),
@@ -179,13 +179,13 @@ public static class SettingsProviderPerformanceLimits
             toggleTooltip: BasisLocalization.Get("settings.perf.jiggleDistanceCull.toggle.tooltip"),
             sliderTooltip: BasisLocalization.Get("settings.perf.jiggleDistanceCull.slider.tooltip"));
 
-        FinalizeCollapsibleGroup(physicsToggle, physics, false);
+        PanelSectionToggleHelpers.FinalizeCollapsibleGroup(physicsToggle, physics, false, _ => ForceLayout());
 
         PanelSectionToggle effectsToggle = PanelSectionToggle.CreateNewEntry(contentParent);
-        PanelElementDescriptor effects = CreateCollapsibleContentGroup(
+        PanelElementDescriptor effects = PanelSectionToggleHelpers.CreateCollapsibleContentGroup(
             effectsToggle,
             contentParent,
-            "settings.perf.group.effects");
+            BasisLocalization.Get("settings.perf.group.effects"));
 
         AddLimitPair(effects.ContentParent,
             BasisLocalization.Get("settings.perf.particleSystems.toggle"),
@@ -214,13 +214,13 @@ public static class SettingsProviderPerformanceLimits
             toggleTooltip: BasisLocalization.Get("settings.perf.lineRenderers.toggle.tooltip"),
             sliderTooltip: BasisLocalization.Get("settings.perf.lineRenderers.slider.tooltip"));
 
-        FinalizeCollapsibleGroup(effectsToggle, effects, false);
+        PanelSectionToggleHelpers.FinalizeCollapsibleGroup(effectsToggle, effects, false, _ => ForceLayout());
 
         PanelSectionToggle runtimeToggle = PanelSectionToggle.CreateNewEntry(contentParent);
-        PanelElementDescriptor runtime = CreateCollapsibleContentGroup(
+        PanelElementDescriptor runtime = PanelSectionToggleHelpers.CreateCollapsibleContentGroup(
             runtimeToggle,
             contentParent,
-            "settings.perf.group.runtime");
+            BasisLocalization.Get("settings.perf.group.runtime"));
 
         AddLimitPair(runtime.ContentParent,
             BasisLocalization.Get("settings.perf.animators.toggle"),
@@ -240,57 +240,14 @@ public static class SettingsProviderPerformanceLimits
             toggleTooltip: BasisLocalization.Get("settings.perf.cilboxBehaviours.toggle.tooltip"),
             sliderTooltip: BasisLocalization.Get("settings.perf.cilboxBehaviours.slider.tooltip"));
 
-        FinalizeCollapsibleGroup(runtimeToggle, runtime, false);
+        PanelSectionToggleHelpers.FinalizeCollapsibleGroup(runtimeToggle, runtime, false, _ => ForceLayout());
 
         SettingsProviderContentTags.BuildContentTagsContent(container);
 
         if (performanceToggle != null)
         {
-            FinalizeCollapsibleGroup(performanceToggle, performanceGroup, false);
+            PanelSectionToggleHelpers.FinalizeCollapsibleGroup(performanceToggle, performanceGroup, false, _ => ForceLayout());
         }
-    }
-
-    private static PanelElementDescriptor CreateCollapsibleContentGroup(
-        PanelSectionToggle sectionToggle,
-        RectTransform parent,
-        string titleKey,
-        bool showGroupTitle = true)
-    {
-        string title = BasisLocalization.Get(titleKey);
-        sectionToggle.SetTitle(title);
-
-        PanelElementDescriptor group =
-            PanelElementDescriptor.CreateNew(PanelElementDescriptor.ElementStyles.Group, parent);
-        if (showGroupTitle)
-        {
-            group.SetTitle(title);
-        }
-        else if (group.Header != null)
-        {
-            group.Header.gameObject.SetActive(false);
-        }
-
-        sectionToggle.RegisterContentContainer(group);
-        return group;
-    }
-
-    private static void FinalizeCollapsibleGroup(
-        PanelSectionToggle sectionToggle,
-        PanelElementDescriptor group,
-        bool defaultOpen)
-    {
-        if (sectionToggle == null || group == null)
-        {
-            return;
-        }
-
-        group.gameObject.SetActive(defaultOpen);
-        sectionToggle.SetExpandedWithoutNotify(defaultOpen);
-        sectionToggle.OnExpandedChanged += visible =>
-        {
-            group.gameObject.SetActive(visible);
-            ForceLayout();
-        };
     }
 
     private static void ForceLayout()

--- a/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/SettingsProviderPerformanceLimits.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/SettingsProviderPerformanceLimits.cs
@@ -283,6 +283,8 @@ public static class SettingsProviderPerformanceLimits
         {
             slider.Descriptor.SetTooltip(sliderTooltip);
 
+            slider.gameObject.SetActive(useBinding.RawValue);
+
             void Sync(bool on)
             {
                 if (slider == null) return;
@@ -290,8 +292,8 @@ public static class SettingsProviderPerformanceLimits
                 ForceLayout();
             }
 
-            Sync(useBinding.RawValue);
             useBinding.OnChanged += Sync;
+            slider.OnInstanceReleased += () => useBinding.OnChanged -= Sync;
         }
     }
 

--- a/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/SettingsProviderTrackerSettings.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/SettingsProviderTrackerSettings.cs
@@ -128,6 +128,7 @@ namespace Basis.BasisUI
             PanelElementDescriptor tuningGroup = PanelElementDescriptor.CreateNew(
                 PanelElementDescriptor.ElementStyles.Group, tabRoot);
             tuningGroup.SetTitle(BasisLocalization.Get("trackerLinking.tuning.title"));
+            advancedToggle.RegisterContentContainer(tuningGroup);
             BuildTuningSliders(tuningGroup.ContentParent);
 
             // Dynamic per-tracker section — updates on device/pair/override changes.
@@ -135,6 +136,7 @@ namespace Basis.BasisUI
             PanelElementDescriptor trackersGroup = PanelElementDescriptor.CreateNew(
                 PanelElementDescriptor.ElementStyles.Group, tabRoot);
             trackersGroup.SetTitle(BasisLocalization.Get("trackerLinking.trackers.title"));
+            connectorToggle.RegisterContentContainer(trackersGroup);
 
             TabState state = new TabState
             {

--- a/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/SettingsProviderTrackerSettings.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/SettingsProviderTrackerSettings.cs
@@ -128,7 +128,6 @@ namespace Basis.BasisUI
             PanelElementDescriptor tuningGroup = PanelElementDescriptor.CreateNew(
                 PanelElementDescriptor.ElementStyles.Group, tabRoot);
             tuningGroup.SetTitle(BasisLocalization.Get("trackerLinking.tuning.title"));
-            advancedToggle.RegisterContentContainer(tuningGroup);
             BuildTuningSliders(tuningGroup.ContentParent);
 
             // Dynamic per-tracker section — updates on device/pair/override changes.
@@ -136,7 +135,6 @@ namespace Basis.BasisUI
             PanelElementDescriptor trackersGroup = PanelElementDescriptor.CreateNew(
                 PanelElementDescriptor.ElementStyles.Group, tabRoot);
             trackersGroup.SetTitle(BasisLocalization.Get("trackerLinking.trackers.title"));
-            connectorToggle.RegisterContentContainer(trackersGroup);
 
             TabState state = new TabState
             {
@@ -189,21 +187,25 @@ namespace Basis.BasisUI
             // Initial visibility + OnValueChanged gating. Two-step rebuild
             // (inner group, then tab descriptor) matches the existing pattern
             // in HandleChange so nested LayoutGroups settle correctly.
-            tuningGroup.gameObject.SetActive(BasisSettingsDefaults.TrackerLinkingAdvancedVisible.RawValue);
-            advancedToggle.OnExpandedChanged += visible =>
+            PanelSectionToggleHelpers.FinalizeCollapsibleContents(
+                advancedToggle,
+                BasisSettingsDefaults.TrackerLinkingAdvancedVisible.RawValue,
+                _ =>
             {
-                tuningGroup.gameObject.SetActive(visible);
                 tuningGroup.ForceRebuild();
                 tabDesc.ForceRebuild();
-            };
+            },
+                tuningGroup);
 
-            trackersGroup.gameObject.SetActive(BasisSettingsDefaults.TrackerLinkingConnectorVisible.RawValue);
-            connectorToggle.OnExpandedChanged += visible =>
+            PanelSectionToggleHelpers.FinalizeCollapsibleContents(
+                connectorToggle,
+                BasisSettingsDefaults.TrackerLinkingConnectorVisible.RawValue,
+                _ =>
             {
-                trackersGroup.gameObject.SetActive(visible);
                 trackersGroup.ForceRebuild();
                 tabDesc.ForceRebuild();
-            };
+            },
+                trackersGroup);
 
             handleChange();
             SettingsProvider.TrackerSettingsExtraBuilder?.Invoke(tabRoot);

--- a/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/SettingsProviderTrackerSettings.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProviderParts/SettingsProviderTrackerSettings.cs
@@ -110,18 +110,18 @@ namespace Basis.BasisUI
             // role override dropdowns) so a configured player doesn't have to
             // scroll past every device on every visit. Same opt-in pattern as
             // the advanced toggle below; user touches it once to set things up.
-            PanelToggle connectorToggle = PanelToggle.CreateNewEntry(tabRoot);
-            connectorToggle.Descriptor.SetTitle(BasisLocalization.Get("trackerLinking.connectorTrackers"));
+            PanelSectionToggle connectorToggle = PanelSectionToggle.CreateNewEntry(tabRoot);
+            connectorToggle.SetTitle(BasisLocalization.Get("trackerLinking.connectorTrackers"));
             connectorToggle.Descriptor.SetTooltip(BasisLocalization.Get("trackerLinking.connectorTrackers.tooltip"));
-            connectorToggle.AssignBinding(BasisSettingsDefaults.TrackerLinkingConnectorVisible);
+            connectorToggle.BindToToggle(BasisSettingsDefaults.TrackerLinkingConnectorVisible);
 
             // Advanced toggle — hides the tuning sliders behind an opt-in so
             // the page stays approachable for users who only want to link
             // trackers. Same pattern as SettingsProviderIK's advancedToggle.
-            PanelToggle advancedToggle = PanelToggle.CreateNewEntry(tabRoot);
-            advancedToggle.Descriptor.SetTitle(BasisLocalization.Get("trackerLinking.advanced"));
+            PanelSectionToggle advancedToggle = PanelSectionToggle.CreateNewEntry(tabRoot);
+            advancedToggle.SetTitle(BasisLocalization.Get("trackerLinking.advanced"));
             advancedToggle.Descriptor.SetTooltip(BasisLocalization.Get("trackerLinking.advanced.tooltip"));
-            advancedToggle.AssignBinding(BasisSettingsDefaults.TrackerLinkingAdvancedVisible);
+            advancedToggle.BindToToggle(BasisSettingsDefaults.TrackerLinkingAdvancedVisible);
 
             // Static tuning group — bound to BasisSettingsDefaults bindings, so values
             // persist across menu reopens and across sessions. Built once.
@@ -188,7 +188,7 @@ namespace Basis.BasisUI
             // (inner group, then tab descriptor) matches the existing pattern
             // in HandleChange so nested LayoutGroups settle correctly.
             tuningGroup.gameObject.SetActive(BasisSettingsDefaults.TrackerLinkingAdvancedVisible.RawValue);
-            advancedToggle.OnValueChanged += visible =>
+            advancedToggle.OnExpandedChanged += visible =>
             {
                 tuningGroup.gameObject.SetActive(visible);
                 tuningGroup.ForceRebuild();
@@ -196,7 +196,7 @@ namespace Basis.BasisUI
             };
 
             trackersGroup.gameObject.SetActive(BasisSettingsDefaults.TrackerLinkingConnectorVisible.RawValue);
-            connectorToggle.OnValueChanged += visible =>
+            connectorToggle.OnExpandedChanged += visible =>
             {
                 trackersGroup.gameObject.SetActive(visible);
                 trackersGroup.ForceRebuild();

--- a/Basis/Packages/com.basis.framework/BasisUI/PanelComponents/PanelSectionDividerManager.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/PanelComponents/PanelSectionDividerManager.cs
@@ -1,0 +1,367 @@
+using System.Collections.Generic;
+using Basis.BasisUI.Styling;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Basis.BasisUI
+{
+    internal sealed class PanelSectionDividerManager
+    {
+        private const float DividerContainerHeight = 4f;
+        private const float DividerHeight = 2f;
+        private const float DividerHorizontalInset = 12f;
+        private static readonly Color FallbackDividerColor = new Color(0.5f, 0.5f, 0.5f, 0.5f);
+
+        private readonly PanelSectionToggle _owner;
+        private readonly List<PanelSectionContentMarker> _contentMarkers;
+
+        private GameObject _dividerAbove;
+        private Image _dividerAboveImage;
+        private PanelSectionToggle _dividerAboveController;
+        private bool _ownsDividerAbove;
+        private GameObject _dividerBelow;
+        private Image _dividerBelowImage;
+        private bool _ownsDividerBelow;
+
+        public PanelSectionDividerManager(PanelSectionToggle owner, List<PanelSectionContentMarker> contentMarkers)
+        {
+            _owner = owner;
+            _contentMarkers = contentMarkers;
+        }
+
+        public void CreateDividerAbove()
+        {
+            RectTransform rectTransform = _owner.rectTransform;
+            if (_dividerAbove != null || rectTransform == null || rectTransform.parent == null)
+            {
+                return;
+            }
+
+            int currentIndex = rectTransform.GetSiblingIndex();
+            PanelSectionToggle previousToggle = ResolvePreviousSectionToggle(currentIndex, out bool previousToggleIsDirectNeighbor);
+            if (previousToggle != null && !previousToggleIsDirectNeighbor)
+            {
+                // Content separates these sections, so the previous section needs
+                // its own bottom divider instead of sharing this section's top divider.
+                if (previousToggle.DividerManager.EnsureOwnedDividerBelow())
+                {
+                    return;
+                }
+            }
+
+            GameObject divider = CreateDividerObject(currentIndex, previousToggle);
+            Image dividerImage = ResolveDividerImage(divider);
+
+            _dividerAbove = divider;
+            _dividerAboveImage = dividerImage;
+            _dividerAboveController = previousToggleIsDirectNeighbor ? previousToggle : null;
+            _ownsDividerAbove = true;
+
+            if (previousToggle != null && previousToggleIsDirectNeighbor)
+            {
+                previousToggle.DividerManager.SetDividerBelow(divider, dividerImage);
+            }
+
+            UpdateVisibility();
+        }
+
+        public void Release()
+        {
+            if (_ownsDividerAbove)
+            {
+                ClearSiblingReferenceTo(_dividerAbove);
+                DestroyDivider(ref _dividerAbove, ref _dividerAboveImage);
+            }
+            else
+            {
+                _dividerAbove = null;
+                _dividerAboveImage = null;
+            }
+
+            _dividerAboveController = null;
+            _ownsDividerAbove = false;
+
+            if (_ownsDividerBelow)
+            {
+                DestroyDivider(ref _dividerBelow, ref _dividerBelowImage);
+            }
+            else
+            {
+                // Shared _dividerBelow is the next section's _dividerAbove and
+                // is owned by that next toggle.
+                _dividerBelow = null;
+                _dividerBelowImage = null;
+            }
+
+            _ownsDividerBelow = false;
+        }
+
+        public void UpdateVisibility()
+        {
+            if (_dividerAbove != null && _dividerAboveController == null)
+            {
+                _dividerAbove.SetActive(true);
+            }
+
+            if (_dividerBelow != null)
+            {
+                _dividerBelow.SetActive(!_owner.Expanded);
+            }
+        }
+
+        private bool EnsureOwnedDividerBelow()
+        {
+            if (_dividerBelow != null)
+            {
+                UpdateVisibility();
+                return true;
+            }
+
+            if (!TryGetDividerBelowSiblingIndex(out int siblingIndex))
+            {
+                return false;
+            }
+
+            GameObject divider = CreateDividerObject(siblingIndex, _owner);
+            SetDividerBelow(divider, ResolveDividerImage(divider), true);
+            return true;
+        }
+
+        private bool TryGetDividerBelowSiblingIndex(out int siblingIndex)
+        {
+            siblingIndex = -1;
+            RectTransform rectTransform = _owner.rectTransform;
+            if (rectTransform == null || rectTransform.parent == null)
+            {
+                return false;
+            }
+
+            Transform parent = rectTransform.parent;
+            int lastOwnedIndex = rectTransform.GetSiblingIndex();
+            for (int i = 0; i < _contentMarkers.Count; i++)
+            {
+                PanelSectionContentMarker marker = _contentMarkers[i];
+                if (marker == null || marker.Owner != _owner || marker.transform.parent != parent)
+                {
+                    continue;
+                }
+
+                lastOwnedIndex = Mathf.Max(lastOwnedIndex, marker.transform.GetSiblingIndex());
+            }
+
+            siblingIndex = Mathf.Min(lastOwnedIndex + 1, parent.childCount);
+            return true;
+        }
+
+        private void SetDividerBelow(GameObject divider, Image image, bool ownsDivider = false)
+        {
+            if (_dividerBelow != null && _dividerBelow != divider)
+            {
+                if (_ownsDividerBelow)
+                {
+                    DestroyDivider(ref _dividerBelow, ref _dividerBelowImage);
+                }
+                else
+                {
+                    BasisDebug.LogWarning($"{nameof(PanelSectionToggle)} divider below was replaced.");
+                }
+            }
+
+            _dividerBelow = divider;
+            _dividerBelowImage = image;
+            _ownsDividerBelow = ownsDivider;
+            UpdateVisibility();
+        }
+
+        private PanelSectionToggle ResolvePreviousSectionToggle(int currentIndex, out bool isDirectNeighbor)
+        {
+            isDirectNeighbor = false;
+            Transform parent = _owner.rectTransform.parent;
+            bool skippedSibling = false;
+            for (int i = currentIndex - 1; i >= 0; i--)
+            {
+                Transform sibling = parent.GetChild(i);
+                if (sibling == null || sibling.TryGetComponent(out PanelSectionBreaklineMarker _))
+                {
+                    skippedSibling = true;
+                    continue;
+                }
+
+                if (sibling.TryGetComponent(out PanelSectionToggle previousToggle))
+                {
+                    isDirectNeighbor = !skippedSibling;
+                    return previousToggle;
+                }
+
+                if (sibling.TryGetComponent(out PanelSectionContentMarker contentMarker))
+                {
+                    if (contentMarker.Owner != null && contentMarker.Owner != _owner)
+                    {
+                        skippedSibling = true;
+                        return contentMarker.Owner;
+                    }
+
+                    skippedSibling = true;
+                    continue;
+                }
+
+                return null;
+            }
+
+            return null;
+        }
+
+        private void ClearSiblingReferenceTo(GameObject divider)
+        {
+            RectTransform rectTransform = _owner.rectTransform;
+            if (divider == null || rectTransform == null || rectTransform.parent == null)
+            {
+                return;
+            }
+
+            Transform parent = rectTransform.parent;
+            for (int i = 0; i < parent.childCount; i++)
+            {
+                if (!parent.GetChild(i).TryGetComponent(out PanelSectionToggle markerOwner))
+                {
+                    continue;
+                }
+
+                PanelSectionDividerManager manager = markerOwner.DividerManager;
+                if (manager._dividerBelow == divider)
+                {
+                    manager._dividerBelow = null;
+                    manager._dividerBelowImage = null;
+                    manager.UpdateVisibility();
+                }
+            }
+        }
+
+        private GameObject CreateDividerObject(int siblingIndex, PanelSectionToggle styleSource)
+        {
+            GameObject dividerObject = new GameObject("Section Divider", typeof(RectTransform), typeof(LayoutElement), typeof(PanelSectionBreaklineMarker));
+            dividerObject.layer = _owner.gameObject.layer;
+
+            dividerObject.TryGetComponent(out RectTransform dividerTransform);
+            dividerTransform.SetParent(_owner.rectTransform.parent, false);
+            dividerTransform.SetSiblingIndex(siblingIndex);
+            dividerTransform.anchorMin = new Vector2(0f, 0.5f);
+            dividerTransform.anchorMax = new Vector2(1f, 0.5f);
+            dividerTransform.pivot = new Vector2(0.5f, 0.5f);
+            dividerTransform.sizeDelta = new Vector2(0f, DividerContainerHeight);
+
+            dividerObject.TryGetComponent(out LayoutElement layout);
+            layout.minHeight = DividerContainerHeight;
+            layout.preferredHeight = DividerContainerHeight;
+
+            GameObject lineObject = new GameObject("Line", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image));
+            lineObject.layer = dividerObject.layer;
+
+            lineObject.TryGetComponent(out RectTransform lineTransform);
+            lineTransform.SetParent(dividerTransform, false);
+            lineTransform.anchorMin = new Vector2(0f, 0.5f);
+            lineTransform.anchorMax = new Vector2(1f, 0.5f);
+            lineTransform.pivot = new Vector2(0.5f, 0.5f);
+            lineTransform.offsetMin = new Vector2(DividerHorizontalInset, -DividerHeight * 0.5f);
+            lineTransform.offsetMax = new Vector2(-DividerHorizontalInset, DividerHeight * 0.5f);
+
+            lineObject.TryGetComponent(out Image dividerImage);
+            dividerImage.raycastTarget = false;
+            ApplyDividerImageStyle(dividerImage, styleSource);
+            dividerImage.color = GetDividerColor();
+
+            return dividerObject;
+        }
+
+        private static Image ResolveDividerImage(GameObject divider)
+        {
+            return divider != null ? divider.GetComponentInChildren<Image>(true) : null;
+        }
+
+        private void ApplyDividerImageStyle(Image targetImage, PanelSectionToggle styleSource)
+        {
+            if (targetImage == null)
+            {
+                return;
+            }
+
+            Image sourceImage =
+                styleSource?.GetDividerSourceImage()
+                ?? _owner.GetDividerSourceImage();
+
+            if (sourceImage == null)
+            {
+                return;
+            }
+
+            targetImage.sprite = sourceImage.sprite;
+            targetImage.material = sourceImage.material;
+            targetImage.type = sourceImage.type;
+            targetImage.fillCenter = sourceImage.fillCenter;
+            targetImage.pixelsPerUnitMultiplier = sourceImage.pixelsPerUnitMultiplier;
+            targetImage.preserveAspect = false;
+        }
+
+        private static Color GetDividerColor()
+        {
+            UiStylePalette palette = UiStyleSettings.GetActivePalette();
+            return palette != null ? palette.AccentColor : FallbackDividerColor;
+        }
+
+        private static void DestroyDivider(ref GameObject divider, ref Image image)
+        {
+            if (divider != null)
+            {
+                ClearEditorSelectionIfTargeting(divider);
+                Object.Destroy(divider);
+            }
+
+            divider = null;
+            image = null;
+        }
+
+        internal static void ClearEditorSelectionIfTargeting(GameObject root)
+        {
+#if UNITY_EDITOR
+            if (root == null)
+            {
+                return;
+            }
+
+            Object[] selectedObjects = UnityEditor.Selection.objects;
+            if (selectedObjects == null || selectedObjects.Length == 0)
+            {
+                return;
+            }
+
+            Object[] filteredSelection = System.Array.FindAll(
+                selectedObjects,
+                selectedObject => !IsEditorSelectionTargeting(root, selectedObject));
+
+            if (filteredSelection.Length != selectedObjects.Length)
+            {
+                UnityEditor.Selection.objects = filteredSelection;
+            }
+#endif
+        }
+
+#if UNITY_EDITOR
+        private static bool IsEditorSelectionTargeting(GameObject root, Object selectedObject)
+        {
+            if (selectedObject == null)
+            {
+                return false;
+            }
+
+            GameObject selectedGameObject = selectedObject as GameObject;
+            if (selectedObject is Component selectedComponent)
+            {
+                selectedGameObject = selectedComponent.gameObject;
+            }
+
+            return selectedGameObject != null
+                && (selectedGameObject == root || selectedGameObject.transform.IsChildOf(root.transform));
+        }
+#endif
+    }
+}

--- a/Basis/Packages/com.basis.framework/BasisUI/PanelComponents/PanelSectionDividerManager.cs.meta
+++ b/Basis/Packages/com.basis.framework/BasisUI/PanelComponents/PanelSectionDividerManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2f81f6c5e2e84cf6a4f77259df2c9a13

--- a/Basis/Packages/com.basis.framework/BasisUI/PanelComponents/PanelSectionToggle.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/PanelComponents/PanelSectionToggle.cs
@@ -1,0 +1,413 @@
+using System;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Basis.BasisUI
+{
+    public sealed class PanelSectionToggle : PanelDataComponent<bool>
+    {
+        private const string CollapsedArrow = ">";
+        private const string ExpandedArrow = "\u25bc";
+        private const float CompactHeightScale = 0.8f;
+        private const float BreaklineContainerHeight = 4f;
+        private const float BreaklineHeight = 2f;
+        private const float BreaklineHorizontalInset = 12f;
+
+        /// <summary>Guard against scaling inappropriately large or sentinel height values.</summary>
+        private const float MaxPreferredHeightThreshold = 1000f;
+
+        public static class Styles
+        {
+            public static string Default => "Packages/com.basis.sdk/Prefabs/Panel Elements/PE Section Toggle.prefab";
+            public static string Entry => "Packages/com.basis.sdk/Prefabs/Panel Elements/PE Section Toggle - Entry Variant.prefab";
+        }
+
+        public Toggle ToggleComponent;
+        public RectTransform ToggleVisual;
+
+        [Header("Visual Elements")]
+        public Graphic Background;
+
+        private TextMeshProUGUI _arrowLabel;
+        private GameObject _breaklineObject;
+        private Image _breaklineImage;
+        private string _title = string.Empty;
+
+        protected override Selectable InteractableTarget => ToggleComponent;
+        public bool Expanded => Value;
+        public event Action<bool> OnExpandedChanged;
+
+        public static PanelSectionToggle CreateNew(Component parent) =>
+            CreateNew<PanelSectionToggle>(Styles.Default, parent);
+
+        public static PanelSectionToggle CreateNewEntry(Component parent) =>
+            CreateNew<PanelSectionToggle>(Styles.Entry, parent);
+
+        public static PanelSectionToggle CreateNew(Component parent, string style) =>
+            CreateNew<PanelSectionToggle>(style, parent);
+
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+            if (SettingsBinding != null)
+            {
+                SetValueWithoutNotify(SettingsBinding.RawValue);
+            }
+        }
+
+        public override void OnCreateEvent()
+        {
+            base.OnCreateEvent();
+            MarkSectionToggleRow();
+            ConfigureArrowIndicator();
+            ApplyCompactHeight();
+            CreateCollapsedBreakline();
+            UpdateArrow();
+            RefreshSiblingBreaklines();
+        }
+
+        public override void OnReleaseEvent()
+        {
+            ReleaseBreakline();
+            base.OnReleaseEvent();
+        }
+
+        public override void AssignBinding(BasisSettingsBinding<bool> binding)
+        {
+            base.AssignBinding(binding);
+            ToggleComponent?.SetIsOnWithoutNotify(binding.RawValue);
+            RefreshSiblingBreaklines();
+        }
+
+        public override void SetValue(bool value)
+        {
+            base.SetValue(value);
+            ToggleComponent?.SetIsOnWithoutNotify(value);
+            OnExpandedChanged?.Invoke(value);
+            RefreshSiblingBreaklines();
+        }
+
+        public override void SetValueWithoutNotify(bool value)
+        {
+            base.SetValueWithoutNotify(value);
+            ToggleComponent?.SetIsOnWithoutNotify(value);
+            RefreshSiblingBreaklines();
+        }
+
+        public override void OnComponentUsed()
+        {
+            base.OnComponentUsed();
+            SetValue(ToggleComponent != null && ToggleComponent.isOn);
+        }
+
+        public void SetTitle(string title)
+        {
+            _title = title ?? string.Empty;
+            Descriptor?.SetTitle(_title);
+            UpdateBreaklineColor();
+        }
+
+        public void BindToToggle(BasisSettingsBinding<bool> binding)
+        {
+            if (binding == null)
+            {
+                SetValueWithoutNotify(false);
+                return;
+            }
+
+            AssignBinding(binding);
+        }
+
+        public void SetExpanded(bool expanded)
+        {
+            SetValue(expanded);
+        }
+
+        public void SetExpandedWithoutNotify(bool expanded)
+        {
+            SetValueWithoutNotify(expanded);
+        }
+
+        protected override void ApplyValue()
+        {
+            base.ApplyValue();
+            UpdateArrow();
+            UpdateBreakline();
+        }
+
+        private void MarkSectionToggleRow()
+        {
+            PanelSectionToggleMarker marker = GetComponent<PanelSectionToggleMarker>();
+            if (marker == null)
+            {
+                marker = gameObject.AddComponent<PanelSectionToggleMarker>();
+            }
+
+            marker.Toggle = this;
+        }
+
+        private void ConfigureArrowIndicator()
+        {
+            RectTransform arrowParent = ResolveArrowParent();
+            if (arrowParent == null)
+            {
+                return;
+            }
+
+            if (ToggleVisual != null)
+            {
+                ToggleVisual.gameObject.SetActive(false);
+            }
+
+            if (Background != null)
+            {
+                Background.gameObject.SetActive(false);
+            }
+
+            GameObject arrowObject = new GameObject("Section Arrow", typeof(RectTransform));
+            arrowObject.layer = arrowParent.gameObject.layer;
+            RectTransform arrowTransform = arrowObject.GetComponent<RectTransform>();
+            arrowTransform.SetParent(arrowParent, false);
+            arrowTransform.anchorMin = Vector2.zero;
+            arrowTransform.anchorMax = Vector2.one;
+            arrowTransform.offsetMin = Vector2.zero;
+            arrowTransform.offsetMax = Vector2.zero;
+
+            _arrowLabel = arrowObject.AddComponent<TextMeshProUGUI>();
+            _arrowLabel.raycastTarget = false;
+            _arrowLabel.alignment = TextAlignmentOptions.Center;
+            _arrowLabel.textWrappingMode = TextWrappingModes.NoWrap;
+
+            TextMeshProUGUI titleLabel = Descriptor?.TitleLabel;
+            if (titleLabel != null)
+            {
+                _arrowLabel.font = titleLabel.font;
+                _arrowLabel.fontSharedMaterial = titleLabel.fontSharedMaterial;
+                _arrowLabel.color = titleLabel.color;
+                _arrowLabel.fontSize = titleLabel.fontSize;
+                _arrowLabel.fontStyle = titleLabel.fontStyle;
+            }
+        }
+
+        private void ApplyCompactHeight()
+        {
+            LayoutElement[] layouts = GetComponentsInChildren<LayoutElement>(true);
+            for (int i = 0; i < layouts.Length; i++)
+            {
+                ScaleHeight(layouts[i]);
+            }
+
+            ScaleRectHeight(rectTransform);
+            ScaleRectHeight(Descriptor?.Header);
+        }
+
+        private static void ScaleHeight(LayoutElement layout)
+        {
+            if (layout == null)
+            {
+                return;
+            }
+
+            if (layout.minHeight > 0f)
+            {
+                layout.minHeight *= CompactHeightScale;
+            }
+
+            if (layout.preferredHeight > 0f && layout.preferredHeight < MaxPreferredHeightThreshold)
+            {
+                layout.preferredHeight *= CompactHeightScale;
+            }
+        }
+
+        private static void ScaleRectHeight(RectTransform rectTransform)
+        {
+            if (rectTransform == null || rectTransform.sizeDelta.y <= 0f)
+            {
+                return;
+            }
+
+            Vector2 size = rectTransform.sizeDelta;
+            size.y *= CompactHeightScale;
+            rectTransform.sizeDelta = size;
+        }
+
+        private void CreateCollapsedBreakline()
+        {
+            if (rectTransform == null || rectTransform.parent == null)
+            {
+                return;
+            }
+
+            GameObject breaklineObject = new GameObject("Section Breakline", typeof(RectTransform), typeof(LayoutElement), typeof(PanelSectionBreaklineMarker));
+            breaklineObject.layer = gameObject.layer;
+
+            RectTransform breaklineTransform = breaklineObject.GetComponent<RectTransform>();
+            breaklineTransform.SetParent(rectTransform.parent, false);
+            breaklineTransform.SetSiblingIndex(rectTransform.GetSiblingIndex() + 1);
+            breaklineTransform.anchorMin = new Vector2(0f, 0.5f);
+            breaklineTransform.anchorMax = new Vector2(1f, 0.5f);
+            breaklineTransform.pivot = new Vector2(0.5f, 0.5f);
+            breaklineTransform.sizeDelta = new Vector2(0f, BreaklineContainerHeight);
+
+            LayoutElement layout = breaklineObject.GetComponent<LayoutElement>();
+            layout.minHeight = BreaklineContainerHeight;
+            layout.preferredHeight = BreaklineContainerHeight;
+
+            GameObject lineObject = new GameObject("Line", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image));
+            lineObject.layer = breaklineObject.layer;
+
+            RectTransform lineTransform = lineObject.GetComponent<RectTransform>();
+            lineTransform.SetParent(breaklineTransform, false);
+            lineTransform.anchorMin = new Vector2(0f, 0.5f);
+            lineTransform.anchorMax = new Vector2(1f, 0.5f);
+            lineTransform.pivot = new Vector2(0.5f, 0.5f);
+            lineTransform.offsetMin = new Vector2(BreaklineHorizontalInset, -BreaklineHeight * 0.5f);
+            lineTransform.offsetMax = new Vector2(-BreaklineHorizontalInset, BreaklineHeight * 0.5f);
+
+            _breaklineImage = lineObject.GetComponent<Image>();
+            _breaklineImage.raycastTarget = false;
+            ApplyBreaklineImageStyle();
+            UpdateBreaklineColor();
+
+            _breaklineObject = breaklineObject;
+        }
+
+        private void ApplyBreaklineImageStyle()
+        {
+            if (_breaklineImage == null || Background is not Image sourceImage)
+            {
+                return;
+            }
+
+            _breaklineImage.sprite = sourceImage.sprite;
+            _breaklineImage.material = sourceImage.material;
+            _breaklineImage.type = sourceImage.type;
+            _breaklineImage.fillCenter = sourceImage.fillCenter;
+            _breaklineImage.pixelsPerUnitMultiplier = sourceImage.pixelsPerUnitMultiplier;
+            _breaklineImage.preserveAspect = false;
+        }
+
+        private void UpdateBreaklineColor()
+        {
+            if (_breaklineImage == null)
+            {
+                return;
+            }
+
+            Color color = Descriptor?.TitleLabel != null ? Descriptor.TitleLabel.color : Color.white;
+            color.a = Mathf.Max(color.a * 0.6f, 0.45f);
+            _breaklineImage.color = color;
+        }
+
+        private void UpdateBreakline()
+        {
+            if (_breaklineObject != null)
+            {
+                _breaklineObject.SetActive(!Expanded && HasNextSectionToggle());
+            }
+        }
+
+        private bool HasNextSectionToggle()
+        {
+            RectTransform row = rectTransform;
+            if (row == null || row.parent == null)
+            {
+                return false;
+            }
+
+            Transform parent = row.parent;
+            int startIndex = row.GetSiblingIndex() + 1;
+            for (int i = startIndex; i < parent.childCount; i++)
+            {
+                Transform sibling = parent.GetChild(i);
+                if (sibling == null)
+                {
+                    continue;
+                }
+
+                if (sibling.GetComponent<PanelSectionBreaklineMarker>() != null)
+                {
+                    continue;
+                }
+
+                if (!sibling.gameObject.activeSelf)
+                {
+                    continue;
+                }
+
+                return sibling.GetComponent<PanelSectionToggleMarker>() != null;
+            }
+
+            return false;
+        }
+
+        private void RefreshSiblingBreaklines()
+        {
+            Transform parent = rectTransform != null ? rectTransform.parent : null;
+            if (parent == null)
+            {
+                return;
+            }
+
+            for (int i = 0; i < parent.childCount; i++)
+            {
+                PanelSectionToggleMarker marker = parent.GetChild(i).GetComponent<PanelSectionToggleMarker>();
+                marker?.Toggle?.UpdateBreakline();
+            }
+        }
+
+        private void ReleaseBreakline()
+        {
+            if (_breaklineObject == null)
+            {
+                return;
+            }
+
+            UnityEngine.Object.Destroy(_breaklineObject);
+            _breaklineObject = null;
+            _breaklineImage = null;
+        }
+
+        private RectTransform ResolveArrowParent()
+        {
+            if (Background != null && Background.transform.parent is RectTransform backgroundParent)
+            {
+                return backgroundParent;
+            }
+
+            if (ToggleVisual != null)
+            {
+                Transform knobParent = ToggleVisual.parent;
+                if (knobParent != null && knobParent.parent is RectTransform switchParent)
+                {
+                    return switchParent;
+                }
+
+                if (knobParent is RectTransform directParent)
+                {
+                    return directParent;
+                }
+            }
+
+            return rectTransform;
+        }
+
+        private void UpdateArrow()
+        {
+            if (_arrowLabel != null)
+            {
+                _arrowLabel.SetText(Expanded ? ExpandedArrow : CollapsedArrow);
+            }
+        }
+    }
+
+    internal sealed class PanelSectionToggleMarker : MonoBehaviour
+    {
+        public PanelSectionToggle Toggle;
+    }
+
+    internal sealed class PanelSectionBreaklineMarker : MonoBehaviour
+    {
+    }
+}

--- a/Basis/Packages/com.basis.framework/BasisUI/PanelComponents/PanelSectionToggle.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/PanelComponents/PanelSectionToggle.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Basis.BasisUI.Styling;
 using TMPro;
 using UnityEngine;
@@ -34,11 +35,14 @@ namespace Basis.BasisUI
         private GameObject _generatedArrowObject;
         private string _title = string.Empty;
         private PanelSectionToggleMarker _marker;
+        private readonly List<PanelSectionContentMarker> _contentMarkers = new();
 
         private GameObject _dividerAbove;
         private Image _dividerAboveImage;
+        private PanelSectionToggle _dividerAboveController;
         private GameObject _dividerBelow;
         private Image _dividerBelowImage;
+        private bool _ownsDividerBelow;
 
         private bool _created;
         private bool _compactHeightApplied;
@@ -87,9 +91,21 @@ namespace Basis.BasisUI
         {
             ClearSiblingReferenceTo(_dividerAbove);
             DestroyDivider(ref _dividerAbove, ref _dividerAboveImage);
+            _dividerAboveController = null;
 
-            _dividerBelow = null;
-            _dividerBelowImage = null;
+            if (_ownsDividerBelow)
+            {
+                DestroyDivider(ref _dividerBelow, ref _dividerBelowImage);
+            }
+            else
+            {
+                // Shared _dividerBelow is the next section's _dividerAbove and
+                // is owned by that next toggle.
+                _dividerBelow = null;
+                _dividerBelowImage = null;
+            }
+
+            _ownsDividerBelow = false;
 
             if (_generatedArrowObject != null)
             {
@@ -102,6 +118,8 @@ namespace Basis.BasisUI
                 _marker.Toggle = null;
                 _marker = null;
             }
+
+            ClearRegisteredContentMarkers();
 
             _created = false;
 
@@ -185,6 +203,10 @@ namespace Basis.BasisUI
             }
 
             marker.Owner = this;
+            if (!_contentMarkers.Contains(marker))
+            {
+                _contentMarkers.Add(marker);
+            }
         }
 
         protected override void ApplyValue()
@@ -316,15 +338,23 @@ namespace Basis.BasisUI
             }
 
             int currentIndex = rectTransform.GetSiblingIndex();
-            PanelSectionToggle previousToggle = ResolvePreviousSectionToggle(currentIndex);
+            PanelSectionToggle previousToggle = ResolvePreviousSectionToggle(currentIndex, out bool previousToggleIsDirectNeighbor);
+            if (previousToggle != null && !previousToggleIsDirectNeighbor)
+            {
+                // Content separates these sections, so the previous section needs
+                // its own bottom divider instead of sharing this section's top divider.
+                previousToggle.EnsureOwnedDividerBelow(currentIndex);
+                currentIndex++;
+            }
 
             GameObject divider = CreateDividerObject(currentIndex, previousToggle);
             Image dividerImage = ResolveDividerImage(divider);
 
             _dividerAbove = divider;
             _dividerAboveImage = dividerImage;
+            _dividerAboveController = previousToggleIsDirectNeighbor ? previousToggle : null;
 
-            if (previousToggle != null)
+            if (previousToggle != null && previousToggleIsDirectNeighbor)
             {
                 previousToggle.SetDividerBelow(divider, dividerImage);
             }
@@ -373,16 +403,41 @@ namespace Basis.BasisUI
             return divider != null ? divider.GetComponentInChildren<Image>(true) : null;
         }
 
-        private void SetDividerBelow(GameObject divider, Image image)
+        private void EnsureOwnedDividerBelow(int siblingIndex)
         {
+            if (_dividerBelow != null)
+            {
+                UpdateDividerVisibility();
+                return;
+            }
+
+            GameObject divider = CreateDividerObject(siblingIndex, this);
+            SetDividerBelow(divider, ResolveDividerImage(divider), true);
+        }
+
+        private void SetDividerBelow(GameObject divider, Image image, bool ownsDivider = false)
+        {
+            if (_dividerBelow != null && _dividerBelow != divider)
+            {
+                if (_ownsDividerBelow)
+                {
+                    DestroyDivider(ref _dividerBelow, ref _dividerBelowImage);
+                }
+                else
+                {
+                    Debug.LogWarning($"{nameof(PanelSectionToggle)} divider below was replaced.");
+                }
+            }
+
             _dividerBelow = divider;
             _dividerBelowImage = image;
+            _ownsDividerBelow = ownsDivider;
             UpdateDividerVisibility();
         }
 
         private void UpdateDividerVisibility()
         {
-            if (_dividerAbove != null)
+            if (_dividerAbove != null && _dividerAboveController == null)
             {
                 _dividerAbove.SetActive(true);
             }
@@ -393,19 +448,23 @@ namespace Basis.BasisUI
             }
         }
 
-        private PanelSectionToggle ResolvePreviousSectionToggle(int currentIndex)
+        private PanelSectionToggle ResolvePreviousSectionToggle(int currentIndex, out bool isDirectNeighbor)
         {
+            isDirectNeighbor = false;
             Transform parent = rectTransform.parent;
+            bool skippedSibling = false;
             for (int i = currentIndex - 1; i >= 0; i--)
             {
                 Transform sibling = parent.GetChild(i);
                 if (sibling == null || sibling.GetComponent<PanelSectionBreaklineMarker>() != null)
                 {
+                    skippedSibling = true;
                     continue;
                 }
 
                 if (sibling.TryGetComponent(out PanelSectionToggle previousToggle))
                 {
+                    isDirectNeighbor = !skippedSibling;
                     return previousToggle;
                 }
 
@@ -442,6 +501,20 @@ namespace Basis.BasisUI
                     markerOwner.UpdateDividerVisibility();
                 }
             }
+        }
+
+        private void ClearRegisteredContentMarkers()
+        {
+            for (int i = 0; i < _contentMarkers.Count; i++)
+            {
+                PanelSectionContentMarker marker = _contentMarkers[i];
+                if (marker != null && marker.Owner == this)
+                {
+                    marker.Owner = null;
+                }
+            }
+
+            _contentMarkers.Clear();
         }
 
         private void ApplyDividerImageStyle(Image targetImage, PanelSectionToggle styleSource)

--- a/Basis/Packages/com.basis.framework/BasisUI/PanelComponents/PanelSectionToggle.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/PanelComponents/PanelSectionToggle.cs
@@ -1,8 +1,8 @@
 using System;
+using Basis.BasisUI.Styling;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
-using Basis.BasisUI.Styling;
 
 namespace Basis.BasisUI
 {
@@ -11,11 +11,11 @@ namespace Basis.BasisUI
         private const string CollapsedArrow = ">";
         private const string ExpandedArrow = "\u25bc";
         private const float CompactHeightScale = 0.8f;
-        private const float BreaklineContainerHeight = 4f;
-        private const float BreaklineHeight = 2f;
-        private const float BreaklineHorizontalInset = 12f;
+        private const float DividerContainerHeight = 4f;
+        private const float DividerHeight = 2f;
+        private const float DividerHorizontalInset = 12f;
 
-        /// <summary>Guard against scaling inappropriately large or sentinel height values.</summary>
+        // Avoid scaling inappropriately large or sentinel preferred-height values.
         private const float MaxPreferredHeightThreshold = 1000f;
 
         public static class Styles
@@ -31,14 +31,17 @@ namespace Basis.BasisUI
         public Graphic Background;
 
         private TextMeshProUGUI _arrowLabel;
-        private GameObject _breaklineObject;
-        private Image _breaklineImage;
+        private GameObject _generatedArrowObject;
         private string _title = string.Empty;
         private PanelSectionToggleMarker _marker;
-        private bool _ownsBreakline;
-        private PanelSectionToggle _breaklineOwnerRef;
-        private GameObject _originalBreaklineObject;
-        private Image _originalBreaklineImage;
+
+        private GameObject _dividerAbove;
+        private Image _dividerAboveImage;
+        private GameObject _dividerBelow;
+        private Image _dividerBelowImage;
+
+        private bool _created;
+        private bool _compactHeightApplied;
 
         protected override Selectable InteractableTarget => ToggleComponent;
         public bool Expanded => Value;
@@ -65,59 +68,73 @@ namespace Basis.BasisUI
         public override void OnCreateEvent()
         {
             base.OnCreateEvent();
+
+            if (_created)
+            {
+                RefreshVisualState();
+                return;
+            }
+
+            _created = true;
             MarkSectionToggleRow();
             ConfigureArrowIndicator();
-            ApplyCompactHeight();
-            CreateBreaklineAbove();
-            UpdateArrow();
-            UpdateBreakline();
+            ApplyCompactHeightOnce();
+            CreateDividerAbove();
+            RefreshVisualState();
         }
 
         public override void OnReleaseEvent()
         {
-            // Tell the owner of the breakline above us to release it
-            if (_breaklineOwnerRef != null)
+            ClearSiblingReferenceTo(_dividerAbove);
+            DestroyDivider(ref _dividerAbove, ref _dividerAboveImage);
+
+            _dividerBelow = null;
+            _dividerBelowImage = null;
+
+            if (_generatedArrowObject != null)
             {
-                _breaklineOwnerRef.ReleaseBreaklineForToggle(this);
-                _breaklineOwnerRef = null;
+                DestroyGeneratedObject(ref _generatedArrowObject);
+                _arrowLabel = null;
             }
 
-            if (_breaklineObject != null)
+            if (_marker != null)
             {
-                ReleaseBreakline();
+                _marker.Toggle = null;
+                _marker = null;
             }
 
-            // Release the original breakline that was overwritten
-            if (_originalBreaklineObject != null)
-            {
-                UnityEngine.Object.Destroy(_originalBreaklineObject);
-                _originalBreaklineObject = null;
-                _originalBreaklineImage = null;
-            }
+            _created = false;
 
             base.OnReleaseEvent();
         }
 
         public override void AssignBinding(BasisSettingsBinding<bool> binding)
         {
+            if (binding == null)
+            {
+                Debug.LogError($"{nameof(PanelSectionToggle)} requires a non-null binding.");
+                SetExpandedWithoutNotify(false);
+                return;
+            }
+
             base.AssignBinding(binding);
             ToggleComponent?.SetIsOnWithoutNotify(binding.RawValue);
-            UpdateBreakline();
+            RefreshVisualState();
         }
 
         public override void SetValue(bool value)
         {
-            base.SetValue(value);
             ToggleComponent?.SetIsOnWithoutNotify(value);
+            base.SetValue(value);
             OnExpandedChanged?.Invoke(value);
-            UpdateBreakline();
+            RefreshVisualState();
         }
 
         public override void SetValueWithoutNotify(bool value)
         {
-            base.SetValueWithoutNotify(value);
             ToggleComponent?.SetIsOnWithoutNotify(value);
-            UpdateBreakline();
+            base.SetValueWithoutNotify(value);
+            RefreshVisualState();
         }
 
         public override void OnComponentUsed()
@@ -130,14 +147,14 @@ namespace Basis.BasisUI
         {
             _title = title ?? string.Empty;
             Descriptor?.SetTitle(_title);
-            UpdateBreaklineColor();
         }
 
         public void BindToToggle(BasisSettingsBinding<bool> binding)
         {
             if (binding == null)
             {
-                SetValueWithoutNotify(false);
+                Debug.LogError($"{nameof(PanelSectionToggle)} requires a non-null binding.");
+                SetExpandedWithoutNotify(false);
                 return;
             }
 
@@ -154,11 +171,33 @@ namespace Basis.BasisUI
             SetValueWithoutNotify(expanded);
         }
 
+        public void RegisterContentContainer(Component contentContainer)
+        {
+            if (contentContainer == null)
+            {
+                return;
+            }
+
+            PanelSectionContentMarker marker = contentContainer.GetComponent<PanelSectionContentMarker>();
+            if (marker == null)
+            {
+                marker = contentContainer.gameObject.AddComponent<PanelSectionContentMarker>();
+            }
+
+            marker.Owner = this;
+        }
+
         protected override void ApplyValue()
         {
             base.ApplyValue();
             UpdateArrow();
-            UpdateBreakline();
+            UpdateDividerVisibility();
+        }
+
+        private void RefreshVisualState()
+        {
+            UpdateArrow();
+            UpdateDividerVisibility();
         }
 
         private void MarkSectionToggleRow()
@@ -173,6 +212,11 @@ namespace Basis.BasisUI
 
         private void ConfigureArrowIndicator()
         {
+            if (_arrowLabel != null)
+            {
+                return;
+            }
+
             RectTransform arrowParent = ResolveArrowParent();
             if (arrowParent == null)
             {
@@ -189,16 +233,17 @@ namespace Basis.BasisUI
                 Background.gameObject.SetActive(false);
             }
 
-            GameObject arrowObject = new GameObject("Section Arrow", typeof(RectTransform));
-            arrowObject.layer = arrowParent.gameObject.layer;
-            RectTransform arrowTransform = arrowObject.GetComponent<RectTransform>();
+            _generatedArrowObject = new GameObject("Section Arrow", typeof(RectTransform));
+            _generatedArrowObject.layer = arrowParent.gameObject.layer;
+
+            RectTransform arrowTransform = _generatedArrowObject.GetComponent<RectTransform>();
             arrowTransform.SetParent(arrowParent, false);
             arrowTransform.anchorMin = Vector2.zero;
             arrowTransform.anchorMax = Vector2.one;
             arrowTransform.offsetMin = Vector2.zero;
             arrowTransform.offsetMax = Vector2.zero;
 
-            _arrowLabel = arrowObject.AddComponent<TextMeshProUGUI>();
+            _arrowLabel = _generatedArrowObject.AddComponent<TextMeshProUGUI>();
             _arrowLabel.raycastTarget = false;
             _arrowLabel.alignment = TextAlignmentOptions.Center;
             _arrowLabel.textWrappingMode = TextWrappingModes.NoWrap;
@@ -214,8 +259,15 @@ namespace Basis.BasisUI
             }
         }
 
-        private void ApplyCompactHeight()
+        private void ApplyCompactHeightOnce()
         {
+            if (_compactHeightApplied)
+            {
+                return;
+            }
+
+            _compactHeightApplied = true;
+
             LayoutElement[] layouts = GetComponentsInChildren<LayoutElement>(true);
             for (int i = 0; i < layouts.Length; i++)
             {
@@ -256,86 +308,154 @@ namespace Basis.BasisUI
             rectTransform.sizeDelta = size;
         }
 
-        /// <summary>
-        /// Create a breakline above this toggle. If the previous sibling is a
-        /// PanelSectionToggle, the breakline goes between them and ownership
-        /// is passed to that previous toggle. Otherwise the breakline sits
-        /// above the first toggle in the group and this toggle owns it.
-        /// </summary>
-        private void CreateBreaklineAbove()
+        private void CreateDividerAbove()
         {
-            if (rectTransform == null || rectTransform.parent == null)
+            if (_dividerAbove != null || rectTransform == null || rectTransform.parent == null)
             {
                 return;
             }
 
             int currentIndex = rectTransform.GetSiblingIndex();
-            Transform previousSibling = currentIndex > 0
-                ? rectTransform.parent.GetChild(currentIndex - 1)
-                : null;
+            PanelSectionToggle previousToggle = ResolvePreviousSectionToggle(currentIndex);
 
-            PanelSectionToggle owner = null;
+            GameObject divider = CreateDividerObject(currentIndex, previousToggle);
+            Image dividerImage = ResolveDividerImage(divider);
 
-            if (previousSibling != null && previousSibling.TryGetComponent(out PanelSectionToggle prevToggle))
+            _dividerAbove = divider;
+            _dividerAboveImage = dividerImage;
+
+            if (previousToggle != null)
             {
-                owner = prevToggle;
+                previousToggle.SetDividerBelow(divider, dividerImage);
             }
 
-            GameObject breaklineObject = new GameObject("Section Breakline", typeof(RectTransform), typeof(LayoutElement), typeof(PanelSectionBreaklineMarker));
-            breaklineObject.layer = gameObject.layer;
+            UpdateDividerVisibility();
+        }
 
-            RectTransform breaklineTransform = breaklineObject.GetComponent<RectTransform>();
-            breaklineTransform.SetParent(rectTransform.parent, false);
-            breaklineTransform.SetSiblingIndex(currentIndex); // Above current toggle
-            breaklineTransform.anchorMin = new Vector2(0f, 0.5f);
-            breaklineTransform.anchorMax = new Vector2(1f, 0.5f);
-            breaklineTransform.pivot = new Vector2(0.5f, 0.5f);
-            breaklineTransform.sizeDelta = new Vector2(0f, BreaklineContainerHeight);
+        private GameObject CreateDividerObject(int siblingIndex, PanelSectionToggle styleSource)
+        {
+            GameObject dividerObject = new GameObject("Section Divider", typeof(RectTransform), typeof(LayoutElement), typeof(PanelSectionBreaklineMarker));
+            dividerObject.layer = gameObject.layer;
 
-            LayoutElement layout = breaklineObject.GetComponent<LayoutElement>();
-            layout.minHeight = BreaklineContainerHeight;
-            layout.preferredHeight = BreaklineContainerHeight;
+            RectTransform dividerTransform = dividerObject.GetComponent<RectTransform>();
+            dividerTransform.SetParent(rectTransform.parent, false);
+            dividerTransform.SetSiblingIndex(siblingIndex);
+            dividerTransform.anchorMin = new Vector2(0f, 0.5f);
+            dividerTransform.anchorMax = new Vector2(1f, 0.5f);
+            dividerTransform.pivot = new Vector2(0.5f, 0.5f);
+            dividerTransform.sizeDelta = new Vector2(0f, DividerContainerHeight);
+
+            LayoutElement layout = dividerObject.GetComponent<LayoutElement>();
+            layout.minHeight = DividerContainerHeight;
+            layout.preferredHeight = DividerContainerHeight;
 
             GameObject lineObject = new GameObject("Line", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image));
-            lineObject.layer = breaklineObject.layer;
+            lineObject.layer = dividerObject.layer;
 
             RectTransform lineTransform = lineObject.GetComponent<RectTransform>();
-            lineTransform.SetParent(breaklineTransform, false);
+            lineTransform.SetParent(dividerTransform, false);
             lineTransform.anchorMin = new Vector2(0f, 0.5f);
             lineTransform.anchorMax = new Vector2(1f, 0.5f);
             lineTransform.pivot = new Vector2(0.5f, 0.5f);
-            lineTransform.offsetMin = new Vector2(BreaklineHorizontalInset, -BreaklineHeight * 0.5f);
-            lineTransform.offsetMax = new Vector2(-BreaklineHorizontalInset, BreaklineHeight * 0.5f);
+            lineTransform.offsetMin = new Vector2(DividerHorizontalInset, -DividerHeight * 0.5f);
+            lineTransform.offsetMax = new Vector2(-DividerHorizontalInset, DividerHeight * 0.5f);
 
-            Image breaklineImage = lineObject.GetComponent<Image>();
-            breaklineImage.raycastTarget = false;
+            Image dividerImage = lineObject.GetComponent<Image>();
+            dividerImage.raycastTarget = false;
+            ApplyDividerImageStyle(dividerImage, styleSource);
+            dividerImage.color = GetDividerColor();
 
-            // Apply style from the source toggle's Background image.
-            // When owner != null, owner is the source; otherwise self is the source.
-            Image sourceImage = (owner?.Background as Image) ?? Background as Image;
-            ApplyBreaklineImageStyleFrom(breaklineImage, sourceImage);
+            return dividerObject;
+        }
 
-            Color color = UiStyleSettings.GetActivePalette()?.LayerColor ?? Color.white;
-            breaklineImage.color = color;
-            // Preserve the original breakline
-            _originalBreaklineObject = _breaklineObject;
-            _originalBreaklineImage = _breaklineImage;
-            if (owner != null)
+        private static Image ResolveDividerImage(GameObject divider)
+        {
+            return divider != null ? divider.GetComponentInChildren<Image>(true) : null;
+        }
+
+        private void SetDividerBelow(GameObject divider, Image image)
+        {
+            _dividerBelow = divider;
+            _dividerBelowImage = image;
+            UpdateDividerVisibility();
+        }
+
+        private void UpdateDividerVisibility()
+        {
+            if (_dividerAbove != null)
             {
-                owner.TakeBreaklineOwnership(breaklineObject, breaklineImage);
-                _breaklineOwnerRef = owner;
+                _dividerAbove.SetActive(true);
             }
-            else
+
+            if (_dividerBelow != null)
             {
-                _breaklineObject = breaklineObject;
-                _breaklineImage = breaklineImage;
-                _ownsBreakline = false;
+                _dividerBelow.SetActive(!Expanded);
             }
         }
 
-        private void ApplyBreaklineImageStyleFrom(Image targetImage, Image sourceImage)
+        private PanelSectionToggle ResolvePreviousSectionToggle(int currentIndex)
         {
-            if (targetImage == null || sourceImage == null)
+            Transform parent = rectTransform.parent;
+            for (int i = currentIndex - 1; i >= 0; i--)
+            {
+                Transform sibling = parent.GetChild(i);
+                if (sibling == null || sibling.GetComponent<PanelSectionBreaklineMarker>() != null)
+                {
+                    continue;
+                }
+
+                if (sibling.TryGetComponent(out PanelSectionToggle previousToggle))
+                {
+                    return previousToggle;
+                }
+
+                if (sibling.TryGetComponent(out PanelSectionContentMarker contentMarker))
+                {
+                    return contentMarker.Owner;
+                }
+
+                return null;
+            }
+
+            return null;
+        }
+
+        private void ClearSiblingReferenceTo(GameObject divider)
+        {
+            if (divider == null || rectTransform == null || rectTransform.parent == null)
+            {
+                return;
+            }
+
+            Transform parent = rectTransform.parent;
+            for (int i = 0; i < parent.childCount; i++)
+            {
+                if (!parent.GetChild(i).TryGetComponent(out PanelSectionToggle markerOwner))
+                {
+                    continue;
+                }
+
+                if (markerOwner._dividerBelow == divider)
+                {
+                    markerOwner._dividerBelow = null;
+                    markerOwner._dividerBelowImage = null;
+                    markerOwner.UpdateDividerVisibility();
+                }
+            }
+        }
+
+        private void ApplyDividerImageStyle(Image targetImage, PanelSectionToggle styleSource)
+        {
+            if (targetImage == null)
+            {
+                return;
+            }
+
+            Image sourceImage =
+                styleSource?.GetDividerSourceImage()
+                ?? GetDividerSourceImage();
+
+            if (sourceImage == null)
             {
                 return;
             }
@@ -348,87 +468,83 @@ namespace Basis.BasisUI
             targetImage.preserveAspect = false;
         }
 
-        private void UpdateBreaklineColor()
+        private Image GetDividerSourceImage()
         {
-            if (_breaklineImage == null)
+            return (Background as Image) ?? (ToggleComponent?.targetGraphic as Image);
+        }
+
+        private static Color GetDividerColor()
+        {
+            UiStylePalette palette = UiStyleSettings.GetActivePalette();
+            return palette != null ? palette.AccentColor : Color.white;
+        }
+
+        private static void DestroyDivider(ref GameObject divider, ref Image image)
+        {
+            if (divider != null)
+            {
+                ClearEditorSelectionIfTargeting(divider);
+                UnityEngine.Object.Destroy(divider);
+            }
+
+            divider = null;
+            image = null;
+        }
+
+        private static void DestroyGeneratedObject(ref GameObject generatedObject)
+        {
+            if (generatedObject != null)
+            {
+                ClearEditorSelectionIfTargeting(generatedObject);
+                UnityEngine.Object.Destroy(generatedObject);
+            }
+
+            generatedObject = null;
+        }
+
+        private static void ClearEditorSelectionIfTargeting(GameObject root)
+        {
+#if UNITY_EDITOR
+            if (root == null)
             {
                 return;
             }
 
-            Color color = UiStyleSettings.GetActivePalette()?.AccentColor ?? Color.white;
-            _breaklineImage.color = color;
-        }
-
-        private void UpdateBreakline()
-        {
-            if (_breaklineObject == null)
+            UnityEngine.Object[] selectedObjects = UnityEditor.Selection.objects;
+            if (selectedObjects == null || selectedObjects.Length == 0)
             {
                 return;
             }
 
-            if (_ownsBreakline)
+            UnityEngine.Object[] filteredSelection = Array.FindAll(
+                selectedObjects,
+                selectedObject => !IsEditorSelectionTargeting(root, selectedObject));
+
+            if (filteredSelection.Length != selectedObjects.Length)
             {
-                // Breakline is below this toggle — apply expand check.
-                _breaklineObject.SetActive(!Expanded);
+                UnityEditor.Selection.objects = filteredSelection;
             }
-            else
-            {
-                // Breakline is above this toggle — always visible.
-                _breaklineObject.SetActive(true);
-            }
+#endif
         }
 
-
-
-        private void ReleaseBreakline()
+#if UNITY_EDITOR
+        private static bool IsEditorSelectionTargeting(GameObject root, UnityEngine.Object selectedObject)
         {
-            if (_breaklineObject == null)
+            if (selectedObject == null)
             {
-                return;
+                return false;
             }
 
-            UnityEngine.Object.Destroy(_breaklineObject);
-            _breaklineObject = null;
-            _breaklineImage = null;
-        }
-
-        /// <summary>
-        /// Called by a sibling when it assigns a breakline to us. We take ownership.
-        /// </summary>
-        internal void TakeBreaklineOwnership(GameObject breaklineObject, Image breaklineImage)
-        {
-            _breaklineObject = breaklineObject;
-            _breaklineImage = breaklineImage;
-            _ownsBreakline = true;
-        }
-
-        /// <summary>
-        /// Called by a sibling when it is being destroyed. Releases the breakline
-        /// that this toggle owns (the one above us, between us and the caller).
-        /// </summary>
-        internal void ReleaseBreaklineForToggle(PanelSectionToggle caller)
-        {
-            if (_ownsBreakline && _breaklineObject != null)
+            GameObject selectedGameObject = selectedObject as GameObject;
+            if (selectedObject is Component selectedComponent)
             {
-                UnityEngine.Object.Destroy(_breaklineObject);
-                _breaklineObject = null;
-                _breaklineImage = null;
-                _ownsBreakline = false;
+                selectedGameObject = selectedComponent.gameObject;
             }
 
-            // Also release the original breakline that was overwritten
-            if (_originalBreaklineObject != null)
-            {
-                UnityEngine.Object.Destroy(_originalBreaklineObject);
-                _originalBreaklineObject = null;
-                _originalBreaklineImage = null;
-            }
-
-            // Clear the caller's references so it doesn't keep a Missing ref.
-            caller._breaklineObject = null;
-            caller._breaklineImage = null;
-            caller._breaklineOwnerRef = null;
+            return selectedGameObject != null
+                && (selectedGameObject == root || selectedGameObject.transform.IsChildOf(root.transform));
         }
+#endif
 
         private RectTransform ResolveArrowParent()
         {
@@ -466,6 +582,11 @@ namespace Basis.BasisUI
     internal sealed class PanelSectionToggleMarker : MonoBehaviour
     {
         public PanelSectionToggle Toggle;
+    }
+
+    internal sealed class PanelSectionContentMarker : MonoBehaviour
+    {
+        public PanelSectionToggle Owner;
     }
 
     internal sealed class PanelSectionBreaklineMarker : MonoBehaviour

--- a/Basis/Packages/com.basis.framework/BasisUI/PanelComponents/PanelSectionToggle.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/PanelComponents/PanelSectionToggle.cs
@@ -2,6 +2,7 @@ using System;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
+using Basis.BasisUI.Styling;
 
 namespace Basis.BasisUI
 {
@@ -33,6 +34,11 @@ namespace Basis.BasisUI
         private GameObject _breaklineObject;
         private Image _breaklineImage;
         private string _title = string.Empty;
+        private PanelSectionToggleMarker _marker;
+        private bool _ownsBreakline;
+        private PanelSectionToggle _breaklineOwnerRef;
+        private GameObject _originalBreaklineObject;
+        private Image _originalBreaklineImage;
 
         protected override Selectable InteractableTarget => ToggleComponent;
         public bool Expanded => Value;
@@ -62,14 +68,33 @@ namespace Basis.BasisUI
             MarkSectionToggleRow();
             ConfigureArrowIndicator();
             ApplyCompactHeight();
-            CreateCollapsedBreakline();
+            CreateBreaklineAbove();
             UpdateArrow();
-            RefreshSiblingBreaklines();
+            UpdateBreakline();
         }
 
         public override void OnReleaseEvent()
         {
-            ReleaseBreakline();
+            // Tell the owner of the breakline above us to release it
+            if (_breaklineOwnerRef != null)
+            {
+                _breaklineOwnerRef.ReleaseBreaklineForToggle(this);
+                _breaklineOwnerRef = null;
+            }
+
+            if (_breaklineObject != null)
+            {
+                ReleaseBreakline();
+            }
+
+            // Release the original breakline that was overwritten
+            if (_originalBreaklineObject != null)
+            {
+                UnityEngine.Object.Destroy(_originalBreaklineObject);
+                _originalBreaklineObject = null;
+                _originalBreaklineImage = null;
+            }
+
             base.OnReleaseEvent();
         }
 
@@ -77,7 +102,7 @@ namespace Basis.BasisUI
         {
             base.AssignBinding(binding);
             ToggleComponent?.SetIsOnWithoutNotify(binding.RawValue);
-            RefreshSiblingBreaklines();
+            UpdateBreakline();
         }
 
         public override void SetValue(bool value)
@@ -85,14 +110,14 @@ namespace Basis.BasisUI
             base.SetValue(value);
             ToggleComponent?.SetIsOnWithoutNotify(value);
             OnExpandedChanged?.Invoke(value);
-            RefreshSiblingBreaklines();
+            UpdateBreakline();
         }
 
         public override void SetValueWithoutNotify(bool value)
         {
             base.SetValueWithoutNotify(value);
             ToggleComponent?.SetIsOnWithoutNotify(value);
-            RefreshSiblingBreaklines();
+            UpdateBreakline();
         }
 
         public override void OnComponentUsed()
@@ -138,13 +163,12 @@ namespace Basis.BasisUI
 
         private void MarkSectionToggleRow()
         {
-            PanelSectionToggleMarker marker = GetComponent<PanelSectionToggleMarker>();
-            if (marker == null)
+            if (!TryGetComponent(out _marker))
             {
-                marker = gameObject.AddComponent<PanelSectionToggleMarker>();
+                _marker = gameObject.AddComponent<PanelSectionToggleMarker>();
             }
 
-            marker.Toggle = this;
+            _marker.Toggle = this;
         }
 
         private void ConfigureArrowIndicator()
@@ -232,11 +256,29 @@ namespace Basis.BasisUI
             rectTransform.sizeDelta = size;
         }
 
-        private void CreateCollapsedBreakline()
+        /// <summary>
+        /// Create a breakline above this toggle. If the previous sibling is a
+        /// PanelSectionToggle, the breakline goes between them and ownership
+        /// is passed to that previous toggle. Otherwise the breakline sits
+        /// above the first toggle in the group and this toggle owns it.
+        /// </summary>
+        private void CreateBreaklineAbove()
         {
             if (rectTransform == null || rectTransform.parent == null)
             {
                 return;
+            }
+
+            int currentIndex = rectTransform.GetSiblingIndex();
+            Transform previousSibling = currentIndex > 0
+                ? rectTransform.parent.GetChild(currentIndex - 1)
+                : null;
+
+            PanelSectionToggle owner = null;
+
+            if (previousSibling != null && previousSibling.TryGetComponent(out PanelSectionToggle prevToggle))
+            {
+                owner = prevToggle;
             }
 
             GameObject breaklineObject = new GameObject("Section Breakline", typeof(RectTransform), typeof(LayoutElement), typeof(PanelSectionBreaklineMarker));
@@ -244,7 +286,7 @@ namespace Basis.BasisUI
 
             RectTransform breaklineTransform = breaklineObject.GetComponent<RectTransform>();
             breaklineTransform.SetParent(rectTransform.parent, false);
-            breaklineTransform.SetSiblingIndex(rectTransform.GetSiblingIndex() + 1);
+            breaklineTransform.SetSiblingIndex(currentIndex); // Above current toggle
             breaklineTransform.anchorMin = new Vector2(0f, 0.5f);
             breaklineTransform.anchorMax = new Vector2(1f, 0.5f);
             breaklineTransform.pivot = new Vector2(0.5f, 0.5f);
@@ -265,27 +307,45 @@ namespace Basis.BasisUI
             lineTransform.offsetMin = new Vector2(BreaklineHorizontalInset, -BreaklineHeight * 0.5f);
             lineTransform.offsetMax = new Vector2(-BreaklineHorizontalInset, BreaklineHeight * 0.5f);
 
-            _breaklineImage = lineObject.GetComponent<Image>();
-            _breaklineImage.raycastTarget = false;
-            ApplyBreaklineImageStyle();
-            UpdateBreaklineColor();
+            Image breaklineImage = lineObject.GetComponent<Image>();
+            breaklineImage.raycastTarget = false;
 
-            _breaklineObject = breaklineObject;
+            // Apply style from the source toggle's Background image.
+            // When owner != null, owner is the source; otherwise self is the source.
+            Image sourceImage = (owner?.Background as Image) ?? Background as Image;
+            ApplyBreaklineImageStyleFrom(breaklineImage, sourceImage);
+
+            Color color = UiStyleSettings.GetActivePalette()?.LayerColor ?? Color.white;
+            breaklineImage.color = color;
+            // Preserve the original breakline
+            _originalBreaklineObject = _breaklineObject;
+            _originalBreaklineImage = _breaklineImage;
+            if (owner != null)
+            {
+                owner.TakeBreaklineOwnership(breaklineObject, breaklineImage);
+                _breaklineOwnerRef = owner;
+            }
+            else
+            {
+                _breaklineObject = breaklineObject;
+                _breaklineImage = breaklineImage;
+                _ownsBreakline = false;
+            }
         }
 
-        private void ApplyBreaklineImageStyle()
+        private void ApplyBreaklineImageStyleFrom(Image targetImage, Image sourceImage)
         {
-            if (_breaklineImage == null || Background is not Image sourceImage)
+            if (targetImage == null || sourceImage == null)
             {
                 return;
             }
 
-            _breaklineImage.sprite = sourceImage.sprite;
-            _breaklineImage.material = sourceImage.material;
-            _breaklineImage.type = sourceImage.type;
-            _breaklineImage.fillCenter = sourceImage.fillCenter;
-            _breaklineImage.pixelsPerUnitMultiplier = sourceImage.pixelsPerUnitMultiplier;
-            _breaklineImage.preserveAspect = false;
+            targetImage.sprite = sourceImage.sprite;
+            targetImage.material = sourceImage.material;
+            targetImage.type = sourceImage.type;
+            targetImage.fillCenter = sourceImage.fillCenter;
+            targetImage.pixelsPerUnitMultiplier = sourceImage.pixelsPerUnitMultiplier;
+            targetImage.preserveAspect = false;
         }
 
         private void UpdateBreaklineColor()
@@ -295,67 +355,30 @@ namespace Basis.BasisUI
                 return;
             }
 
-            Color color = Descriptor?.TitleLabel != null ? Descriptor.TitleLabel.color : Color.white;
-            color.a = Mathf.Max(color.a * 0.6f, 0.45f);
+            Color color = UiStyleSettings.GetActivePalette()?.AccentColor ?? Color.white;
             _breaklineImage.color = color;
         }
 
         private void UpdateBreakline()
         {
-            if (_breaklineObject != null)
-            {
-                _breaklineObject.SetActive(!Expanded && HasNextSectionToggle());
-            }
-        }
-
-        private bool HasNextSectionToggle()
-        {
-            RectTransform row = rectTransform;
-            if (row == null || row.parent == null)
-            {
-                return false;
-            }
-
-            Transform parent = row.parent;
-            int startIndex = row.GetSiblingIndex() + 1;
-            for (int i = startIndex; i < parent.childCount; i++)
-            {
-                Transform sibling = parent.GetChild(i);
-                if (sibling == null)
-                {
-                    continue;
-                }
-
-                if (sibling.GetComponent<PanelSectionBreaklineMarker>() != null)
-                {
-                    continue;
-                }
-
-                if (!sibling.gameObject.activeSelf)
-                {
-                    continue;
-                }
-
-                return sibling.GetComponent<PanelSectionToggleMarker>() != null;
-            }
-
-            return false;
-        }
-
-        private void RefreshSiblingBreaklines()
-        {
-            Transform parent = rectTransform != null ? rectTransform.parent : null;
-            if (parent == null)
+            if (_breaklineObject == null)
             {
                 return;
             }
 
-            for (int i = 0; i < parent.childCount; i++)
+            if (_ownsBreakline)
             {
-                PanelSectionToggleMarker marker = parent.GetChild(i).GetComponent<PanelSectionToggleMarker>();
-                marker?.Toggle?.UpdateBreakline();
+                // Breakline is below this toggle — apply expand check.
+                _breaklineObject.SetActive(!Expanded);
+            }
+            else
+            {
+                // Breakline is above this toggle — always visible.
+                _breaklineObject.SetActive(true);
             }
         }
+
+
 
         private void ReleaseBreakline()
         {
@@ -367,6 +390,44 @@ namespace Basis.BasisUI
             UnityEngine.Object.Destroy(_breaklineObject);
             _breaklineObject = null;
             _breaklineImage = null;
+        }
+
+        /// <summary>
+        /// Called by a sibling when it assigns a breakline to us. We take ownership.
+        /// </summary>
+        internal void TakeBreaklineOwnership(GameObject breaklineObject, Image breaklineImage)
+        {
+            _breaklineObject = breaklineObject;
+            _breaklineImage = breaklineImage;
+            _ownsBreakline = true;
+        }
+
+        /// <summary>
+        /// Called by a sibling when it is being destroyed. Releases the breakline
+        /// that this toggle owns (the one above us, between us and the caller).
+        /// </summary>
+        internal void ReleaseBreaklineForToggle(PanelSectionToggle caller)
+        {
+            if (_ownsBreakline && _breaklineObject != null)
+            {
+                UnityEngine.Object.Destroy(_breaklineObject);
+                _breaklineObject = null;
+                _breaklineImage = null;
+                _ownsBreakline = false;
+            }
+
+            // Also release the original breakline that was overwritten
+            if (_originalBreaklineObject != null)
+            {
+                UnityEngine.Object.Destroy(_originalBreaklineObject);
+                _originalBreaklineObject = null;
+                _originalBreaklineImage = null;
+            }
+
+            // Clear the caller's references so it doesn't keep a Missing ref.
+            caller._breaklineObject = null;
+            caller._breaklineImage = null;
+            caller._breaklineOwnerRef = null;
         }
 
         private RectTransform ResolveArrowParent()

--- a/Basis/Packages/com.basis.framework/BasisUI/PanelComponents/PanelSectionToggle.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/PanelComponents/PanelSectionToggle.cs
@@ -80,7 +80,6 @@ namespace Basis.BasisUI
             ConfigureArrowIndicator();
             ApplyCompactHeightOnce();
             DividerManager.CreateDividerAbove();
-            RefreshVisualState();
         }
 
         public override void OnReleaseEvent()

--- a/Basis/Packages/com.basis.framework/BasisUI/PanelComponents/PanelSectionToggle.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/PanelComponents/PanelSectionToggle.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using Basis.BasisUI.Styling;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -12,13 +11,9 @@ namespace Basis.BasisUI
         private const string CollapsedArrow = ">";
         private const string ExpandedArrow = "\u25bc";
         private const float CompactHeightScale = 0.8f;
-        private const float DividerContainerHeight = 4f;
-        private const float DividerHeight = 2f;
-        private const float DividerHorizontalInset = 12f;
 
         // Avoid scaling inappropriately large or sentinel preferred-height values.
         private const float MaxPreferredHeightThreshold = 1000f;
-        private static readonly Color FallbackDividerColor = new Color(0.5f, 0.5f, 0.5f, 0.5f);
 
         public static class Styles
         {
@@ -37,19 +32,13 @@ namespace Basis.BasisUI
         private string _title = string.Empty;
         private PanelSectionToggleMarker _marker;
         private readonly List<PanelSectionContentMarker> _contentMarkers = new();
-
-        private GameObject _dividerAbove;
-        private Image _dividerAboveImage;
-        private PanelSectionToggle _dividerAboveController;
-        private bool _ownsDividerAbove;
-        private GameObject _dividerBelow;
-        private Image _dividerBelowImage;
-        private bool _ownsDividerBelow;
+        private PanelSectionDividerManager _dividerManager;
 
         private bool _created;
         private bool _compactHeightApplied;
 
         protected override Selectable InteractableTarget => ToggleComponent;
+        internal PanelSectionDividerManager DividerManager => _dividerManager ??= new PanelSectionDividerManager(this, _contentMarkers);
         public bool Expanded => Value;
         public event Action<bool> OnExpandedChanged;
 
@@ -90,39 +79,13 @@ namespace Basis.BasisUI
             MarkSectionToggleRow();
             ConfigureArrowIndicator();
             ApplyCompactHeightOnce();
-            CreateDividerAbove();
+            DividerManager.CreateDividerAbove();
             RefreshVisualState();
         }
 
         public override void OnReleaseEvent()
         {
-            if (_ownsDividerAbove)
-            {
-                ClearSiblingReferenceTo(_dividerAbove);
-                DestroyDivider(ref _dividerAbove, ref _dividerAboveImage);
-            }
-            else
-            {
-                _dividerAbove = null;
-                _dividerAboveImage = null;
-            }
-
-            _dividerAboveController = null;
-            _ownsDividerAbove = false;
-
-            if (_ownsDividerBelow)
-            {
-                DestroyDivider(ref _dividerBelow, ref _dividerBelowImage);
-            }
-            else
-            {
-                // Shared _dividerBelow is the next section's _dividerAbove and
-                // is owned by that next toggle.
-                _dividerBelow = null;
-                _dividerBelowImage = null;
-            }
-
-            _ownsDividerBelow = false;
+            DividerManager.Release();
 
             if (_generatedArrowObject != null)
             {
@@ -234,13 +197,13 @@ namespace Basis.BasisUI
         {
             base.ApplyValue();
             UpdateArrow();
-            UpdateDividerVisibility();
+            DividerManager.UpdateVisibility();
         }
 
         private void RefreshVisualState()
         {
             UpdateArrow();
-            UpdateDividerVisibility();
+            DividerManager.UpdateVisibility();
         }
 
         private void MarkSectionToggleRow()
@@ -351,225 +314,11 @@ namespace Basis.BasisUI
             rectTransform.sizeDelta = size;
         }
 
-        private void CreateDividerAbove()
-        {
-            if (_dividerAbove != null || rectTransform == null || rectTransform.parent == null)
-            {
-                return;
-            }
-
-            int currentIndex = rectTransform.GetSiblingIndex();
-            PanelSectionToggle previousToggle = ResolvePreviousSectionToggle(currentIndex, out bool previousToggleIsDirectNeighbor);
-            if (previousToggle != null && !previousToggleIsDirectNeighbor)
-            {
-                // Content separates these sections, so the previous section needs
-                // its own bottom divider instead of sharing this section's top divider.
-                if (previousToggle.EnsureOwnedDividerBelow())
-                {
-                    return;
-                }
-            }
-
-            GameObject divider = CreateDividerObject(currentIndex, previousToggle);
-            Image dividerImage = ResolveDividerImage(divider);
-
-            _dividerAbove = divider;
-            _dividerAboveImage = dividerImage;
-            _dividerAboveController = previousToggleIsDirectNeighbor ? previousToggle : null;
-            _ownsDividerAbove = true;
-
-            if (previousToggle != null && previousToggleIsDirectNeighbor)
-            {
-                previousToggle.SetDividerBelow(divider, dividerImage);
-            }
-
-            UpdateDividerVisibility();
-        }
-
-        private GameObject CreateDividerObject(int siblingIndex, PanelSectionToggle styleSource)
-        {
-            GameObject dividerObject = new GameObject("Section Divider", typeof(RectTransform), typeof(LayoutElement), typeof(PanelSectionBreaklineMarker));
-            dividerObject.layer = gameObject.layer;
-
-            dividerObject.TryGetComponent(out RectTransform dividerTransform);
-            dividerTransform.SetParent(rectTransform.parent, false);
-            dividerTransform.SetSiblingIndex(siblingIndex);
-            dividerTransform.anchorMin = new Vector2(0f, 0.5f);
-            dividerTransform.anchorMax = new Vector2(1f, 0.5f);
-            dividerTransform.pivot = new Vector2(0.5f, 0.5f);
-            dividerTransform.sizeDelta = new Vector2(0f, DividerContainerHeight);
-
-            dividerObject.TryGetComponent(out LayoutElement layout);
-            layout.minHeight = DividerContainerHeight;
-            layout.preferredHeight = DividerContainerHeight;
-
-            GameObject lineObject = new GameObject("Line", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image));
-            lineObject.layer = dividerObject.layer;
-
-            lineObject.TryGetComponent(out RectTransform lineTransform);
-            lineTransform.SetParent(dividerTransform, false);
-            lineTransform.anchorMin = new Vector2(0f, 0.5f);
-            lineTransform.anchorMax = new Vector2(1f, 0.5f);
-            lineTransform.pivot = new Vector2(0.5f, 0.5f);
-            lineTransform.offsetMin = new Vector2(DividerHorizontalInset, -DividerHeight * 0.5f);
-            lineTransform.offsetMax = new Vector2(-DividerHorizontalInset, DividerHeight * 0.5f);
-
-            lineObject.TryGetComponent(out Image dividerImage);
-            dividerImage.raycastTarget = false;
-            ApplyDividerImageStyle(dividerImage, styleSource);
-            dividerImage.color = GetDividerColor();
-
-            return dividerObject;
-        }
-
-        private static Image ResolveDividerImage(GameObject divider)
-        {
-            return divider != null ? divider.GetComponentInChildren<Image>(true) : null;
-        }
-
-        private bool EnsureOwnedDividerBelow()
-        {
-            if (_dividerBelow != null)
-            {
-                UpdateDividerVisibility();
-                return true;
-            }
-
-            if (!TryGetDividerBelowSiblingIndex(out int siblingIndex))
-            {
-                return false;
-            }
-
-            GameObject divider = CreateDividerObject(siblingIndex, this);
-            SetDividerBelow(divider, ResolveDividerImage(divider), true);
-            return true;
-        }
-
-        private bool TryGetDividerBelowSiblingIndex(out int siblingIndex)
-        {
-            siblingIndex = -1;
-            if (rectTransform == null || rectTransform.parent == null)
-            {
-                return false;
-            }
-
-            Transform parent = rectTransform.parent;
-            int lastOwnedIndex = rectTransform.GetSiblingIndex();
-            for (int i = 0; i < _contentMarkers.Count; i++)
-            {
-                PanelSectionContentMarker marker = _contentMarkers[i];
-                if (marker == null || marker.Owner != this || marker.transform.parent != parent)
-                {
-                    continue;
-                }
-
-                lastOwnedIndex = Mathf.Max(lastOwnedIndex, marker.transform.GetSiblingIndex());
-            }
-
-            siblingIndex = Mathf.Min(lastOwnedIndex + 1, parent.childCount);
-            return true;
-        }
-
         private void UnregisterContentMarker(PanelSectionContentMarker marker)
         {
             if (marker != null)
             {
                 _contentMarkers.Remove(marker);
-            }
-        }
-
-        private void SetDividerBelow(GameObject divider, Image image, bool ownsDivider = false)
-        {
-            if (_dividerBelow != null && _dividerBelow != divider)
-            {
-                if (_ownsDividerBelow)
-                {
-                    DestroyDivider(ref _dividerBelow, ref _dividerBelowImage);
-                }
-                else
-                {
-                    BasisDebug.LogWarning($"{nameof(PanelSectionToggle)} divider below was replaced.");
-                }
-            }
-
-            _dividerBelow = divider;
-            _dividerBelowImage = image;
-            _ownsDividerBelow = ownsDivider;
-            UpdateDividerVisibility();
-        }
-
-        private void UpdateDividerVisibility()
-        {
-            if (_dividerAbove != null && _dividerAboveController == null)
-            {
-                _dividerAbove.SetActive(true);
-            }
-
-            if (_dividerBelow != null)
-            {
-                _dividerBelow.SetActive(!Expanded);
-            }
-        }
-
-        private PanelSectionToggle ResolvePreviousSectionToggle(int currentIndex, out bool isDirectNeighbor)
-        {
-            isDirectNeighbor = false;
-            Transform parent = rectTransform.parent;
-            bool skippedSibling = false;
-            for (int i = currentIndex - 1; i >= 0; i--)
-            {
-                Transform sibling = parent.GetChild(i);
-                if (sibling == null || sibling.TryGetComponent(out PanelSectionBreaklineMarker _))
-                {
-                    skippedSibling = true;
-                    continue;
-                }
-
-                if (sibling.TryGetComponent(out PanelSectionToggle previousToggle))
-                {
-                    isDirectNeighbor = !skippedSibling;
-                    return previousToggle;
-                }
-
-                if (sibling.TryGetComponent(out PanelSectionContentMarker contentMarker))
-                {
-                    if (contentMarker.Owner != null && contentMarker.Owner != this)
-                    {
-                        skippedSibling = true;
-                        return contentMarker.Owner;
-                    }
-
-                    skippedSibling = true;
-                    continue;
-                }
-
-                return null;
-            }
-
-            return null;
-        }
-
-        private void ClearSiblingReferenceTo(GameObject divider)
-        {
-            if (divider == null || rectTransform == null || rectTransform.parent == null)
-            {
-                return;
-            }
-
-            Transform parent = rectTransform.parent;
-            for (int i = 0; i < parent.childCount; i++)
-            {
-                if (!parent.GetChild(i).TryGetComponent(out PanelSectionToggle markerOwner))
-                {
-                    continue;
-                }
-
-                if (markerOwner._dividerBelow == divider)
-                {
-                    markerOwner._dividerBelow = null;
-                    markerOwner._dividerBelowImage = null;
-                    markerOwner.UpdateDividerVisibility();
-                }
             }
         }
 
@@ -587,107 +336,21 @@ namespace Basis.BasisUI
             _contentMarkers.Clear();
         }
 
-        private void ApplyDividerImageStyle(Image targetImage, PanelSectionToggle styleSource)
-        {
-            if (targetImage == null)
-            {
-                return;
-            }
-
-            Image sourceImage =
-                styleSource?.GetDividerSourceImage()
-                ?? GetDividerSourceImage();
-
-            if (sourceImage == null)
-            {
-                return;
-            }
-
-            targetImage.sprite = sourceImage.sprite;
-            targetImage.material = sourceImage.material;
-            targetImage.type = sourceImage.type;
-            targetImage.fillCenter = sourceImage.fillCenter;
-            targetImage.pixelsPerUnitMultiplier = sourceImage.pixelsPerUnitMultiplier;
-            targetImage.preserveAspect = false;
-        }
-
-        private Image GetDividerSourceImage()
+        internal Image GetDividerSourceImage()
         {
             return (Background as Image) ?? (ToggleComponent?.targetGraphic as Image);
-        }
-
-        private static Color GetDividerColor()
-        {
-            UiStylePalette palette = UiStyleSettings.GetActivePalette();
-            return palette != null ? palette.AccentColor : FallbackDividerColor;
-        }
-
-        private static void DestroyDivider(ref GameObject divider, ref Image image)
-        {
-            if (divider != null)
-            {
-                ClearEditorSelectionIfTargeting(divider);
-                UnityEngine.Object.Destroy(divider);
-            }
-
-            divider = null;
-            image = null;
         }
 
         private static void DestroyGeneratedObject(ref GameObject generatedObject)
         {
             if (generatedObject != null)
             {
-                ClearEditorSelectionIfTargeting(generatedObject);
+                PanelSectionDividerManager.ClearEditorSelectionIfTargeting(generatedObject);
                 UnityEngine.Object.Destroy(generatedObject);
             }
 
             generatedObject = null;
         }
-
-        private static void ClearEditorSelectionIfTargeting(GameObject root)
-        {
-#if UNITY_EDITOR
-            if (root == null)
-            {
-                return;
-            }
-
-            UnityEngine.Object[] selectedObjects = UnityEditor.Selection.objects;
-            if (selectedObjects == null || selectedObjects.Length == 0)
-            {
-                return;
-            }
-
-            UnityEngine.Object[] filteredSelection = Array.FindAll(
-                selectedObjects,
-                selectedObject => !IsEditorSelectionTargeting(root, selectedObject));
-
-            if (filteredSelection.Length != selectedObjects.Length)
-            {
-                UnityEditor.Selection.objects = filteredSelection;
-            }
-#endif
-        }
-
-#if UNITY_EDITOR
-        private static bool IsEditorSelectionTargeting(GameObject root, UnityEngine.Object selectedObject)
-        {
-            if (selectedObject == null)
-            {
-                return false;
-            }
-
-            GameObject selectedGameObject = selectedObject as GameObject;
-            if (selectedObject is Component selectedComponent)
-            {
-                selectedGameObject = selectedComponent.gameObject;
-            }
-
-            return selectedGameObject != null
-                && (selectedGameObject == root || selectedGameObject.transform.IsChildOf(root.transform));
-        }
-#endif
 
         private RectTransform ResolveArrowParent()
         {

--- a/Basis/Packages/com.basis.framework/BasisUI/PanelComponents/PanelSectionToggle.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/PanelComponents/PanelSectionToggle.cs
@@ -18,6 +18,7 @@ namespace Basis.BasisUI
 
         // Avoid scaling inappropriately large or sentinel preferred-height values.
         private const float MaxPreferredHeightThreshold = 1000f;
+        private static readonly Color FallbackDividerColor = new Color(0.5f, 0.5f, 0.5f, 0.5f);
 
         public static class Styles
         {
@@ -40,6 +41,7 @@ namespace Basis.BasisUI
         private GameObject _dividerAbove;
         private Image _dividerAboveImage;
         private PanelSectionToggle _dividerAboveController;
+        private bool _ownsDividerAbove;
         private GameObject _dividerBelow;
         private Image _dividerBelowImage;
         private bool _ownsDividerBelow;
@@ -73,6 +75,11 @@ namespace Basis.BasisUI
         {
             base.OnCreateEvent();
 
+            if (ToggleComponent == null)
+            {
+                BasisDebug.LogError($"{nameof(PanelSectionToggle)} requires {nameof(ToggleComponent)} to be assigned.");
+            }
+
             if (_created)
             {
                 RefreshVisualState();
@@ -89,9 +96,19 @@ namespace Basis.BasisUI
 
         public override void OnReleaseEvent()
         {
-            ClearSiblingReferenceTo(_dividerAbove);
-            DestroyDivider(ref _dividerAbove, ref _dividerAboveImage);
+            if (_ownsDividerAbove)
+            {
+                ClearSiblingReferenceTo(_dividerAbove);
+                DestroyDivider(ref _dividerAbove, ref _dividerAboveImage);
+            }
+            else
+            {
+                _dividerAbove = null;
+                _dividerAboveImage = null;
+            }
+
             _dividerAboveController = null;
+            _ownsDividerAbove = false;
 
             if (_ownsDividerBelow)
             {
@@ -130,7 +147,7 @@ namespace Basis.BasisUI
         {
             if (binding == null)
             {
-                Debug.LogError($"{nameof(PanelSectionToggle)} requires a non-null binding.");
+                BasisDebug.LogError($"{nameof(PanelSectionToggle)} requires a non-null binding.");
                 SetExpandedWithoutNotify(false);
                 return;
             }
@@ -171,7 +188,7 @@ namespace Basis.BasisUI
         {
             if (binding == null)
             {
-                Debug.LogError($"{nameof(PanelSectionToggle)} requires a non-null binding.");
+                BasisDebug.LogError($"{nameof(PanelSectionToggle)} requires a non-null binding.");
                 SetExpandedWithoutNotify(false);
                 return;
             }
@@ -196,10 +213,14 @@ namespace Basis.BasisUI
                 return;
             }
 
-            PanelSectionContentMarker marker = contentContainer.GetComponent<PanelSectionContentMarker>();
-            if (marker == null)
+            if (!contentContainer.TryGetComponent(out PanelSectionContentMarker marker))
             {
                 marker = contentContainer.gameObject.AddComponent<PanelSectionContentMarker>();
+            }
+
+            if (marker.Owner != null && marker.Owner != this)
+            {
+                marker.Owner.UnregisterContentMarker(marker);
             }
 
             marker.Owner = this;
@@ -258,7 +279,7 @@ namespace Basis.BasisUI
             _generatedArrowObject = new GameObject("Section Arrow", typeof(RectTransform));
             _generatedArrowObject.layer = arrowParent.gameObject.layer;
 
-            RectTransform arrowTransform = _generatedArrowObject.GetComponent<RectTransform>();
+            _generatedArrowObject.TryGetComponent(out RectTransform arrowTransform);
             arrowTransform.SetParent(arrowParent, false);
             arrowTransform.anchorMin = Vector2.zero;
             arrowTransform.anchorMax = Vector2.one;
@@ -343,8 +364,10 @@ namespace Basis.BasisUI
             {
                 // Content separates these sections, so the previous section needs
                 // its own bottom divider instead of sharing this section's top divider.
-                previousToggle.EnsureOwnedDividerBelow(currentIndex);
-                currentIndex++;
+                if (previousToggle.EnsureOwnedDividerBelow())
+                {
+                    return;
+                }
             }
 
             GameObject divider = CreateDividerObject(currentIndex, previousToggle);
@@ -353,6 +376,7 @@ namespace Basis.BasisUI
             _dividerAbove = divider;
             _dividerAboveImage = dividerImage;
             _dividerAboveController = previousToggleIsDirectNeighbor ? previousToggle : null;
+            _ownsDividerAbove = true;
 
             if (previousToggle != null && previousToggleIsDirectNeighbor)
             {
@@ -367,7 +391,7 @@ namespace Basis.BasisUI
             GameObject dividerObject = new GameObject("Section Divider", typeof(RectTransform), typeof(LayoutElement), typeof(PanelSectionBreaklineMarker));
             dividerObject.layer = gameObject.layer;
 
-            RectTransform dividerTransform = dividerObject.GetComponent<RectTransform>();
+            dividerObject.TryGetComponent(out RectTransform dividerTransform);
             dividerTransform.SetParent(rectTransform.parent, false);
             dividerTransform.SetSiblingIndex(siblingIndex);
             dividerTransform.anchorMin = new Vector2(0f, 0.5f);
@@ -375,14 +399,14 @@ namespace Basis.BasisUI
             dividerTransform.pivot = new Vector2(0.5f, 0.5f);
             dividerTransform.sizeDelta = new Vector2(0f, DividerContainerHeight);
 
-            LayoutElement layout = dividerObject.GetComponent<LayoutElement>();
+            dividerObject.TryGetComponent(out LayoutElement layout);
             layout.minHeight = DividerContainerHeight;
             layout.preferredHeight = DividerContainerHeight;
 
             GameObject lineObject = new GameObject("Line", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image));
             lineObject.layer = dividerObject.layer;
 
-            RectTransform lineTransform = lineObject.GetComponent<RectTransform>();
+            lineObject.TryGetComponent(out RectTransform lineTransform);
             lineTransform.SetParent(dividerTransform, false);
             lineTransform.anchorMin = new Vector2(0f, 0.5f);
             lineTransform.anchorMax = new Vector2(1f, 0.5f);
@@ -390,7 +414,7 @@ namespace Basis.BasisUI
             lineTransform.offsetMin = new Vector2(DividerHorizontalInset, -DividerHeight * 0.5f);
             lineTransform.offsetMax = new Vector2(-DividerHorizontalInset, DividerHeight * 0.5f);
 
-            Image dividerImage = lineObject.GetComponent<Image>();
+            lineObject.TryGetComponent(out Image dividerImage);
             dividerImage.raycastTarget = false;
             ApplyDividerImageStyle(dividerImage, styleSource);
             dividerImage.color = GetDividerColor();
@@ -403,16 +427,55 @@ namespace Basis.BasisUI
             return divider != null ? divider.GetComponentInChildren<Image>(true) : null;
         }
 
-        private void EnsureOwnedDividerBelow(int siblingIndex)
+        private bool EnsureOwnedDividerBelow()
         {
             if (_dividerBelow != null)
             {
                 UpdateDividerVisibility();
-                return;
+                return true;
+            }
+
+            if (!TryGetDividerBelowSiblingIndex(out int siblingIndex))
+            {
+                return false;
             }
 
             GameObject divider = CreateDividerObject(siblingIndex, this);
             SetDividerBelow(divider, ResolveDividerImage(divider), true);
+            return true;
+        }
+
+        private bool TryGetDividerBelowSiblingIndex(out int siblingIndex)
+        {
+            siblingIndex = -1;
+            if (rectTransform == null || rectTransform.parent == null)
+            {
+                return false;
+            }
+
+            Transform parent = rectTransform.parent;
+            int lastOwnedIndex = rectTransform.GetSiblingIndex();
+            for (int i = 0; i < _contentMarkers.Count; i++)
+            {
+                PanelSectionContentMarker marker = _contentMarkers[i];
+                if (marker == null || marker.Owner != this || marker.transform.parent != parent)
+                {
+                    continue;
+                }
+
+                lastOwnedIndex = Mathf.Max(lastOwnedIndex, marker.transform.GetSiblingIndex());
+            }
+
+            siblingIndex = Mathf.Min(lastOwnedIndex + 1, parent.childCount);
+            return true;
+        }
+
+        private void UnregisterContentMarker(PanelSectionContentMarker marker)
+        {
+            if (marker != null)
+            {
+                _contentMarkers.Remove(marker);
+            }
         }
 
         private void SetDividerBelow(GameObject divider, Image image, bool ownsDivider = false)
@@ -425,7 +488,7 @@ namespace Basis.BasisUI
                 }
                 else
                 {
-                    Debug.LogWarning($"{nameof(PanelSectionToggle)} divider below was replaced.");
+                    BasisDebug.LogWarning($"{nameof(PanelSectionToggle)} divider below was replaced.");
                 }
             }
 
@@ -456,7 +519,7 @@ namespace Basis.BasisUI
             for (int i = currentIndex - 1; i >= 0; i--)
             {
                 Transform sibling = parent.GetChild(i);
-                if (sibling == null || sibling.GetComponent<PanelSectionBreaklineMarker>() != null)
+                if (sibling == null || sibling.TryGetComponent(out PanelSectionBreaklineMarker _))
                 {
                     skippedSibling = true;
                     continue;
@@ -470,7 +533,14 @@ namespace Basis.BasisUI
 
                 if (sibling.TryGetComponent(out PanelSectionContentMarker contentMarker))
                 {
-                    return contentMarker.Owner;
+                    if (contentMarker.Owner != null && contentMarker.Owner != this)
+                    {
+                        skippedSibling = true;
+                        return contentMarker.Owner;
+                    }
+
+                    skippedSibling = true;
+                    continue;
                 }
 
                 return null;
@@ -549,7 +619,7 @@ namespace Basis.BasisUI
         private static Color GetDividerColor()
         {
             UiStylePalette palette = UiStyleSettings.GetActivePalette();
-            return palette != null ? palette.AccentColor : Color.white;
+            return palette != null ? palette.AccentColor : FallbackDividerColor;
         }
 
         private static void DestroyDivider(ref GameObject divider, ref Image image)

--- a/Basis/Packages/com.basis.framework/BasisUI/PanelComponents/PanelSectionToggle.cs.meta
+++ b/Basis/Packages/com.basis.framework/BasisUI/PanelComponents/PanelSectionToggle.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 794ac7aa378676d41b5d1eafab097e3f

--- a/Basis/Packages/com.basis.framework/BasisUI/PanelComponents/PanelSectionToggleHelpers.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/PanelComponents/PanelSectionToggleHelpers.cs
@@ -5,6 +5,10 @@ namespace Basis.BasisUI
 {
     internal static class PanelSectionToggleHelpers
     {
+        /// <summary>
+        /// Creates a titled content group for a section toggle and registers it for divider ownership.
+        /// Callers should add child controls while the returned group is still active, then finalize it.
+        /// </summary>
         public static PanelElementDescriptor CreateCollapsibleContentGroup(
             PanelSectionToggle sectionToggle,
             RectTransform parent,
@@ -29,6 +33,10 @@ namespace Basis.BasisUI
             return group;
         }
 
+        /// <summary>
+        /// Applies the initial expanded state and wires a section toggle to show or hide its content group.
+        /// The optional callback is for parent layout rebuilds or other caller-specific side effects.
+        /// </summary>
         public static void FinalizeCollapsibleGroup(
             PanelSectionToggle sectionToggle,
             PanelElementDescriptor group,
@@ -47,6 +55,71 @@ namespace Basis.BasisUI
                 group.gameObject.SetActive(visible);
                 onExpandedChanged?.Invoke(visible);
             };
+        }
+
+        /// <summary>
+        /// Registers one or more existing controls or groups as content under a section toggle.
+        /// Use this when content rows are already created and should collapse without adding another group.
+        /// </summary>
+        public static void FinalizeCollapsibleContents(
+            PanelSectionToggle sectionToggle,
+            bool defaultOpen,
+            Action<bool> onExpandedChanged,
+            params Component[] contents)
+        {
+            if (sectionToggle == null || contents == null)
+            {
+                return;
+            }
+
+            for (int i = 0; i < contents.Length; i++)
+            {
+                Component content = contents[i];
+                if (content != null)
+                {
+                    sectionToggle.RegisterContentContainer(content);
+                }
+            }
+
+            SetContentsActive(contents, defaultOpen);
+            sectionToggle.SetExpandedWithoutNotify(defaultOpen);
+            sectionToggle.OnExpandedChanged += visible =>
+            {
+                SetContentsActive(contents, visible);
+                onExpandedChanged?.Invoke(visible);
+            };
+        }
+
+        /// <summary>
+        /// Applies the same active state to every registered content item.
+        /// </summary>
+        private static void SetContentsActive(Component[] contents, bool active)
+        {
+            for (int i = 0; i < contents.Length; i++)
+            {
+                SetContentActive(contents[i], active);
+            }
+        }
+
+        /// <summary>
+        /// Uses the panel descriptor when available so panel components follow existing UI activation behavior.
+        /// </summary>
+        private static void SetContentActive(Component content, bool active)
+        {
+            switch (content)
+            {
+                case null:
+                    return;
+                case PanelComponent panelComponent:
+                    panelComponent.Descriptor.SetActive(active);
+                    return;
+                case PanelElementDescriptor descriptor:
+                    descriptor.SetActive(active);
+                    return;
+                default:
+                    content.gameObject.SetActive(active);
+                    return;
+            }
         }
     }
 }

--- a/Basis/Packages/com.basis.framework/BasisUI/PanelComponents/PanelSectionToggleHelpers.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/PanelComponents/PanelSectionToggleHelpers.cs
@@ -1,0 +1,52 @@
+using System;
+using UnityEngine;
+
+namespace Basis.BasisUI
+{
+    internal static class PanelSectionToggleHelpers
+    {
+        public static PanelElementDescriptor CreateCollapsibleContentGroup(
+            PanelSectionToggle sectionToggle,
+            RectTransform parent,
+            string title,
+            bool showGroupTitle = true)
+        {
+            sectionToggle.SetTitle(title);
+
+            PanelElementDescriptor group = PanelElementDescriptor.CreateNew(
+                PanelElementDescriptor.ElementStyles.Group,
+                parent);
+            if (showGroupTitle)
+            {
+                group.SetTitle(title);
+            }
+            else if (group.Header != null)
+            {
+                group.Header.gameObject.SetActive(false);
+            }
+
+            sectionToggle.RegisterContentContainer(group);
+            return group;
+        }
+
+        public static void FinalizeCollapsibleGroup(
+            PanelSectionToggle sectionToggle,
+            PanelElementDescriptor group,
+            bool defaultOpen,
+            Action<bool> onExpandedChanged = null)
+        {
+            if (sectionToggle == null || group == null)
+            {
+                return;
+            }
+
+            group.gameObject.SetActive(defaultOpen);
+            sectionToggle.SetExpandedWithoutNotify(defaultOpen);
+            sectionToggle.OnExpandedChanged += visible =>
+            {
+                group.gameObject.SetActive(visible);
+                onExpandedChanged?.Invoke(visible);
+            };
+        }
+    }
+}

--- a/Basis/Packages/com.basis.framework/BasisUI/PanelComponents/PanelSectionToggleHelpers.cs.meta
+++ b/Basis/Packages/com.basis.framework/BasisUI/PanelComponents/PanelSectionToggleHelpers.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5bb47f957ad14c9d90b63fcf60ddc88c

--- a/Basis/Packages/com.basis.sdk/Prefabs/Panel Elements/PE Section Toggle - Entry Variant.prefab
+++ b/Basis/Packages/com.basis.sdk/Prefabs/Panel Elements/PE Section Toggle - Entry Variant.prefab
@@ -56,8 +56,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 2100000, guid: 400aab2496c5028449f88f0184de3e3b, type: 2}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 0
@@ -86,9 +86,9 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 4b07434b547b6d144a23ceb11ba60a41, type: 3}
-  m_Name: 
+  m_Name:
   m_EditorClassIdentifier: Basis Framework::Basis.BasisUI.Styling.UiStyleImage
-  ColorStyle: 
+  ColorStyle:
 --- !u!1 &6627445660936167654
 GameObject:
   m_ObjectHideFlags: 0
@@ -145,8 +145,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 2100000, guid: 400aab2496c5028449f88f0184de3e3b, type: 2}
   m_Color: {r: 0.3529412, g: 0.3529412, b: 0.43529412, a: 1}
   m_RaycastTarget: 0
@@ -498,7 +498,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
-  m_Name: 
+  m_Name:
   m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Toggle
   m_Navigation:
     m_Mode: 0
@@ -544,7 +544,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument: 
+          m_StringArgument:
           m_BoolArgument: 0
         m_CallState: 2
   m_IsOn: 0
@@ -558,7 +558,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 794ac7aa378676d41b5d1eafab097e3f, type: 3}
-  m_Name: 
+  m_Name:
   m_EditorClassIdentifier: Basis Framework::Basis.BasisUI.PanelSectionToggle
   ToggleComponent: {fileID: 2831075354322693821}
   ToggleVisual: {fileID: 6708973251941489184}
@@ -577,5 +577,5 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:

--- a/Basis/Packages/com.basis.sdk/Prefabs/Panel Elements/PE Section Toggle - Entry Variant.prefab
+++ b/Basis/Packages/com.basis.sdk/Prefabs/Panel Elements/PE Section Toggle - Entry Variant.prefab
@@ -1,0 +1,581 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6583835796220696228
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6708973251941489184}
+  - component: {fileID: 3006436012667173754}
+  - component: {fileID: 7715949340683606163}
+  - component: {fileID: 7202963783118992174}
+  m_Layer: 9
+  m_Name: Checkmark
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6708973251941489184
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6583835796220696228}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5102506247728419943}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -35, y: 0}
+  m_SizeDelta: {x: 50, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3006436012667173754
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6583835796220696228}
+  m_CullTransparentMesh: 1
+--- !u!114 &7715949340683606163
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6583835796220696228}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 2100000, guid: 400aab2496c5028449f88f0184de3e3b, type: 2}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: a336a8280e1dda94fbef1a59936ed578, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &7202963783118992174
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6583835796220696228}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4b07434b547b6d144a23ceb11ba60a41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Basis Framework::Basis.BasisUI.Styling.UiStyleImage
+  ColorStyle: 
+--- !u!1 &6627445660936167654
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5102506247728419943}
+  - component: {fileID: 8659356656985809459}
+  - component: {fileID: 2885130199011414187}
+  m_Layer: 9
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5102506247728419943
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6627445660936167654}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6708973251941489184}
+  m_Father: {fileID: 7148407317961888584}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8659356656985809459
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6627445660936167654}
+  m_CullTransparentMesh: 1
+--- !u!114 &2885130199011414187
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6627445660936167654}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 2100000, guid: 400aab2496c5028449f88f0184de3e3b, type: 2}
+  m_Color: {r: 0.3529412, g: 0.3529412, b: 0.43529412, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: a336a8280e1dda94fbef1a59936ed578, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1.75
+--- !u!1 &6651534060469963332
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7148407317961888584}
+  m_Layer: 9
+  m_Name: Toggle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7148407317961888584
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6651534060469963332}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5102506247728419943}
+  m_Father: {fileID: 1145583136380266281}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 130, y: 0}
+  m_Pivot: {x: 1, y: 0.5}
+--- !u!1001 &8393600631856970478
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 263208987085631843, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 263208987085631843, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 263208987085631843, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 880
+      objectReference: {fileID: 0}
+    - target: {fileID: 263208987085631843, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 263208987085631843, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 520
+      objectReference: {fileID: 0}
+    - target: {fileID: 263208987085631843, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -40
+      objectReference: {fileID: 0}
+    - target: {fileID: 418794736520680895, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 418794736520680895, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 418794736520680895, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 418794736520680895, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 418794736520680895, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 418794736520680895, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 806919717946939206, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 806919717946939206, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 806919717946939206, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 806919717946939206, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 806919717946939206, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 806919717946939206, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 869904323345228785, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 869904323345228785, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 869904323345228785, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 580
+      objectReference: {fileID: 0}
+    - target: {fileID: 869904323345228785, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 869904323345228785, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 290
+      objectReference: {fileID: 0}
+    - target: {fileID: 869904323345228785, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -30
+      objectReference: {fileID: 0}
+    - target: {fileID: 1617632830203509521, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_RaycastTarget
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2582961933184960890, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_TextWrappingMode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2898124286402438520, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2898124286402438520, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2898124286402438520, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2898124286402438520, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2898124286402438520, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2898124286402438520, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4081030067364142984, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_RaycastTarget
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4316124631809654426, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4316124631809654426, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4316124631809654426, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4316124631809654426, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4316124631809654426, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7951298956566130567, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7951298956566130567, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7951298956566130567, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7951298956566130567, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7951298956566130567, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7951298956566130567, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7951298956566130567, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 960
+      objectReference: {fileID: 0}
+    - target: {fileID: 7951298956566130567, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7951298956566130567, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7951298956566130567, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7951298956566130567, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7951298956566130567, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7951298956566130567, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7951298956566130567, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7951298956566130567, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7951298956566130567, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 480
+      objectReference: {fileID: 0}
+    - target: {fileID: 7951298956566130567, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -40
+      objectReference: {fileID: 0}
+    - target: {fileID: 7951298956566130567, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7951298956566130567, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7951298956566130567, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8454217969816905391, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_Name
+      value: PE Section Toggle - Entry Variant
+      objectReference: {fileID: 0}
+    - target: {fileID: 8906398806221495751, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8906398806221495751, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8906398806221495751, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8906398806221495751, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8906398806221495751, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8906398806221495751, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 8906398806221495751, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 7148407317961888584}
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 8454217969816905391, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2831075354322693821}
+    - targetCorrespondingSourceObject: {fileID: 8454217969816905391, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1540608586321280205}
+  m_SourcePrefab: {fileID: 100100000, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+--- !u!1 &85398235727600705 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8454217969816905391, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+  m_PrefabInstance: {fileID: 8393600631856970478}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &2831075354322693821
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 85398235727600705}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Toggle
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 0}
+    m_HighlightedColor: {r: 1, g: 1, b: 1, a: 0.5019608}
+    m_PressedColor: {r: 1, g: 1, b: 1, a: 0.5019608}
+    m_SelectedColor: {r: 1, g: 1, b: 1, a: 0.5019608}
+    m_DisabledColor: {r: 0, g: 0, b: 0, a: 0}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 7589167289436740151}
+  toggleTransition: 1
+  graphic: {fileID: 0}
+  m_Group: {fileID: 0}
+  onValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1540608586321280205}
+        m_TargetAssemblyTypeName: Basis.BasisUI.PanelSectionToggle, Basis Framework
+        m_MethodName: OnComponentUsed
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  m_IsOn: 0
+--- !u!114 &1540608586321280205
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 85398235727600705}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 794ac7aa378676d41b5d1eafab097e3f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Basis Framework::Basis.BasisUI.PanelSectionToggle
+  ToggleComponent: {fileID: 2831075354322693821}
+  ToggleVisual: {fileID: 6708973251941489184}
+  Background: {fileID: 2885130199011414187}
+--- !u!224 &1145583136380266281 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8906398806221495751, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+  m_PrefabInstance: {fileID: 8393600631856970478}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &7589167289436740151 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2102666718608367833, guid: 00eaf66b466c4644eb2568c728a1dac8, type: 3}
+  m_PrefabInstance: {fileID: 8393600631856970478}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 85398235727600705}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Basis/Packages/com.basis.sdk/Prefabs/Panel Elements/PE Section Toggle - Entry Variant.prefab.meta
+++ b/Basis/Packages/com.basis.sdk/Prefabs/Panel Elements/PE Section Toggle - Entry Variant.prefab.meta
@@ -2,6 +2,6 @@ fileFormatVersion: 2
 guid: 9b76bc86253e4a7c9d6c9f8a0b1e2d3c
 PrefabImporter:
   externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Basis/Packages/com.basis.sdk/Prefabs/Panel Elements/PE Section Toggle - Entry Variant.prefab.meta
+++ b/Basis/Packages/com.basis.sdk/Prefabs/Panel Elements/PE Section Toggle - Entry Variant.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9b76bc86253e4a7c9d6c9f8a0b1e2d3c
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Basis/Packages/com.basis.sdk/Prefabs/Panel Elements/PE Section Toggle.prefab
+++ b/Basis/Packages/com.basis.sdk/Prefabs/Panel Elements/PE Section Toggle.prefab
@@ -91,8 +91,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 2100000, guid: 400aab2496c5028449f88f0184de3e3b, type: 2}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 0
@@ -167,8 +167,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 2100000, guid: 400aab2496c5028449f88f0184de3e3b, type: 2}
   m_Color: {r: 0.3529412, g: 0.3529412, b: 0.43529412, a: 1}
   m_RaycastTarget: 0
@@ -325,11 +325,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2695670721113310902, guid: c291cad985c051346b5516c30fda2029, type: 3}
       propertyPath: m_Material
-      value: 
+      value:
       objectReference: {fileID: 2100000, guid: 400aab2496c5028449f88f0184de3e3b, type: 2}
     - target: {fileID: 3263669264447411214, guid: c291cad985c051346b5516c30fda2029, type: 3}
       propertyPath: m_Material
-      value: 
+      value:
       objectReference: {fileID: 2100000, guid: 400aab2496c5028449f88f0184de3e3b, type: 2}
     - target: {fileID: 3263669264447411214, guid: c291cad985c051346b5516c30fda2029, type: 3}
       propertyPath: m_RaycastTarget
@@ -385,7 +385,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7078463098538894437, guid: c291cad985c051346b5516c30fda2029, type: 3}
       propertyPath: m_Material
-      value: 
+      value:
       objectReference: {fileID: 2100000, guid: 400aab2496c5028449f88f0184de3e3b, type: 2}
     - target: {fileID: 7078463098538894437, guid: c291cad985c051346b5516c30fda2029, type: 3}
       propertyPath: m_RaycastTarget
@@ -488,8 +488,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Navigation:
     m_Mode: 0
     m_WrapAround: 0
@@ -548,7 +548,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 794ac7aa378676d41b5d1eafab097e3f, type: 3}
-  m_Name: 
+  m_Name:
   m_EditorClassIdentifier: Basis Framework::Basis.BasisUI.PanelSectionToggle
   ToggleComponent: {fileID: 798007477887917358}
   ToggleVisual: {fileID: 7228324214470216984}
@@ -562,8 +562,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
 --- !u!224 &8544700722471038800 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 8009018518866211647, guid: c291cad985c051346b5516c30fda2029, type: 3}

--- a/Basis/Packages/com.basis.sdk/Prefabs/Panel Elements/PE Section Toggle.prefab
+++ b/Basis/Packages/com.basis.sdk/Prefabs/Panel Elements/PE Section Toggle.prefab
@@ -1,0 +1,571 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1678406460775592990
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8372032557611025346}
+  m_Layer: 9
+  m_Name: Toggle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8372032557611025346
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1678406460775592990}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5852734643178072041}
+  m_Father: {fileID: 8544700722471038800}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 130, y: 0}
+  m_Pivot: {x: 1, y: 0.5}
+--- !u!1 &3474911448849509803
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7228324214470216984}
+  - component: {fileID: 2194908040139220715}
+  - component: {fileID: 6504331657829573555}
+  m_Layer: 9
+  m_Name: Checkmark
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7228324214470216984
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3474911448849509803}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5852734643178072041}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -35, y: 0}
+  m_SizeDelta: {x: 50, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2194908040139220715
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3474911448849509803}
+  m_CullTransparentMesh: 1
+--- !u!114 &6504331657829573555
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3474911448849509803}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 2100000, guid: 400aab2496c5028449f88f0184de3e3b, type: 2}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: a336a8280e1dda94fbef1a59936ed578, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &3991425674623522493
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5852734643178072041}
+  - component: {fileID: 1122593010144335316}
+  - component: {fileID: 424729567652196656}
+  m_Layer: 9
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5852734643178072041
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3991425674623522493}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7228324214470216984}
+  m_Father: {fileID: 8372032557611025346}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1122593010144335316
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3991425674623522493}
+  m_CullTransparentMesh: 1
+--- !u!114 &424729567652196656
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3991425674623522493}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 2100000, guid: 400aab2496c5028449f88f0184de3e3b, type: 2}
+  m_Color: {r: 0.3529412, g: 0.3529412, b: 0.43529412, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: a336a8280e1dda94fbef1a59936ed578, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1.75
+--- !u!1001 &1851366345059556463
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 682069729901212213, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_Name
+      value: PE Section Toggle
+      objectReference: {fileID: 0}
+    - target: {fileID: 1414218821371179746, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1414218821371179746, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1414218821371179746, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1414218821371179746, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1414218821371179746, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1453993739021371305, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1453993739021371305, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1453993739021371305, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1453993739021371305, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1453993739021371305, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1453993739021371305, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1453993739021371305, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 901
+      objectReference: {fileID: 0}
+    - target: {fileID: 1453993739021371305, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1453993739021371305, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1453993739021371305, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1453993739021371305, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1453993739021371305, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1453993739021371305, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1453993739021371305, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1453993739021371305, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1453993739021371305, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 466.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1453993739021371305, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1453993739021371305, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1453993739021371305, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1453993739021371305, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2076803988945981323, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2076803988945981323, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2076803988945981323, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2076803988945981323, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2076803988945981323, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2076803988945981323, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2695670721113310902, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_Material
+      value: 
+      objectReference: {fileID: 2100000, guid: 400aab2496c5028449f88f0184de3e3b, type: 2}
+    - target: {fileID: 3263669264447411214, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_Material
+      value: 
+      objectReference: {fileID: 2100000, guid: 400aab2496c5028449f88f0184de3e3b, type: 2}
+    - target: {fileID: 3263669264447411214, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_RaycastTarget
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5694186965103729849, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5694186965103729849, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5694186965103729849, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5694186965103729849, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5694186965103729849, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5694186965103729849, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6206298811529862929, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6206298811529862929, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6206298811529862929, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6206298811529862929, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6206298811529862929, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6206298811529862929, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7078463098538894437, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_Material
+      value: 
+      objectReference: {fileID: 2100000, guid: 400aab2496c5028449f88f0184de3e3b, type: 2}
+    - target: {fileID: 7078463098538894437, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_RaycastTarget
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7562956730987566487, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7562956730987566487, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7562956730987566487, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7562956730987566487, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7562956730987566487, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7562956730987566487, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009018518866211647, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009018518866211647, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009018518866211647, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009018518866211647, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009018518866211647, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8009018518866211647, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9054833079585433203, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9054833079585433203, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9054833079585433203, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9054833079585433203, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9054833079585433203, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 8009018518866211647, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 8372032557611025346}
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 682069729901212213, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 798007477887917358}
+    - targetCorrespondingSourceObject: {fileID: 682069729901212213, guid: c291cad985c051346b5516c30fda2029, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1750356860778149787}
+  m_SourcePrefab: {fileID: 100100000, guid: c291cad985c051346b5516c30fda2029, type: 3}
+--- !u!1 &1208773602798579290 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 682069729901212213, guid: c291cad985c051346b5516c30fda2029, type: 3}
+  m_PrefabInstance: {fileID: 1851366345059556463}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &798007477887917358
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1208773602798579290}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 4384726876132874969}
+  toggleTransition: 0
+  graphic: {fileID: 0}
+  m_Group: {fileID: 0}
+  onValueChanged:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1750356860778149787}
+        m_TargetAssemblyTypeName: Basis.BasisUI.PanelSectionToggle, Basis Framework
+        m_MethodName: OnComponentUsed
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: _OnComponentUsed
+          m_BoolArgument: 0
+        m_CallState: 2
+  m_IsOn: 1
+--- !u!114 &1750356860778149787
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1208773602798579290}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 794ac7aa378676d41b5d1eafab097e3f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Basis Framework::Basis.BasisUI.PanelSectionToggle
+  ToggleComponent: {fileID: 798007477887917358}
+  ToggleVisual: {fileID: 7228324214470216984}
+  Background: {fileID: 0}
+--- !u!114 &4384726876132874969 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2695670721113310902, guid: c291cad985c051346b5516c30fda2029, type: 3}
+  m_PrefabInstance: {fileID: 1851366345059556463}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1208773602798579290}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &8544700722471038800 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8009018518866211647, guid: c291cad985c051346b5516c30fda2029, type: 3}
+  m_PrefabInstance: {fileID: 1851366345059556463}
+  m_PrefabAsset: {fileID: 0}

--- a/Basis/Packages/com.basis.sdk/Prefabs/Panel Elements/PE Section Toggle.prefab.meta
+++ b/Basis/Packages/com.basis.sdk/Prefabs/Panel Elements/PE Section Toggle.prefab.meta
@@ -2,6 +2,6 @@ fileFormatVersion: 2
 guid: 91d6c9e2a4fa4ff28d51ab0d8788b99e
 PrefabImporter:
   externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Basis/Packages/com.basis.sdk/Prefabs/Panel Elements/PE Section Toggle.prefab.meta
+++ b/Basis/Packages/com.basis.sdk/Prefabs/Panel Elements/PE Section Toggle.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 91d6c9e2a4fa4ff28d51ab0d8788b99e
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
* Adds an easily collapsible menu section for Basis UI.
<img width="1176" height="928" alt="image" src="https://github.com/user-attachments/assets/19f82788-48a7-46d3-a7d9-8b128dace906" />
<img width="1176" height="928" alt="image" src="https://github.com/user-attachments/assets/d8e33f7e-d470-4c26-9479-400862bd0a90" />


## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [x] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — `BasisEventDriver` runs the single per-frame tick that drives the whole framework (network apply, local player sim, blendshapes, JigglePhysics, nameplates, and more) as one sequential chain. An unhandled exception anywhere in that chain aborts the rest of the tick, so every step after the throwing one is silently skipped for that frame. New work added to the driver must either be guaranteed not to throw, or be wrapped in a `try`/`catch` that contains the failure and surfaces it through `BasisDebug` — logged once / rate-limited, never every frame (see the existing `HVRBasisBuiltInAddresses.Simulate()` guard for the pattern). Expect this to be scrutinized closely in review.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [x] Windows
- [ ] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [ ] Tested in VR (note headset under **Notes**)
- [ ] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [ ] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [ ] N/A — change does not touch any of the above

## Notes
<!-- Optional context for reviewers. Headset model, why a required box is N/A, anything else worth knowing. -->
