### PR TITLE
Validation fixes

### DIFF
--- a/Basis/Packages/com.basis.framework/Networking/Sync/BasisSyncedRigidbody.cs
+++ b/Basis/Packages/com.basis.framework/Networking/Sync/BasisSyncedRigidbody.cs
@@ -149,7 +149,11 @@ namespace Basis.Scripts.Networking.Sync
             if (Body == null) return;
             Vector3 p = Body.position;
             Quaternion r = Body.rotation;
-            if (RelativeTo != null) p = RelativeTo.InverseTransformPoint(p);
+            if (RelativeTo != null)
+            {
+                p = RelativeTo.InverseTransformPoint(p);
+                r = Quaternion.Inverse(RelativeTo.rotation) * r;
+            }
 
             if (_posX.IsValid) LocalSet(_posX, p.x);
             if (_posY.IsValid) LocalSet(_posY, p.y);
@@ -209,11 +213,12 @@ namespace Basis.Scripts.Networking.Sync
 
             Vector3 p = Body.position;
             Quaternion r = Body.rotation;
+            bool hasSyncedPosition = _posX.IsValid;
+            bool hasSyncedRotation = _rotQuat.IsValid || _rotQw.IsValid || _rotEuler;
 
             if (_posX.IsValid) p.x = GetFloat(_posX);
             if (_posY.IsValid) p.y = GetFloat(_posY);
             if (_posZ.IsValid) p.z = GetFloat(_posZ);
-            if (RelativeTo != null && _posX.IsValid) p = RelativeTo.TransformPoint(p);
 
             if (_rotQuat.IsValid)
             {
@@ -232,6 +237,12 @@ namespace Basis.Scripts.Networking.Sync
             else if (_rotEuler)
             {
                 r = Quaternion.Euler(GetAngle(_eulerX), GetAngle(_eulerY), GetAngle(_eulerZ));
+            }
+
+            if (RelativeTo != null)
+            {
+                if (hasSyncedPosition) p = RelativeTo.TransformPoint(p);
+                if (hasSyncedRotation) r = RelativeTo.rotation * r;
             }
 
             if (DriveRemoteKinematic)

--- a/Basis/Packages/com.basis.framework/Networking/Sync/BasisSyncedTransform.cs
+++ b/Basis/Packages/com.basis.framework/Networking/Sync/BasisSyncedTransform.cs
@@ -140,7 +140,9 @@ namespace Basis.Scripts.Networking.Sync
                         if (RotationX || RotationY || RotationZ)
                         {
                             _rotEuler = true;
-                            _heldEuler = WorldSpace ? Target.eulerAngles : Target.localEulerAngles;
+                            _heldEuler = RelativeTo != null
+                                ? (Quaternion.Inverse(RelativeTo.rotation) * Target.rotation).eulerAngles
+                                : WorldSpace ? Target.eulerAngles : Target.localEulerAngles;
                             if (RotationX) _eulerX = RegisterAngle(RotCompX.ToSpec(), InterpolateRotation);
                             if (RotationY) _eulerY = RegisterAngle(RotCompY.ToSpec(), InterpolateRotation);
                             if (RotationZ) _eulerZ = RegisterAngle(RotCompZ.ToSpec(), InterpolateRotation);
@@ -188,9 +190,14 @@ namespace Basis.Scripts.Networking.Sync
 
             Vector3 p;
             Quaternion r;
-            if (WorldSpace) Target.GetPositionAndRotation(out p, out r);
+            if (RelativeTo != null)
+            {
+                Target.GetPositionAndRotation(out p, out r);
+                p = RelativeTo.InverseTransformPoint(p);
+                r = Quaternion.Inverse(RelativeTo.rotation) * r;
+            }
+            else if (WorldSpace) Target.GetPositionAndRotation(out p, out r);
             else Target.GetLocalPositionAndRotation(out p, out r);
-            if (RelativeTo != null) p = RelativeTo.InverseTransformPoint(Target.position);
 
             if (_posX.IsValid) LocalSet(_posX, p.x);
             if (_posY.IsValid) LocalSet(_posY, p.y);
@@ -209,7 +216,7 @@ namespace Basis.Scripts.Networking.Sync
             }
             else if (_rotEuler)
             {
-                Vector3 e = WorldSpace ? Target.eulerAngles : Target.localEulerAngles;
+                Vector3 e = r.eulerAngles;
                 if (_eulerX.IsValid) LocalSet(_eulerX, e.x);
                 if (_eulerY.IsValid) LocalSet(_eulerY, e.y);
                 if (_eulerZ.IsValid) LocalSet(_eulerZ, e.z);
@@ -279,9 +286,7 @@ namespace Basis.Scripts.Networking.Sync
 
             if (RelativeTo != null)
             {
-                Target.position = RelativeTo.TransformPoint(p);
-                if (WorldSpace) Target.rotation = r;
-                else Target.localRotation = r;
+                Target.SetPositionAndRotation(RelativeTo.TransformPoint(p), RelativeTo.rotation * r);
             }
             else if (WorldSpace) Target.SetPositionAndRotation(p, r);
             else Target.SetLocalPositionAndRotation(p, r);
@@ -300,10 +305,15 @@ namespace Basis.Scripts.Networking.Sync
             s = Vector3.one;
             if (Target == null) return false;
 
-            if (WorldSpace) Target.GetPositionAndRotation(out p, out r);
+            if (RelativeTo != null)
+            {
+                Target.GetPositionAndRotation(out p, out r);
+                p = RelativeTo.InverseTransformPoint(p);
+                r = Quaternion.Inverse(RelativeTo.rotation) * r;
+            }
+            else if (WorldSpace) Target.GetPositionAndRotation(out p, out r);
             else Target.GetLocalPositionAndRotation(out p, out r);
             s = Target.localScale;
-            if (RelativeTo != null) p = RelativeTo.InverseTransformPoint(Target.position);
 
             if (_posX.IsValid) p.x = GetFloat(_posX);
             if (_posY.IsValid) p.y = GetFloat(_posY);
@@ -354,7 +364,9 @@ namespace Basis.Scripts.Networking.Sync
 
             // Unsynced axes have no keyframe data — hold them at the Target's live value so the
             // from/to points sit on the real motion path.
-            Vector3 baseLocal = WorldSpace ? Target.position : Target.localPosition;
+            Vector3 baseLocal = RelativeTo != null
+                ? RelativeTo.InverseTransformPoint(Target.position)
+                : WorldSpace ? Target.position : Target.localPosition;
             Vector3 f = baseLocal;
             Vector3 t = baseLocal;
             if (_posX.IsValid) { int o = Schema.GetField(_posX.FieldIndex).Offset; f.x = from.Cont[o]; t.x = to.Cont[o]; }
@@ -362,7 +374,12 @@ namespace Basis.Scripts.Networking.Sync
             if (_posZ.IsValid) { int o = Schema.GetField(_posZ.FieldIndex).Offset; f.z = from.Cont[o]; t.z = to.Cont[o]; }
 
             Transform parent = Target.parent;
-            if (WorldSpace || parent == null)
+            if (RelativeTo != null)
+            {
+                fromWorld = RelativeTo.TransformPoint(f);
+                toWorld = RelativeTo.TransformPoint(t);
+            }
+            else if (WorldSpace || parent == null)
             {
                 fromWorld = f;
                 toWorld = t;

--- a/Basis/Packages/com.basis.imagepickup/BasisDesktopImageDropHook.cs
+++ b/Basis/Packages/com.basis.imagepickup/BasisDesktopImageDropHook.cs
@@ -21,10 +21,12 @@ namespace Basis.ImagePickup
         private delegate bool EnumThreadWindowProc(IntPtr hWnd, IntPtr lParam);
 
         [DllImport("kernel32.dll")] private static extern uint GetCurrentThreadId();
+        [DllImport("kernel32.dll")] private static extern void SetLastError(uint dwErrCode);
         [DllImport("user32.dll")] private static extern bool EnumThreadWindows(uint threadId, EnumThreadWindowProc callback, IntPtr lParam);
         [DllImport("user32.dll")] private static extern bool IsWindowVisible(IntPtr hWnd);
         [DllImport("user32.dll", SetLastError = true)] private static extern IntPtr SetWindowLongPtr(IntPtr hWnd, int index, IntPtr newLong);
         [DllImport("user32.dll")] private static extern IntPtr CallWindowProc(IntPtr previous, IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
+        [DllImport("user32.dll")] private static extern IntPtr DefWindowProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
         [DllImport("shell32.dll")] private static extern void DragAcceptFiles(IntPtr hWnd, bool accept);
         [DllImport("shell32.dll", CharSet = CharSet.Auto)] private static extern uint DragQueryFile(IntPtr hDrop, uint file, StringBuilder buffer, uint length);
         [DllImport("shell32.dll")] private static extern void DragFinish(IntPtr hDrop);
@@ -32,9 +34,12 @@ namespace Basis.ImagePickup
         private static BasisDesktopImageDropHook _instance;
         private static readonly WndProcDelegate _wndProcDelegate = HookedWndProc;
         private static IntPtr _foundWindow;
+        private static IntPtr _activePreviousWndProc = IntPtr.Zero;
+        private static IntPtr _activeWindowHandle = IntPtr.Zero;
 
         private IntPtr _windowHandle = IntPtr.Zero;
         private IntPtr _previousWndProc = IntPtr.Zero;
+        private bool _hookInstalled;
 
         private readonly List<string> _pending = new();
         private readonly object _pendingLock = new();
@@ -50,19 +55,42 @@ namespace Basis.ImagePickup
                 return;
             }
 
-            DragAcceptFiles(_windowHandle, true);
+            SetLastError(0);
             _previousWndProc = SetWindowLongPtr(_windowHandle, GWLP_WNDPROC, Marshal.GetFunctionPointerForDelegate(_wndProcDelegate));
+            int error = Marshal.GetLastWin32Error();
+            if (_previousWndProc == IntPtr.Zero && error != 0)
+            {
+                BasisDebug.LogWarning($"Image pickup: failed to subclass the player window ({error}); file drop disabled.");
+                _windowHandle = IntPtr.Zero;
+                if (_instance == this) _instance = null;
+                enabled = false;
+                return;
+            }
+
+            _hookInstalled = true;
+            _activeWindowHandle = _windowHandle;
+            _activePreviousWndProc = _previousWndProc;
+            DragAcceptFiles(_windowHandle, true);
         }
 
         private void OnDisable()
         {
-            if (_windowHandle != IntPtr.Zero && _previousWndProc != IntPtr.Zero)
+            if (_windowHandle != IntPtr.Zero)
             {
-                SetWindowLongPtr(_windowHandle, GWLP_WNDPROC, _previousWndProc);
+                if (_hookInstalled)
+                {
+                    SetWindowLongPtr(_windowHandle, GWLP_WNDPROC, _previousWndProc);
+                }
                 DragAcceptFiles(_windowHandle, false);
+            }
+            if (_activeWindowHandle == _windowHandle)
+            {
+                _activeWindowHandle = IntPtr.Zero;
+                _activePreviousWndProc = IntPtr.Zero;
             }
             _windowHandle = IntPtr.Zero;
             _previousWndProc = IntPtr.Zero;
+            _hookInstalled = false;
             if (_instance == this) _instance = null;
         }
 
@@ -84,13 +112,27 @@ namespace Basis.ImagePickup
         private static IntPtr HookedWndProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam)
         {
             BasisDesktopImageDropHook instance = _instance;
-            if (instance == null) return IntPtr.Zero;
+            IntPtr previous = instance != null ? instance._previousWndProc : _activePreviousWndProc;
 
-            if (msg == WM_DROPFILES)
+            if (instance != null && msg == WM_DROPFILES)
             {
-                instance.CollectDroppedFiles(wParam);
+                try
+                {
+                    instance.CollectDroppedFiles(wParam);
+                }
+                catch (Exception e)
+                {
+                    BasisDebug.LogWarning($"Image pickup: file drop handling failed ({e.Message}).");
+                }
             }
-            return CallWindowProc(instance._previousWndProc, hWnd, msg, wParam, lParam);
+            return ForwardWindowMessage(previous, hWnd, msg, wParam, lParam);
+        }
+
+        private static IntPtr ForwardWindowMessage(IntPtr previous, IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam)
+        {
+            return previous != IntPtr.Zero
+                ? CallWindowProc(previous, hWnd, msg, wParam, lParam)
+                : DefWindowProc(hWnd, msg, wParam, lParam);
         }
 
         private void CollectDroppedFiles(IntPtr hDrop)

--- a/Basis/Packages/com.basis.imagepickup/BasisImagePickupManager.cs
+++ b/Basis/Packages/com.basis.imagepickup/BasisImagePickupManager.cs
@@ -21,6 +21,7 @@ namespace Basis.ImagePickup
         public static BasisImagePickupManager Instance { get; private set; }
 
         private const string FixedNetworkIdentifier = "BasisImagePickupManager";
+        private const int MaxIgnoredOwnerNameBytes = 1024;
 
         private const byte OpSpawn = 1;
         private const byte OpChunk = 2;
@@ -238,8 +239,8 @@ namespace Basis.ImagePickup
         private void HandleSpawn(ushort senderId, BinaryReader reader)
         {
             Guid id = new Guid(reader.ReadBytes(16));
-            ushort ownerId = reader.ReadUInt16();
-            string ownerName = reader.ReadString();
+            reader.ReadUInt16();
+            if (!TrySkipWireString(reader, MaxIgnoredOwnerNameBytes)) return;
             int width = reader.ReadInt32();
             int height = reader.ReadInt32();
             int totalBytes = reader.ReadInt32();
@@ -266,8 +267,8 @@ namespace Basis.ImagePickup
                 TotalChunks = totalChunks,
                 Width = width,
                 Height = height,
-                OwnerId = ownerId,
-                OwnerName = ownerName,
+                OwnerId = senderId,
+                OwnerName = ResolveOwnerName(senderId),
                 Deadline = Time.unscaledTime + BasisImagePickupSettings.InboundTransferTimeoutSeconds,
                 Position = position,
                 Rotation = rotation,
@@ -401,6 +402,45 @@ namespace Basis.ImagePickup
         {
             _imageCountBySender.TryGetValue(sender, out int count);
             _imageCountBySender[sender] = count + 1;
+        }
+
+        private static string ResolveOwnerName(ushort senderId)
+        {
+            if (BasisNetworkPlayer.GetPlayerById(senderId, out BasisNetworkPlayer player))
+            {
+                string name = player.SafeDisplayName;
+                if (string.IsNullOrEmpty(name)) name = player.displayName;
+                if (!string.IsNullOrEmpty(name)) return name;
+            }
+            return $"Player {senderId}";
+        }
+
+        private static bool TrySkipWireString(BinaryReader reader, int maxByteLength)
+        {
+            if (!TryRead7BitEncodedInt(reader, out int byteLength)) return false;
+            if (byteLength < 0 || byteLength > maxByteLength) return false;
+
+            long remainingBytes = reader.BaseStream.Length - reader.BaseStream.Position;
+            if (remainingBytes < byteLength) return false;
+
+            reader.BaseStream.Position += byteLength;
+            return true;
+        }
+
+        private static bool TryRead7BitEncodedInt(BinaryReader reader, out int value)
+        {
+            value = 0;
+            for (int shift = 0; shift < 35; shift += 7)
+            {
+                if (reader.BaseStream.Length - reader.BaseStream.Position < 1) return false;
+
+                byte b = reader.ReadByte();
+                if (shift == 28 && (b & 0xF0) != 0) return false;
+
+                value |= (b & 0x7F) << shift;
+                if ((b & 0x80) == 0) return true;
+            }
+            return false;
         }
 
         private void DecrementSenderCount(ushort sender)

--- a/Basis/Packages/com.basis.imagepickup/BasisImagePickupManager.cs
+++ b/Basis/Packages/com.basis.imagepickup/BasisImagePickupManager.cs
@@ -279,15 +279,23 @@ namespace Basis.ImagePickup
             Guid id = new Guid(reader.ReadBytes(16));
             int chunkIndex = reader.ReadInt32();
             int length = reader.ReadInt32();
-            byte[] data = reader.ReadBytes(length);
 
             if (!_inbound.TryGetValue(id, out InboundTransfer transfer)) return;
             if (transfer.Sender != senderId) return;
             if (chunkIndex < 0 || chunkIndex >= transfer.TotalChunks) return;
-            if (data.Length != length) return;
+            if (length < 0 || length > BasisImagePickupSettings.ChunkPayloadBytes) return;
 
             int offset = chunkIndex * BasisImagePickupSettings.ChunkPayloadBytes;
-            if (offset < 0 || offset + length > transfer.Buffer.Length) return;
+            if (offset < 0 || offset >= transfer.Buffer.Length) return;
+
+            int expectedLength = Mathf.Min(BasisImagePickupSettings.ChunkPayloadBytes, transfer.Buffer.Length - offset);
+            if (length != expectedLength) return;
+
+            long remainingBytes = reader.BaseStream.Length - reader.BaseStream.Position;
+            if (remainingBytes < length) return;
+
+            byte[] data = reader.ReadBytes(length);
+            if (data.Length != length) return;
 
             if (!transfer.Received[chunkIndex])
             {

--- a/Basis/Packages/com.basis.imagepickup/BasisImageSecurity.cs
+++ b/Basis/Packages/com.basis.imagepickup/BasisImageSecurity.cs
@@ -79,7 +79,7 @@ namespace Basis.ImagePickup
             if (bytes.Length > BasisImagePickupSettings.MaxImageBytes) { result.Error = "Too large"; return result; }
             if (!TryReadPngDimensions(bytes, out int w, out int h, out string headerError)) { result.Error = headerError; return result; }
             if (!DimensionsWithinCaps(w, h, out string capError)) { result.Error = capError; return result; }
-            return BuildFromBytes(bytes, true, true);
+            return BuildFromBytes(bytes, true, false);
         }
 
         private static BasisImageValidationResult BuildFromBytes(byte[] bytes, bool reencode, bool allowDownscale)

--- a/Basis/Packages/com.basis.imagepickup/BasisImageSecurity.cs
+++ b/Basis/Packages/com.basis.imagepickup/BasisImageSecurity.cs
@@ -79,7 +79,7 @@ namespace Basis.ImagePickup
             if (bytes.Length > BasisImagePickupSettings.MaxImageBytes) { result.Error = "Too large"; return result; }
             if (!TryReadPngDimensions(bytes, out int w, out int h, out string headerError)) { result.Error = headerError; return result; }
             if (!DimensionsWithinCaps(w, h, out string capError)) { result.Error = capError; return result; }
-            return BuildFromBytes(bytes, false, false);
+            return BuildFromBytes(bytes, true, true);
         }
 
         private static BasisImageValidationResult BuildFromBytes(byte[] bytes, bool reencode, bool allowDownscale)


### PR DESCRIPTION
## Summary
Fixes issues that may occur and should be mitigated in Imagepickup and Object Sync

- Validates image chunk payload lengths before allocation/read to avoid malformed packet allocation abuse.
- Derives remote image ownership from the authenticated network sender instead of trusting wire-provided owner id/name.
- Re-encodes network-received PNGs before save/forward paths so ancillary/appended payloads are stripped.
- Applies `RelativeTo` rotation in transform and rigidbody sync, making relative poses consistent for rotated anchors.
- Hardens the Windows file-drop WndProc hook so subclass failures disable the hook and all callback paths forward messages.
## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [ ] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — `BasisEventDriver` runs the single per-frame tick that drives the whole framework (network apply, local player sim, blendshapes, JigglePhysics, nameplates, and more) as one sequential chain. An unhandled exception anywhere in that chain aborts the rest of the tick, so every step after the throwing one is silently skipped for that frame. New work added to the driver must either be guaranteed not to throw, or be wrapped in a `try`/`catch` that contains the failure and surfaces it through `BasisDebug` — logged once / rate-limited, never every frame (see the existing `HVRBasisBuiltInAddresses.Simulate()` guard for the pattern). Expect this to be scrutinized closely in review.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [ ] Windows
- [ ] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [ ] Tested in VR (note headset under **Notes**)
- [ ] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [ ] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [ ] N/A — change does not touch any of the above

## Notes
All static code analysis with a few LLMs agree about the issues needing to be fixed.
We shouldn't trust the wire ownership ID since it can be forged and can cause other issues with image cleanup.
