### PR TITLE
Fix Issues in the current Developer branch

### DIFF
--- a/Basis Server/BasisNetworkServer/BasisNetworking/BasisDatabase.cs
+++ b/Basis Server/BasisNetworkServer/BasisNetworking/BasisDatabase.cs
@@ -29,6 +29,7 @@ namespace BasisNetworkServer.BasisNetworking
     public static class BasisPersistentDatabase
     {
         private static readonly ConcurrentDictionary<string, BasisData> _dataByName = new();
+        private static readonly object _dataLock = new();
         private static readonly object _fileLock = new();
 
         private static string _filePath = "basis_data.json";
@@ -72,18 +73,24 @@ namespace BasisNetworkServer.BasisNetworking
                 BNL.LogError("Payload exceeds maximum entry count. (basis database)");
                 return false;
             }
-            if (!_dataByName.ContainsKey(item.Name) && _dataByName.Count >= BasisNetworkServer.Security.BasisResourceLimitManager.MaxDatabaseEntries)
+            lock (_dataLock)
             {
-                BNL.LogError("Database entry limit reached; rejecting new entry. (basis database)");
-                return false;
-            }
-            _dataByName.AddOrUpdate(item.Name,
-                addValueFactory: _ => item,
-                updateValueFactory: (_, existing) =>
+                if (_dataByName.TryGetValue(item.Name, out BasisData existing))
                 {
-                    existing.JsonPayload = new ConcurrentDictionary<string, object>(item.JsonPayload);
-                    return existing;
-                });
+                    existing.JsonPayload = item.JsonPayload != null
+                        ? new ConcurrentDictionary<string, object>(item.JsonPayload)
+                        : new ConcurrentDictionary<string, object>();
+                }
+                else
+                {
+                    if (_dataByName.Count >= BasisNetworkServer.Security.BasisResourceLimitManager.MaxDatabaseEntries)
+                    {
+                        BNL.LogError("Database entry limit reached; rejecting new entry. (basis database)");
+                        return false;
+                    }
+                    _dataByName[item.Name] = item;
+                }
+            }
 
             MarkDirty();
             return true;
@@ -103,7 +110,11 @@ namespace BasisNetworkServer.BasisNetworking
         public static bool Remove(string name)
         {
             if (string.IsNullOrWhiteSpace(name)) return false;
-            var result = _dataByName.TryRemove(name, out _);
+            bool result;
+            lock (_dataLock)
+            {
+                result = _dataByName.TryRemove(name, out _);
+            }
             if (result) MarkDirty();
             return result;
         }
@@ -120,16 +131,19 @@ namespace BasisNetworkServer.BasisNetworking
             {
                 try
                 {
-                    var list = GetAll().ToList();
-
-                    using var stream = new FileStream(_filePath, FileMode.Create, FileAccess.Write, FileShare.None);
-                    var serializer = new DataContractJsonSerializer(typeof(List<BasisData>), new DataContractJsonSerializerSettings
+                    lock (_dataLock)
                     {
-                        UseSimpleDictionaryFormat = true
-                    });
+                        var list = _dataByName.Values.ToList();
 
-                    serializer.WriteObject(stream, list);
-                    _isDirty = false;
+                        using var stream = new FileStream(_filePath, FileMode.Create, FileAccess.Write, FileShare.None);
+                        var serializer = new DataContractJsonSerializer(typeof(List<BasisData>), new DataContractJsonSerializerSettings
+                        {
+                            UseSimpleDictionaryFormat = true
+                        });
+
+                        serializer.WriteObject(stream, list);
+                        _isDirty = false;
+                    }
                 }
                 catch (IOException ex)
                 {
@@ -155,11 +169,15 @@ namespace BasisNetworkServer.BasisNetworking
 
                     if (serializer.ReadObject(stream) is List<BasisData> loadedData)
                     {
-                        _dataByName.Clear();
-                        foreach (var item in loadedData)
+                        lock (_dataLock)
                         {
-                            if (!string.IsNullOrWhiteSpace(item.Name))
-                                _dataByName[item.Name] = item;
+                            _dataByName.Clear();
+                            foreach (var item in loadedData)
+                            {
+                                if (!string.IsNullOrWhiteSpace(item.Name))
+                                    _dataByName[item.Name] = item;
+                            }
+                            _isDirty = false;
                         }
                     }
                 }

--- a/Basis Server/BasisNetworkServer/BasisNetworking/BasisDatabase.cs
+++ b/Basis Server/BasisNetworkServer/BasisNetworking/BasisDatabase.cs
@@ -29,8 +29,13 @@ namespace BasisNetworkServer.BasisNetworking
     public static class BasisPersistentDatabase
     {
         private static readonly ConcurrentDictionary<string, BasisData> _dataByName = new();
+#if NET9_0_OR_GREATER
+        private static readonly Lock _dataLock = new();
+        private static readonly Lock _fileLock = new();
+#else
         private static readonly object _dataLock = new();
         private static readonly object _fileLock = new();
+#endif
 
         private static string _filePath = "basis_data.json";
         private static volatile bool _isDirty = false;

--- a/Basis/Packages/com.basis.framework/Device Management/EyeTracking/BasisEyeTrackingManager.cs
+++ b/Basis/Packages/com.basis.framework/Device Management/EyeTracking/BasisEyeTrackingManager.cs
@@ -105,10 +105,7 @@ namespace Basis.Scripts.Device_Management.EyeTracking
             }
 
             bool hmdGaze = hmdHas && (hmdData.HasWorldRay || hmdData.HasPerEyeAngles);
-            if (hmdGaze)
-            {
-                _lastHmdActiveTime = Time.unscaledTime;
-            }
+            if (hmdGaze) _lastHmdActiveTime = Time.unscaledTime;
             bool oscGaze = oscHas && (oscData.HasWorldRay || oscData.HasPerEyeAngles);
 
             BasisEyeTrackingData merged = default;

--- a/Basis/Packages/com.basis.framework/Device Management/EyeTracking/BasisEyeTrackingManager.cs
+++ b/Basis/Packages/com.basis.framework/Device Management/EyeTracking/BasisEyeTrackingManager.cs
@@ -105,6 +105,10 @@ namespace Basis.Scripts.Device_Management.EyeTracking
             }
 
             bool hmdGaze = hmdHas && (hmdData.HasWorldRay || hmdData.HasPerEyeAngles);
+            if (hmdGaze)
+            {
+                _lastHmdActiveTime = Time.unscaledTime;
+            }
             bool oscGaze = oscHas && (oscData.HasWorldRay || oscData.HasPerEyeAngles);
 
             BasisEyeTrackingData merged = default;

--- a/Basis/Packages/com.basis.framework/Networking/Object Sync/BasisObjectSyncNetworking.cs.meta
+++ b/Basis/Packages/com.basis.framework/Networking/Object Sync/BasisObjectSyncNetworking.cs.meta
@@ -1,2 +1,2 @@
 fileFormatVersion: 2
-guid: 52a9ea38cfa7aca4ebec1aec993bbb64
+guid: d2aa9116619ed954aa8e19d984b58ada

--- a/Basis/Packages/com.basis.framework/Networking/Object Sync/BasisPickupSyncNetworking.cs.meta
+++ b/Basis/Packages/com.basis.framework/Networking/Object Sync/BasisPickupSyncNetworking.cs.meta
@@ -1,2 +1,2 @@
 fileFormatVersion: 2
-guid: d2aa9116619ed954aa8e19d984b58ada
+guid: 52a9ea38cfa7aca4ebec1aec993bbb64

--- a/Basis/Packages/com.basis.framework/Networking/Sync/BasisSyncCodec.cs
+++ b/Basis/Packages/com.basis.framework/Networking/Sync/BasisSyncCodec.cs
@@ -438,7 +438,12 @@ namespace Basis.Scripts.Networking.Sync
                 for (int i = 0; i < bits; i++)
                 {
                     if (((_buf[_byte] >> _bit) & 1) != 0) value |= 1u << i;
-                    AdvanceBit();
+                    //Advance Bit
+                    if (++_bit == 8)
+                    {
+                        _bit = 0;
+                        _byte++;
+                    }
                 }
                 return true;
             }
@@ -457,15 +462,6 @@ namespace Basis.Scripts.Networking.Sync
                 if (bits < 0 || bits > 32) return false;
                 int available = ((_limit - _byte) << 3) - _bit;
                 return available >= bits;
-            }
-
-            private void AdvanceBit()
-            {
-                if (++_bit == 8)
-                {
-                    _bit = 0;
-                    _byte++;
-                }
             }
         }
     }

--- a/Basis/Packages/com.basis.framework/Networking/Sync/BasisSyncCodec.cs
+++ b/Basis/Packages/com.basis.framework/Networking/Sync/BasisSyncCodec.cs
@@ -138,6 +138,7 @@ namespace Basis.Scripts.Networking.Sync
 
             if (keyframe)
             {
+                // Preflight the packet so rejected/truncated data never partially mutates the baseline.
                 var verify = new BitReader(buf, o, length);
                 for (int fi = 0; fi < fieldCount; fi++)
                 {
@@ -156,6 +157,7 @@ namespace Basis.Scripts.Networking.Sync
                 o += schema.DirtyMaskBytes;
                 if (o > length) return false;
 
+                // Preflight the packet so rejected/truncated data never partially mutates the baseline.
                 var verify = new BitReader(buf, o, length);
                 for (int fi = 0; fi < fieldCount; fi++)
                 {

--- a/Basis/Packages/com.basis.framework/Networking/Sync/BasisSyncCodec.cs
+++ b/Basis/Packages/com.basis.framework/Networking/Sync/BasisSyncCodec.cs
@@ -103,7 +103,7 @@ namespace Basis.Scripts.Networking.Sync
         /// <summary>True if the trailing 2-byte Fletcher-16 matches the packet body. Call before trusting a packet's sequence/values.</summary>
         public static bool VerifyChecksum(byte[] buf, int length)
         {
-            if (buf == null || length < HeaderSize + ChecksumSize) return false;
+            if (buf == null || length < HeaderSize + ChecksumSize || length > buf.Length) return false;
             int payloadLen = length - ChecksumSize;
             ushort expected = Fletcher16(buf, payloadLen);
             ushort actual = (ushort)(buf[payloadLen] | (buf[payloadLen + 1] << 8));
@@ -126,7 +126,7 @@ namespace Basis.Scripts.Networking.Sync
             seq = 0;
             keyframe = false;
             intervalMs = 0;
-            if (buf == null || length < HeaderSize) return false;
+            if (buf == null || length < HeaderSize || length > buf.Length) return false;
 
             int o = 0;
             seq = buf[o++];
@@ -134,23 +134,44 @@ namespace Basis.Scripts.Networking.Sync
             keyframe = (flags & FlagKeyframe) != 0;
             intervalMs = (ushort)(buf[o] | (buf[o + 1] << 8));
             o += 2;
+            int fieldCount = schema.FieldCount;
 
             if (keyframe)
             {
+                var verify = new BitReader(buf, o, length);
+                for (int fi = 0; fi < fieldCount; fi++)
+                {
+                    if (!SkipField(schema, schema.GetField(fi), ref verify)) return false;
+                }
+
                 var r = new BitReader(buf, o, length);
-                for (int fi = 0; fi < schema.FieldCount; fi++)
-                    DecodeField(schema, schema.GetField(fi), baseline, ref r);
+                for (int fi = 0; fi < fieldCount; fi++)
+                {
+                    if (!DecodeField(schema, schema.GetField(fi), baseline, ref r)) return false;
+                }
             }
             else
             {
                 int maskStart = o;
                 o += schema.DirtyMaskBytes;
                 if (o > length) return false;
-                var r = new BitReader(buf, o, length);
-                for (int fi = 0; fi < schema.FieldCount; fi++)
+
+                var verify = new BitReader(buf, o, length);
+                for (int fi = 0; fi < fieldCount; fi++)
                 {
                     if ((buf[maskStart + (fi >> 3)] & (1 << (fi & 7))) != 0)
-                        DecodeField(schema, schema.GetField(fi), baseline, ref r);
+                    {
+                        if (!SkipField(schema, schema.GetField(fi), ref verify)) return false;
+                    }
+                }
+
+                var r = new BitReader(buf, o, length);
+                for (int fi = 0; fi < fieldCount; fi++)
+                {
+                    if ((buf[maskStart + (fi >> 3)] & (1 << (fi & 7))) != 0)
+                    {
+                        if (!DecodeField(schema, schema.GetField(fi), baseline, ref r)) return false;
+                    }
                 }
             }
             return true;
@@ -187,7 +208,7 @@ namespace Basis.Scripts.Networking.Sync
             }
         }
 
-        private static void DecodeField(BasisSyncSchema schema, in BasisSyncField f, BasisSyncValues v, ref BitReader r)
+        private static bool DecodeField(BasisSyncSchema schema, in BasisSyncField f, BasisSyncValues v, ref BitReader r)
         {
             switch (f.Pool)
             {
@@ -195,12 +216,13 @@ namespace Basis.Scripts.Networking.Sync
                     for (int c = 0; c < f.ContComponents; c++)
                     {
                         int ci = f.Offset + c;
-                        v.Cont[ci] = DecodeCont(ref r, schema.QuantMode(ci), schema.QuantMin(ci), schema.QuantMax(ci), schema.QuantBits(ci));
+                        if (!TryDecodeCont(ref r, schema.QuantMode(ci), schema.QuantMin(ci), schema.QuantMax(ci), schema.QuantBits(ci), out float value)) return false;
+                        v.Cont[ci] = value;
                     }
                     break;
                 case BasisSyncPool.Rotation:
                 {
-                    uint packed = r.ReadBits(32);
+                    if (!r.TryReadBits(32, out uint packed)) return false;
                     UnityEngine.Quaternion uq = BasisCompression.QuaternionCompressor.DecompressQuaternion(packed);
                     v.Rot[f.Offset] = new quaternion(uq.x, uq.y, uq.z, uq.w);
                     break;
@@ -208,13 +230,65 @@ namespace Basis.Scripts.Networking.Sync
                 default:
                     switch (f.Type)
                     {
-                        case BasisSyncFieldType.Bool: v.Disc[f.Offset] = r.ReadBits(1) != 0 ? 1 : 0; break;
-                        case BasisSyncFieldType.Byte: v.Disc[f.Offset] = (int)r.ReadBits(8); break;
-                        case BasisSyncFieldType.UShort: v.Disc[f.Offset] = (int)r.ReadBits(16); break;
-                        case BasisSyncFieldType.UInt: v.Disc[f.Offset] = (int)ReadVarUInt(ref r); break;
-                        default: v.Disc[f.Offset] = ReadVarInt(ref r); break;
+                        case BasisSyncFieldType.Bool:
+                        {
+                            if (!r.TryReadBits(1, out uint value)) return false;
+                            v.Disc[f.Offset] = value != 0 ? 1 : 0;
+                            break;
+                        }
+                        case BasisSyncFieldType.Byte:
+                        {
+                            if (!r.TryReadBits(8, out uint value)) return false;
+                            v.Disc[f.Offset] = (int)value;
+                            break;
+                        }
+                        case BasisSyncFieldType.UShort:
+                        {
+                            if (!r.TryReadBits(16, out uint value)) return false;
+                            v.Disc[f.Offset] = (int)value;
+                            break;
+                        }
+                        case BasisSyncFieldType.UInt:
+                        {
+                            if (!TryReadVarUInt(ref r, out uint value)) return false;
+                            v.Disc[f.Offset] = (int)value;
+                            break;
+                        }
+                        default:
+                        {
+                            if (!TryReadVarInt(ref r, out int value)) return false;
+                            v.Disc[f.Offset] = value;
+                            break;
+                        }
                     }
                     break;
+            }
+            return true;
+        }
+
+        private static bool SkipField(BasisSyncSchema schema, in BasisSyncField f, ref BitReader r)
+        {
+            switch (f.Pool)
+            {
+                case BasisSyncPool.Continuous:
+                    for (int c = 0; c < f.ContComponents; c++)
+                    {
+                        if (!r.SkipBits(ContBits(schema, f.Offset + c))) return false;
+                    }
+                    return true;
+                case BasisSyncPool.Rotation:
+                    return r.SkipBits(32);
+                default:
+                    switch (f.Type)
+                    {
+                        case BasisSyncFieldType.Bool: return r.SkipBits(1);
+                        case BasisSyncFieldType.Byte: return r.SkipBits(8);
+                        case BasisSyncFieldType.UShort: return r.SkipBits(16);
+                        case BasisSyncFieldType.UInt:
+                        default:
+                            uint ignored;
+                            return TryReadVarUInt(ref r, out ignored);
+                    }
             }
         }
 
@@ -241,30 +315,42 @@ namespace Basis.Scripts.Networking.Sync
             }
         }
 
-        private static float DecodeCont(ref BitReader r, BasisQuantMode mode, float min, float max, int bits)
+        private static bool TryDecodeCont(ref BitReader r, BasisQuantMode mode, float min, float max, int bits, out float value)
         {
+            value = 0f;
             switch (mode)
             {
                 case BasisQuantMode.Half:
-                    return math.f16tof32(r.ReadBits(16));
+                {
+                    if (!r.TryReadBits(16, out uint raw)) return false;
+                    value = math.f16tof32(raw);
+                    return true;
+                }
                 case BasisQuantMode.Ranged:
                 {
                     int b = ClampBits(bits);
                     uint maxQ = (1u << b) - 1u;
-                    uint q = r.ReadBits(b);
-                    return min + (q / (float)maxQ) * (max - min);
+                    if (!r.TryReadBits(b, out uint q)) return false;
+                    value = min + (q / (float)maxQ) * (max - min);
+                    return true;
                 }
                 default:
-                    return BitsToFloat(r.ReadBits(32));
+                {
+                    if (!r.TryReadBits(32, out uint raw)) return false;
+                    value = BitsToFloat(raw);
+                    return true;
+                }
             }
         }
 
         private static void WriteVarInt(ref BitWriter w, int value) => WriteVarUInt(ref w, (uint)((value << 1) ^ (value >> 31)));
 
-        private static int ReadVarInt(ref BitReader r)
+        private static bool TryReadVarInt(ref BitReader r, out int value)
         {
-            uint zig = ReadVarUInt(ref r);
-            return (int)(zig >> 1) ^ -(int)(zig & 1);
+            value = 0;
+            if (!TryReadVarUInt(ref r, out uint zig)) return false;
+            value = (int)(zig >> 1) ^ -(int)(zig & 1);
+            return true;
         }
 
         private static void WriteVarUInt(ref BitWriter w, uint v)
@@ -277,18 +363,20 @@ namespace Basis.Scripts.Networking.Sync
             w.WriteBits(v, 8);
         }
 
-        private static uint ReadVarUInt(ref BitReader r)
+        private static bool TryReadVarUInt(ref BitReader r, out uint value)
         {
-            uint val = 0;
+            value = 0;
             int shift = 0;
-            while (shift <= 35)
+            for (int count = 0; count < 5; count++)
             {
-                byte b = (byte)r.ReadBits(8);
-                val |= (uint)(b & 0x7F) << shift;
-                if ((b & 0x80) == 0) break;
+                if (!r.TryReadBits(8, out uint raw)) return false;
+                byte b = (byte)raw;
+                if (count == 4 && (b & 0xF0) != 0) return false;
+                value |= (uint)(b & 0x7F) << shift;
+                if ((b & 0x80) == 0) return true;
                 shift += 7;
             }
-            return val;
+            return false;
         }
 
         private static unsafe uint FloatToBits(float v) => *(uint*)&v;
@@ -326,7 +414,7 @@ namespace Basis.Scripts.Networking.Sync
             public int ByteLength => _byte + (_bit > 0 ? 1 : 0);
         }
 
-        /// <summary>LSB-first bit reader; returns 0 once the byte limit is exhausted (corrupt/truncated safe).</summary>
+        /// <summary>LSB-first bit reader with explicit bounds checks for corrupt/truncated packets.</summary>
         private struct BitReader
         {
             private readonly byte[] _buf;
@@ -342,15 +430,42 @@ namespace Basis.Scripts.Networking.Sync
                 _limit = limitBytes < buf.Length ? limitBytes : buf.Length;
             }
 
-            public uint ReadBits(int bits)
+            public bool TryReadBits(int bits, out uint value)
             {
-                uint v = 0;
+                value = 0;
+                if (!CanReadBits(bits)) return false;
+
                 for (int i = 0; i < bits; i++)
                 {
-                    if (_byte < _limit && ((_buf[_byte] >> _bit) & 1) != 0) v |= 1u << i;
-                    if (++_bit == 8) { _bit = 0; _byte++; }
+                    if (((_buf[_byte] >> _bit) & 1) != 0) value |= 1u << i;
+                    AdvanceBit();
                 }
-                return v;
+                return true;
+            }
+
+            public bool SkipBits(int bits)
+            {
+                if (!CanReadBits(bits)) return false;
+                int total = _bit + bits;
+                _byte += total >> 3;
+                _bit = total & 7;
+                return true;
+            }
+
+            private bool CanReadBits(int bits)
+            {
+                if (bits < 0 || bits > 32) return false;
+                int available = ((_limit - _byte) << 3) - _bit;
+                return available >= bits;
+            }
+
+            private void AdvanceBit()
+            {
+                if (++_bit == 8)
+                {
+                    _bit = 0;
+                    _byte++;
+                }
             }
         }
     }

--- a/Basis/Packages/com.basis.framework/Networking/Sync/BasisSyncReceiver.cs
+++ b/Basis/Packages/com.basis.framework/Networking/Sync/BasisSyncReceiver.cs
@@ -94,7 +94,7 @@ namespace Basis.Scripts.Networking.Sync
 
         public void OnPacket(byte[] payload, int length)
         {
-            if (payload == null || length < BasisSyncCodec.HeaderSize) return;
+            if (payload == null || length < BasisSyncCodec.HeaderSize || length > payload.Length || length > _maxPacket) return;
             // Drop corrupted packets before they touch the sequence/baseline, so a corrupted sequence number
             // can't poison the high-water-mark and a corrupted value is never applied.
             if (_verifyChecksum && !BasisSyncCodec.VerifyChecksum(payload, length)) return;

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/BasisNetworking/BasisDatabase.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/BasisNetworking/BasisDatabase.cs
@@ -84,10 +84,10 @@ namespace BasisNetworkServer.BasisNetworking
                 else
                 {
                     if (_dataByName.Count >= BasisNetworkServer.Security.BasisResourceLimitManager.MaxDatabaseEntries)
-                    {
-                        BNL.LogError("Database entry limit reached; rejecting new entry. (basis database)");
-                        return false;
-                    }
+                {
+                    BNL.LogError("Database entry limit reached; rejecting new entry. (basis database)");
+                    return false;
+                }
                     _dataByName[item.Name] = item;
                 }
             }
@@ -110,7 +110,11 @@ namespace BasisNetworkServer.BasisNetworking
         public static bool Remove(string name)
         {
             if (string.IsNullOrWhiteSpace(name)) return false;
-            var result = _dataByName.TryRemove(name, out _);
+            bool result;
+            lock (_dataLock)
+            {
+                result = _dataByName.TryRemove(name, out _);
+            }
             if (result) MarkDirty();
             return result;
         }
@@ -127,16 +131,19 @@ namespace BasisNetworkServer.BasisNetworking
             {
                 try
                 {
-                    var list = GetAll().ToList();
-
-                    using var stream = new FileStream(_filePath, FileMode.Create, FileAccess.Write, FileShare.None);
-                    var serializer = new DataContractJsonSerializer(typeof(List<BasisData>), new DataContractJsonSerializerSettings
+                    lock (_dataLock)
                     {
-                        UseSimpleDictionaryFormat = true
-                    });
+                        var list = _dataByName.Values.ToList();
 
-                    serializer.WriteObject(stream, list);
-                    _isDirty = false;
+                        using var stream = new FileStream(_filePath, FileMode.Create, FileAccess.Write, FileShare.None);
+                        var serializer = new DataContractJsonSerializer(typeof(List<BasisData>), new DataContractJsonSerializerSettings
+                        {
+                            UseSimpleDictionaryFormat = true
+                        });
+
+                        serializer.WriteObject(stream, list);
+                        _isDirty = false;
+                    }
                 }
                 catch (IOException ex)
                 {
@@ -162,11 +169,15 @@ namespace BasisNetworkServer.BasisNetworking
 
                     if (serializer.ReadObject(stream) is List<BasisData> loadedData)
                     {
-                        _dataByName.Clear();
-                        foreach (var item in loadedData)
+                        lock (_dataLock)
                         {
-                            if (!string.IsNullOrWhiteSpace(item.Name))
-                                _dataByName[item.Name] = item;
+                            _dataByName.Clear();
+                            foreach (var item in loadedData)
+                            {
+                                if (!string.IsNullOrWhiteSpace(item.Name))
+                                    _dataByName[item.Name] = item;
+                            }
+                            _isDirty = false;
                         }
                     }
                 }

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/BasisNetworking/BasisDatabase.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/BasisNetworking/BasisDatabase.cs
@@ -29,8 +29,13 @@ namespace BasisNetworkServer.BasisNetworking
     public static class BasisPersistentDatabase
     {
         private static readonly ConcurrentDictionary<string, BasisData> _dataByName = new();
+#if NET9_0_OR_GREATER
+        private static readonly Lock _dataLock = new();
+        private static readonly Lock _fileLock = new();
+#else
         private static readonly object _dataLock = new();
         private static readonly object _fileLock = new();
+#endif
 
         private static string _filePath = "basis_data.json";
         private static volatile bool _isDirty = false;

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/BasisNetworking/BasisDatabase.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/BasisNetworking/BasisDatabase.cs
@@ -77,7 +77,9 @@ namespace BasisNetworkServer.BasisNetworking
             {
                 if (_dataByName.TryGetValue(item.Name, out BasisData existing))
                 {
-                    existing.JsonPayload = new ConcurrentDictionary<string, object>(item.JsonPayload);
+                    existing.JsonPayload = item.JsonPayload != null
+                        ? new ConcurrentDictionary<string, object>(item.JsonPayload)
+                        : new ConcurrentDictionary<string, object>();
                 }
                 else
                 {

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/BasisNetworking/BasisDatabase.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/BasisNetworking/BasisDatabase.cs
@@ -29,6 +29,7 @@ namespace BasisNetworkServer.BasisNetworking
     public static class BasisPersistentDatabase
     {
         private static readonly ConcurrentDictionary<string, BasisData> _dataByName = new();
+        private static readonly object _dataLock = new();
         private static readonly object _fileLock = new();
 
         private static string _filePath = "basis_data.json";
@@ -72,18 +73,22 @@ namespace BasisNetworkServer.BasisNetworking
                 BNL.LogError("Payload exceeds maximum entry count. (basis database)");
                 return false;
             }
-            if (!_dataByName.ContainsKey(item.Name) && _dataByName.Count >= BasisNetworkServer.Security.BasisResourceLimitManager.MaxDatabaseEntries)
+            lock (_dataLock)
             {
-                BNL.LogError("Database entry limit reached; rejecting new entry. (basis database)");
-                return false;
-            }
-            _dataByName.AddOrUpdate(item.Name,
-                addValueFactory: _ => item,
-                updateValueFactory: (_, existing) =>
+                if (_dataByName.TryGetValue(item.Name, out BasisData existing))
                 {
                     existing.JsonPayload = new ConcurrentDictionary<string, object>(item.JsonPayload);
-                    return existing;
-                });
+                }
+                else
+                {
+                    if (_dataByName.Count >= BasisNetworkServer.Security.BasisResourceLimitManager.MaxDatabaseEntries)
+                    {
+                        BNL.LogError("Database entry limit reached; rejecting new entry. (basis database)");
+                        return false;
+                    }
+                    _dataByName[item.Name] = item;
+                }
+            }
 
             MarkDirty();
             return true;


### PR DESCRIPTION
## Summary
Improvements to Reliability and packet serialization decoding.

   - Updates HMD eye-tracking presence when HMD gaze data is present, allowing gaze-driven systems such as foveation to
 detect active HMD eye tracking.
   - Hardens `BasisSyncReceiver.OnPacket()` against invalid packet lengths before queueing packets.
   - Hardens `BasisSyncCodec.Deserialize()` against malformed/truncated sync packets by validating packet bounds before
 decoding and avoiding partial baseline mutation.
   - Makes persistent database add/update capacity enforcement atomic by locking the check + insert/update path.
   - Restores legacy Object Sync script GUID compatibility by keeping existing serialized prefab references pointed at
 `BasisObjectSyncNetworking`.

## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [ ] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — `BasisEventDriver` runs the single per-frame tick that drives the whole framework (network apply, local player sim, blendshapes, JigglePhysics, nameplates, and more) as one sequential chain. An unhandled exception anywhere in that chain aborts the rest of the tick, so every step after the throwing one is silently skipped for that frame. New work added to the driver must either be guaranteed not to throw, or be wrapped in a `try`/`catch` that contains the failure and surfaces it through `BasisDebug` — logged once / rate-limited, never every frame (see the existing `HVRBasisBuiltInAddresses.Simulate()` guard for the pattern). Expect this to be scrutinized closely in review.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [ ] Windows
- [ ] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [ ] Tested in VR (note headset under **Notes**)
- [ ] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [ ] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [ ] N/A — change does not touch any of the above

## Notes
<!-- Optional context for reviewers. Headset model, why a required box is N/A, anything else worth knowing. -->
