### PR TITLE
Auto-hold: DesktopOnly/Everywhere modes + per-player VR opt-out

### DIFF
--- a/Basis/Packages/com.basis.framework/BasisUI/BasisSettingsDefaults.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/BasisSettingsDefaults.cs
@@ -696,6 +696,7 @@ namespace Basis.BasisUI
         // ---------------- INTERACTIONS ----------------
         public static BasisSettingsBinding<bool> DisableSeats = new("disableseats", new BasisPlatformDefault<bool>(false));
         public static BasisSettingsBinding<bool> DisablePropPickup = new("disableproppickup", new BasisPlatformDefault<bool>(false));
+        public static BasisSettingsBinding<bool> DisableVRAutoHold = new("disablevrautohold", new BasisPlatformDefault<bool>(false));
         public static BasisSettingsBinding<bool> ForceGridSnap = new("forcegridsnap", new BasisPlatformDefault<bool>(false));
         public static BasisSettingsBinding<float> GridSnapSize = new("gridsnapsize", new BasisPlatformDefault<float>(0.25f));
         public static BasisSettingsBinding<bool> ForceRotationSnap = new("forcerotationsnap", new BasisPlatformDefault<bool>(false));
@@ -1711,6 +1712,7 @@ namespace Basis.BasisUI
             LimitKnee.LoadBindingValue();
             DisableSeats.LoadBindingValue();
             DisablePropPickup.LoadBindingValue();
+            DisableVRAutoHold.LoadBindingValue();
             ForceGridSnap.LoadBindingValue();
             GridSnapSize.LoadBindingValue();
             ForceRotationSnap.LoadBindingValue();

--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/en.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/en.json
@@ -3519,6 +3519,18 @@
       "value": "Prevent picking up props placed in the world."
     },
     {
+      "key": "settings.general.disableVRAutoHold",
+      "value": "Disable VR Auto-Hold"
+    },
+    {
+      "key": "settings.general.disableVRAutoHold.tooltip",
+      "value": "Always hold the grab button to keep a pickup held in VR, even when a world sets it to auto-hold."
+    },
+    {
+      "key": "settings.general.disableVRAutoHold.description",
+      "value": "Ignore VR auto-hold on pickups, so you must keep holding the grab button to carry them."
+    },
+    {
       "key": "settings.general.hud.title",
       "value": "HUD"
     },

--- a/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProvider.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Menus/Main Menu Providers/SettingsProvider.cs
@@ -455,6 +455,11 @@ namespace Basis.BasisUI
                 toggleDisablePropPickup.AssignBinding(BasisSettingsDefaults.DisablePropPickup);
                 toggleDisablePropPickup.Descriptor.SetTitle(BasisLocalization.Get("settings.general.disablePropPickup"));
                 toggleDisablePropPickup.Descriptor.SetTooltip(BasisLocalization.Get("settings.general.disablePropPickup.tooltip"));
+
+                PanelToggle toggleDisableVRAutoHold = PanelToggle.CreateNewEntry(container);
+                toggleDisableVRAutoHold.AssignBinding(BasisSettingsDefaults.DisableVRAutoHold);
+                toggleDisableVRAutoHold.Descriptor.SetTitle(BasisLocalization.Get("settings.general.disableVRAutoHold"));
+                toggleDisableVRAutoHold.Descriptor.SetTooltip(BasisLocalization.Get("settings.general.disableVRAutoHold.tooltip"));
             }, false, _ => descriptor.ForceRebuild());
 
             // HUD overlays — heads-up display elements rendered over the scene.

--- a/Basis/Packages/com.basis.framework/Interactions/BasisInteractableObject.cs
+++ b/Basis/Packages/com.basis.framework/Interactions/BasisInteractableObject.cs
@@ -1,3 +1,4 @@
+using Basis.BasisUI;
 using Basis.Scripts.BasisSdk.Players;
 using Basis.Scripts.Device_Management.Devices;
 using System;
@@ -36,7 +37,7 @@ namespace Basis.Scripts.BasisSdk.Interactions
         /// Determines whether the interactable should automatically be held after interaction.
         /// </summary>
         [SerializeField]
-        public BasisAutoHold AutoHold = BasisAutoHold.No;
+        public BasisAutoHold AutoHold = BasisAutoHold.None;
 
         /// <summary>
         /// Enum for controlling automatic hold behavior after interaction.
@@ -45,25 +46,39 @@ namespace Basis.Scripts.BasisSdk.Interactions
         public enum BasisAutoHold
         {
             /// <summary>
-            /// Auto-hold on every device (desktop and VR). The object stays held after the grip is
-            /// released until the drop input fires (see <see cref="IsHoldDropTriggered"/>).
+            /// Auto-hold on desktop only; VR must keep holding the grab input.
             /// </summary>
-            Yes = 0,
+            DesktopOnly = 0,
 
             /// <summary>
-            /// Never auto-hold. The object releases as soon as the grip/trigger is let go.
+            /// Object never remains held; drops as soon as the grab input is released.
             /// </summary>
-            No = 1,
+            None = 1,
+
+            /// <summary>
+            /// Auto-hold on desktop and in VR.
+            /// </summary>
+            Everywhere = 2,
         }
 
         /// <summary>
-        /// Whether auto-hold (staying held after release) is enabled for this object.
+        /// Whether auto-hold (staying held after release) is active for this object on the current device.
+        /// VR players can opt out via <see cref="BasisSettingsDefaults.DisableVRAutoHold"/>.
         /// Centralizes the check so callers don't compare against <see cref="AutoHold"/> directly.
         /// </summary>
-        /// <returns><c>true</c> when <see cref="AutoHold"/> is <see cref="BasisAutoHold.Yes"/>.</returns>
         public bool IsAutoHoldActive()
         {
-            return AutoHold == BasisAutoHold.Yes;
+            switch (AutoHold)
+            {
+                case BasisAutoHold.Everywhere:
+                    if (!Device_Management.BasisDeviceManagement.IsUserInDesktop() && BasisSettingsDefaults.DisableVRAutoHold.RawValue)
+                        return false;
+                    return true;
+                case BasisAutoHold.DesktopOnly:
+                    return Device_Management.BasisDeviceManagement.IsUserInDesktop();
+                default:
+                    return false;
+            }
         }
         public BasisInputKey InputKey = BasisInputKey.Trigger;
         public enum BasisInputKey

--- a/Basis/Packages/com.basis.framework/Interactions/BasisPlayerInteract.cs
+++ b/Basis/Packages/com.basis.framework/Interactions/BasisPlayerInteract.cs
@@ -222,7 +222,7 @@ namespace Basis.Scripts.BasisSdk.Interactions
                     }
                 }
                 // Direct grab detection: hand-proximity grab for VR hands
-                else if (TryDetectDirectGrab(interactInput, out BasisInteractableObject grabTarget))
+                else if (TryDetectDirectGrab(interactInput, gripPressedAgain, out BasisInteractableObject grabTarget))
                 {
                     HandleDirectGrab(grabTarget, ref interactInput);
                 }
@@ -584,7 +584,7 @@ namespace Basis.Scripts.BasisSdk.Interactions
         /// Attempts to find a directly grabbable interactable near the hand bone position.
         /// Only activates for hand inputs when grip is pressed.
         /// </summary>
-        private bool TryDetectDirectGrab(BasisInteractInput interactInput, out BasisInteractableObject grabTarget)
+        private bool TryDetectDirectGrab(BasisInteractInput interactInput, bool gripPressedAgain, out BasisInteractableObject grabTarget)
         {
             grabTarget = null;
             BasisInput input = interactInput.input;
@@ -593,10 +593,12 @@ namespace Basis.Scripts.BasisSdk.Interactions
             if (interactInput.lastTarget != null && interactInput.lastTarget.IsInteractingWith(input))
                 return false;
 
-            // Only for hand roles with grip pressed
+            // Require a fresh grip press: a grip still held from a drop must not re-grab (intentional grab only)
+            if (!gripPressedAgain) return false;
+
+            // Only for hand roles
             if (!input.TryGetRole(out BasisBoneTrackedRole role)) return false;
             if (role != BasisBoneTrackedRole.LeftHand && role != BasisBoneTrackedRole.RightHand) return false;
-            if (!input.CurrentInputState.GripButton) return false;
 
             // Get the hand bone world position
             if (!input.HasControl || input.Control == null) return false;

--- a/Basis/Packages/com.basis.pooltable/Modules/BilliardsModule/UdonScripts/CueGrip.cs
+++ b/Basis/Packages/com.basis.pooltable/Modules/BilliardsModule/UdonScripts/CueGrip.cs
@@ -22,11 +22,11 @@ public class CueGrip : MonoBehaviour
         pickup.OnPickupUse.AddListener(OnPickupUse);
         if (BasisDeviceManagement.IsCurrentModeVR())
         {
-            pickup.AutoHold = BasisInteractableObject.BasisAutoHold.No;
+            pickup.AutoHold = BasisInteractableObject.BasisAutoHold.None;
         }
         else
         {
-            pickup.AutoHold = BasisInteractableObject.BasisAutoHold.Yes;
+            pickup.AutoHold = BasisInteractableObject.BasisAutoHold.DesktopOnly;
         }
     }
     private void OnPickupUse(BasisPickUpUseMode mode)


### PR DESCRIPTION
**What:** Builds on this branch's VR auto-hold. Replaces `BasisAutoHold` `Yes`/`No` with `None`/`DesktopOnly`/`Everywhere`, so a world can auto-hold on desktop only or everywhere. `IsAutoHoldActive()` now resolves per-device.

**Opt-out:** New `DisableVRAutoHold` player setting ("Disable VR Auto-Hold") makes `IsAutoHoldActive()` return false in VR, overriding a world's per-grabbable value — the player wins over the world. Desktop is unaffected.

**Drop persistence:** Direct grab now requires a fresh grip press instead of a merely-held grip, so a pickup dropped by the world (or by the auto-hold toggle) stays dropped until the player intentionally grabs again — the still-held grip no longer instantly re-grabs it. Reuses the existing `wasGripDown` edge.

**Compat:** `DesktopOnly=0` (old `Yes`), `None=1` (old `No`), `Everywhere=2`; `CueGrip` updated to the new names.
