### PR TITLE
Derive walk/run speed from the speed fields instead of a stale hardcoded multiplier

### DIFF
--- a/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalCharacterDriver.cs
+++ b/Basis/Packages/com.basis.framework/Drivers/Local/BasisLocalCharacterDriver.cs
@@ -119,8 +119,6 @@ namespace Basis.Scripts.BasisCharacterController
         /// </summary>
         [field: SerializeField] public float MovementSpeedScale { get; private set; }
         [field: SerializeField] public float MovementSpeedBoost { get; private set; }
-        private float DefaultMovementSpeedMultiplier = 0.625f;
-        private float MaximumMovementSpeedBoost = 1.6f;
         /// <summary>
         /// A value between 0 and 1 representing the character's crouch state, where 0 is fully crouched and 1 is fully standing.
         /// </summary>
@@ -178,7 +176,6 @@ namespace Basis.Scripts.BasisCharacterController
             {
                 HasEvents = true;
             }
-            MaximumMovementSpeedBoost = MaximumMovementSpeed / DefaultMovementSpeed;
             SetMovementSpeedMultiplier(GetMultiplierForMovementSpeed(DefaultMovementSpeed));
             Validate();
             CalculateCharacterSize();
@@ -378,8 +375,8 @@ namespace Basis.Scripts.BasisCharacterController
 
         public void UpdateMovementSpeed(bool maxSpeed)
         {
-            var topSpeed = maxSpeed ? 1f : DefaultMovementSpeedMultiplier;
-            var boostSpeed = maxSpeed ? MaximumMovementSpeedBoost : 1f;
+            var topSpeed = GetMultiplierForMovementSpeed(maxSpeed ? MaximumMovementSpeed : DefaultMovementSpeed);
+            var boostSpeed = maxSpeed ? MaximumMovementSpeed / DefaultMovementSpeed : 1f;
             // inverse of crouch blend so standing is the least value, multiply by the boost that running gives
             MovementSpeedBoost = (1 - CrouchBlend) * boostSpeed;
             SetMovementSpeedMultiplier(topSpeed * CrouchBlend * MovementVector.magnitude);


### PR DESCRIPTION
**Problem:** The player's walk speed isn't driven by `DefaultMovementSpeed`. Walking uses a private `DefaultMovementSpeedMultiplier` hardcoded to `0.625`, which doesn't match the field — `unlerp(0.5, 4, 2.5) = 0.571`, not `0.625` — so the actual walk speed is ~2.69 m/s, not the 2.5 the field implies. `DefaultMovementSpeed` only takes effect for the first frame before `UpdateMovementSpeed` overwrites it, and because the multiplier is fixed and independent of the speed fields, setting `DefaultMovementSpeed`/`MaximumMovementSpeed` can't actually change the speeds (e.g. can't make run == walk to disable running). It also makes `IsRunning` (`CurrentSpeed > DefaultMovementSpeed`) true while merely walking, since 2.69 > 2.5.

**Fix:** Remove the stored `DefaultMovementSpeedMultiplier` and `MaximumMovementSpeedBoost` and derive both from the plain speed fields where used — walk from `DefaultMovementSpeed`, run from `MaximumMovementSpeed`, boost from their ratio. `MinimumMovementSpeed`/`DefaultMovementSpeed`/`MaximumMovementSpeed` become the only inputs, so walk and run can be set equal, different, or at any ratio.

**Note:** Default walk speed now matches the field (2.5) instead of the previous ~2.69 — bump `DefaultMovementSpeed` if you'd rather keep the old feel.
