### PR TITLE
feat(api): expose player position in GET /api/players

### DIFF
--- a/Basis Server/BasisNetworkServer/BasisRestApiRoutes.cs
+++ b/Basis Server/BasisNetworkServer/BasisRestApiRoutes.cs
@@ -97,7 +97,7 @@ public sealed class BasisRestApiRoutes
     private void ListPlayers(HttpListenerResponse res)
     {
         var entries = _control.ListPlayers().Select(p =>
-            $$"""{"netId":{{p.NetId}},"uuid":{{JsonSerializer.Serialize(p.Uuid)}},"displayName":{{JsonSerializer.Serialize(p.DisplayName)}},"platform":{{JsonSerializer.Serialize(p.Platform)}}}""");
+            $$"""{"netId":{{p.NetId}},"uuid":{{JsonSerializer.Serialize(p.Uuid)}},"displayName":{{JsonSerializer.Serialize(p.DisplayName)}},"platform":{{JsonSerializer.Serialize(p.Platform)}},"position":{{JsonSerializer.Serialize(p.Position)}}}""");
         WriteJson(res, $$"""{"players":[{{string.Join(",", entries)}}]}""");
     }
 

--- a/Basis Server/BasisNetworkServer/BasisServerControl.cs
+++ b/Basis Server/BasisNetworkServer/BasisServerControl.cs
@@ -1,5 +1,6 @@
 #if !UNITY_2017_1_OR_NEWER
 using Basis.Network.Core;
+using BasisNetworkServer.BasisNetworkingReductionSystem;
 using BasisNetworkServer.Security;
 using System;
 using System.Collections.Generic;
@@ -21,7 +22,7 @@ namespace Basis.Network.Server
     public record WorldLoadParams(string Url, string Password, bool Persistent, LoadStrategy Strategy);
     public record SwitchWorldParams(string Url, string Password, bool Persistent, string AnnounceMessage, int Delay);
     public record WorldInfo(string NetId, string Url, bool Persistent, bool AdminLocked, LoadStrategy Strategy);
-    public record PlayerInfo(int NetId, string Uuid, string DisplayName, string Platform);
+    public record PlayerInfo(int NetId, string Uuid, string DisplayName, string Platform, float[] Position = null);
 
     public interface IServerControl
     {
@@ -140,7 +141,12 @@ namespace Basis.Network.Server
                     displayName = meta.playerDisplayName ?? string.Empty;
                     platform    = meta.playerPlatform   ?? string.Empty;
                 }
-                result.Add(new PlayerInfo(kv.Key, uuid, displayName, platform));
+                float[] position = null;
+                if (BasisServerReductionSystemEvents.playerStates.TryGetValue(kv.Key, out var state) && state.IsActive)
+                {
+                    position = new[] { state.Position.x, state.Position.y, state.Position.z };
+                }
+                result.Add(new PlayerInfo(kv.Key, uuid, displayName, platform, position));
             }
             return result;
         }

--- a/Basis Server/BasisRestApi.Tests/RestApiTests.cs
+++ b/Basis Server/BasisRestApi.Tests/RestApiTests.cs
@@ -238,6 +238,61 @@ namespace BasisRestApi.Tests
             Assert.Equal(HttpStatusCode.OK, res.StatusCode);
         }
 
+        // ── GET /api/players ──────────────────────────────────────────────────
+
+        [Fact]
+        public async Task GetPlayers_Empty_ReturnsEmptyList()
+        {
+            var res = await _authed.GetAsync("/api/players");
+            Assert.Equal(HttpStatusCode.OK, res.StatusCode);
+            var doc = JsonDocument.Parse(await res.Content.ReadAsStringAsync());
+            Assert.Equal(0, doc.RootElement.GetProperty("players").GetArrayLength());
+        }
+
+        [Fact]
+        public async Task GetPlayers_PositionIsArrayWhenKnown_NullWhenNot()
+        {
+            ushort port = FreePort();
+            using var handler = new BasisRestApiHandler(new Configuration
+            {
+                ApiEnabled = true, ApiKey = ApiKey, ApiHost = "localhost", ApiPort = port,
+            }, new FakeControl
+            {
+                Players = new[]
+                {
+                    new PlayerInfo(1, "uuid-1", "Alice", "desktop", new[] { 1.5f, 2f, -3.25f }),
+                    new PlayerInfo(2, "uuid-2", "Bob", "vr"),
+                },
+            });
+            using var client = new HttpClient { BaseAddress = new Uri($"http://localhost:{port}") };
+            client.DefaultRequestHeaders.Add("Authorization", $"Bearer {ApiKey}");
+
+            var res = await client.GetAsync("/api/players");
+            Assert.Equal(HttpStatusCode.OK, res.StatusCode);
+            var players = JsonDocument.Parse(await res.Content.ReadAsStringAsync())
+                .RootElement.GetProperty("players");
+
+            var pos = players[0].GetProperty("position");
+            Assert.Equal(3, pos.GetArrayLength());
+            Assert.Equal(1.5f, pos[0].GetSingle());
+            Assert.Equal(2f, pos[1].GetSingle());
+            Assert.Equal(-3.25f, pos[2].GetSingle());
+            Assert.Equal(JsonValueKind.Null, players[1].GetProperty("position").ValueKind);
+        }
+
+        private sealed class FakeControl : IServerControl
+        {
+            public IReadOnlyList<PlayerInfo> Players = Array.Empty<PlayerInfo>();
+            public void AnnounceAll(string message) { }
+            public bool AnnouncePlayer(string uuid, string message) => false;
+            public string LoadWorld(WorldLoadParams p) => "0";
+            public bool UnloadWorld(string netId) => false;
+            public int ClearAllWorlds() => 0;
+            public IReadOnlyList<WorldInfo> ListWorlds() => Array.Empty<WorldInfo>();
+            public IReadOnlyList<PlayerInfo> ListPlayers() => Players;
+            public string SwitchWorld(SwitchWorldParams p, CancellationToken cancellationToken = default) => "0";
+        }
+
         // ── POST /api/announce/{uuid} ─────────────────────────────────────────
 
         [Fact]

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/BasisRestApiRoutes.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/BasisRestApiRoutes.cs
@@ -97,7 +97,7 @@ public sealed class BasisRestApiRoutes
     private void ListPlayers(HttpListenerResponse res)
     {
         var entries = _control.ListPlayers().Select(p =>
-            $$"""{"netId":{{p.NetId}},"uuid":{{JsonSerializer.Serialize(p.Uuid)}},"displayName":{{JsonSerializer.Serialize(p.DisplayName)}},"platform":{{JsonSerializer.Serialize(p.Platform)}}}""");
+            $$"""{"netId":{{p.NetId}},"uuid":{{JsonSerializer.Serialize(p.Uuid)}},"displayName":{{JsonSerializer.Serialize(p.DisplayName)}},"platform":{{JsonSerializer.Serialize(p.Platform)}},"position":{{JsonSerializer.Serialize(p.Position)}}}""");
         WriteJson(res, $$"""{"players":[{{string.Join(",", entries)}}]}""");
     }
 

--- a/Basis/Packages/com.basis.server/BasisNetworkServer/BasisServerControl.cs
+++ b/Basis/Packages/com.basis.server/BasisNetworkServer/BasisServerControl.cs
@@ -1,5 +1,6 @@
 #if !UNITY_2017_1_OR_NEWER
 using Basis.Network.Core;
+using BasisNetworkServer.BasisNetworkingReductionSystem;
 using BasisNetworkServer.Security;
 using System;
 using System.Collections.Generic;
@@ -21,7 +22,7 @@ namespace Basis.Network.Server
     public record WorldLoadParams(string Url, string Password, bool Persistent, LoadStrategy Strategy);
     public record SwitchWorldParams(string Url, string Password, bool Persistent, string AnnounceMessage, int Delay);
     public record WorldInfo(string NetId, string Url, bool Persistent, bool AdminLocked, LoadStrategy Strategy);
-    public record PlayerInfo(int NetId, string Uuid, string DisplayName, string Platform);
+    public record PlayerInfo(int NetId, string Uuid, string DisplayName, string Platform, float[] Position = null);
 
     public interface IServerControl
     {
@@ -140,7 +141,12 @@ namespace Basis.Network.Server
                     displayName = meta.playerDisplayName ?? string.Empty;
                     platform    = meta.playerPlatform   ?? string.Empty;
                 }
-                result.Add(new PlayerInfo(kv.Key, uuid, displayName, platform));
+                float[] position = null;
+                if (BasisServerReductionSystemEvents.playerStates.TryGetValue(kv.Key, out var state) && state.IsActive)
+                {
+                    position = new[] { state.Position.x, state.Position.y, state.Position.z };
+                }
+                result.Add(new PlayerInfo(kv.Key, uuid, displayName, platform, position));
             }
             return result;
         }


### PR DESCRIPTION
## Summary

Extends the management API from #860 with player positions: `GET /api/players` now includes each player's last-known world-space position.

- `PlayerInfo` gains an optional `Position` (`float[]` `[x, y, z]`), populated in `BasisServerControl.ListPlayers()` from the server reduction system's per-player state (`BasisServerReductionSystemEvents.playerStates`) — the same last-received avatar-sync position already maintained for distance-based interest management. No new tracking, no extra work outside the API request path.
- `"position"` is `null` until the player's first avatar sync lands (or if their reduction-system state is inactive).
- Adds two `/api/players` tests: empty list against the real control, and position/null serialization against an injected `IServerControl` fake — suite is now 31 tests, all passing.

Example response:

```json
{"players":[{"netId":1,"uuid":"...","displayName":"Alice","platform":"desktop","position":[12.5,1.6,-4.25]}]}
```

## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [x] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — `BasisEventDriver` runs the single per-frame tick that drives the whole framework (network apply, local player sim, blendshapes, JigglePhysics, nameplates, and more) as one sequential chain. An unhandled exception anywhere in that chain aborts the rest of the tick, so every step after the throwing one is silently skipped for that frame. New work added to the driver must either be guaranteed not to throw, or be wrapped in a `try`/`catch` that contains the failure and surfaces it through `BasisDebug` — logged once / rate-limited, never every frame (see the existing `HVRBasisBuiltInAddresses.Simulate()` guard for the pattern). Expect this to be scrutinized closely in review.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [ ] Windows
- [ ] Linux
- [ ] Android
- [ ] iOS
- [x] macOS

Input / control mode coverage:

- [ ] Tested in VR (note headset under **Notes**)
- [ ] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [x] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [x] N/A — change does not touch any of the above

## Notes

**All Unity-specific checks are N/A — same as #860, this is entirely server-side (.NET standalone, `#if !UNITY_2017_1_OR_NEWER`).**

- No transforms, MonoBehaviours, Addressables, BasisEventDriver, camera access, or scene discovery — none of those APIs exist in the standalone server binary.
- The position read is a lock-free `TryGetValue` on the existing sharded dictionary plus one 3-float array allocation, on the admin API request path only — never per-frame. The reduction system itself is untouched.
- "Tested" = built and validated via the xUnit suite (`dotnet test`, 31/31 passing, 2 new `/api/players` tests) on macOS. The empty-list test exercises the real `BasisServerControl` over real HTTP; the serialization test injects a fake `IServerControl`. Not yet validated against a live server with connected clients.
- The two pre-existing mirror copies (`Basis Server/` and `Basis/Packages/com.basis.server/`) received the identical change; their unrelated pre-existing drift (strategy validation, `%23` fragment handling) was left as-is.
