### PR TITLE
Whitelist Bakery runtime components so Bakery-baked worlds keep their lightmaps

### DIFF
--- a/Basis/Packages/com.basis.sdk/Settings/SceneContentPoliceSelector.asset
+++ b/Basis/Packages/com.basis.sdk/Settings/SceneContentPoliceSelector.asset
@@ -386,3 +386,16 @@ MonoBehaviour:
   - Basis.Shims.BasisOsc
   - UnityEngine.Video.VideoPlayer
   - Basis.Scripts.BasisSdk.Highlight.BasisHighlightOverride
+  - ftLightmapsStorage
+  - BakeryLightmapGroupSelector
+  - BakeryLightmappedPrefab
+  - BakeryVolume
+  - BakerySector
+  - BakeryDirectLight
+  - BakeryPointLight
+  - BakerySkyLight
+  - BakeryLightMesh
+  - BakeryLightFilter
+  - BakeryAlwaysRender
+  - BakeryPackAsSingleSquare
+  - BakerySharedLodUv


### PR DESCRIPTION
**Bug:** Bakery-baked worlds load with broken/partial baked lighting, and the console logs `MonoBehaviour ftLightmapsStorage is not approved and will be removed`. Bakes and builds clean; only wrong once the world bundle is loaded.

**Cause:** Bakery ships a runtime `ftLightmapsStorage` (on `!ftraceLightmaps`) that re-applies the baked lightmaps into `LightmapSettings` and sets each renderer's `lightmapIndex`/`lightmapScaleOffset` at scene load. `ContentPoliceControl.ContentControl` `DestroyImmediate`s any scene `MonoBehaviour` whose type isn't in the World `ContentPoliceSelector`; `ftLightmapsStorage` isn't listed, so it's stripped — and its `OnDestroy` (`ftLightmaps.UnloadScene`) then tears down the lightmap array it had already applied.

**Fix:** Add Bakery's runtime scene components to `SceneContentPoliceSelector` (the World selector) so they survive the content scrub. They only touch lightmap/renderer/shader-keyword state — no file/network I/O, reflection, or `AddComponent`.
