### PR TITLE
Add shims for EventTrigger and Toggle.onValueChanged

### DIFF
--- a/Basis/Packages/com.basis.sdk/Settings/PropContentPoliceSelector.asset
+++ b/Basis/Packages/com.basis.sdk/Settings/PropContentPoliceSelector.asset
@@ -349,3 +349,4 @@ MonoBehaviour:
   - Basis.Shims.BasisOsc
   - UnityEngine.Video.VideoPlayer
   - Basis.Scripts.BasisSdk.Highlight.BasisHighlightOverride
+  - Basis.Shims.BasisActionTrigger

--- a/Basis/Packages/com.basis.sdk/Settings/SceneContentPoliceSelector.asset
+++ b/Basis/Packages/com.basis.sdk/Settings/SceneContentPoliceSelector.asset
@@ -399,3 +399,4 @@ MonoBehaviour:
   - BakeryAlwaysRender
   - BakeryPackAsSingleSquare
   - BakerySharedLodUv
+  - Basis.Shims.BasisActionTrigger

--- a/Basis/Packages/com.basis.shim/Shims/BasisActionTrigger.cs
+++ b/Basis/Packages/com.basis.shim/Shims/BasisActionTrigger.cs
@@ -1,0 +1,134 @@
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace Basis.Shims
+{
+    public class BasisActionTrigger : MonoBehaviour,
+        IPointerEnterHandler,
+        IPointerExitHandler,
+        IPointerDownHandler,
+        IPointerUpHandler,
+        IPointerClickHandler,
+        IInitializePotentialDragHandler,
+        IBeginDragHandler,
+        IDragHandler,
+        IEndDragHandler,
+        IDropHandler,
+        IScrollHandler,
+        IUpdateSelectedHandler,
+        ISelectHandler,
+        IDeselectHandler,
+        IMoveHandler,
+        ISubmitHandler,
+        ICancelHandler
+    {
+        public delegate void PointerEventHandler(PointerEventData eventData);
+
+        public delegate void BaseEventHandler(BaseEventData eventData);
+
+        public delegate void AxisEventHandler(AxisEventData eventData);
+
+        public PointerEventHandler PointerEnter { get; set; }
+        public PointerEventHandler PointerExit { get; set; }
+        public PointerEventHandler PointerDown { get; set; }
+        public PointerEventHandler PointerUp { get; set; }
+        public PointerEventHandler PointerClick { get; set; }
+        public PointerEventHandler InitializePotentialDrag { get; set; }
+        public PointerEventHandler BeginDrag { get; set; }
+        public PointerEventHandler Drag { get; set; }
+        public PointerEventHandler EndDrag { get; set; }
+        public PointerEventHandler Drop { get; set; }
+        public PointerEventHandler Scroll { get; set; }
+        public BaseEventHandler UpdateSelected { get; set; }
+        public BaseEventHandler Select { get; set; }
+        public BaseEventHandler Deselect { get; set; }
+        public AxisEventHandler Move { get; set; }
+        public BaseEventHandler Submit { get; set; }
+        public BaseEventHandler Cancel { get; set; }
+
+        public void OnPointerEnter(PointerEventData eventData)
+        {
+            PointerEnter?.Invoke(eventData);
+        }
+
+        public void OnPointerExit(PointerEventData eventData)
+        {
+            PointerExit?.Invoke(eventData);
+        }
+
+        public void OnPointerDown(PointerEventData eventData)
+        {
+            PointerDown?.Invoke(eventData);
+        }
+
+        public void OnPointerUp(PointerEventData eventData)
+        {
+            PointerUp?.Invoke(eventData);
+        }
+
+        public void OnPointerClick(PointerEventData eventData)
+        {
+            PointerClick?.Invoke(eventData);
+        }
+
+        public void OnInitializePotentialDrag(PointerEventData eventData)
+        {
+            InitializePotentialDrag?.Invoke(eventData);
+        }
+
+        public void OnBeginDrag(PointerEventData eventData)
+        {
+            BeginDrag?.Invoke(eventData);
+        }
+
+        public void OnDrag(PointerEventData eventData)
+        {
+            Drag?.Invoke(eventData);
+        }
+
+        public void OnEndDrag(PointerEventData eventData)
+        {
+            EndDrag?.Invoke(eventData);
+        }
+
+        public void OnDrop(PointerEventData eventData)
+        {
+            Drop?.Invoke(eventData);
+        }
+
+        public void OnScroll(PointerEventData eventData)
+        {
+            Scroll?.Invoke(eventData);
+        }
+
+        public void OnUpdateSelected(BaseEventData eventData)
+        {
+            UpdateSelected?.Invoke(eventData);
+        }
+
+        public void OnSelect(BaseEventData eventData)
+        {
+            Select?.Invoke(eventData);
+        }
+
+        public void OnDeselect(BaseEventData eventData)
+        {
+            Deselect?.Invoke(eventData);
+        }
+
+        public void OnMove(AxisEventData eventData)
+        {
+            Move?.Invoke(eventData);
+        }
+
+        public void OnSubmit(BaseEventData eventData)
+        {
+            Submit?.Invoke(eventData);
+        }
+
+        public void OnCancel(BaseEventData eventData)
+        {
+            Cancel?.Invoke(eventData);
+        }
+    }
+}

--- a/Basis/Packages/com.basis.shim/Shims/BasisActionTrigger.cs.meta
+++ b/Basis/Packages/com.basis.shim/Shims/BasisActionTrigger.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3c9d530cb6988364baced9c6aa089513

--- a/Basis/Packages/com.basis.shim/Shims/BasisUIExtensions.cs
+++ b/Basis/Packages/com.basis.shim/Shims/BasisUIExtensions.cs
@@ -1,0 +1,17 @@
+using UnityEngine.UI;
+
+namespace Basis.Shims
+{
+    public static class BasisUIExtensions
+    {
+        /// <summary>
+        /// Shim for Toggle.onValueChanged.AddListener to prevent direct access to onValueChanged and avoid usage of UnityEvent
+        /// </summary>
+        /// <param name="toggle"></param>
+        /// <param name="callback"></param>
+        public static void AddListener(this Toggle toggle, System.Action<bool> callback)
+        {
+            toggle.onValueChanged.AddListener((value) => callback(value));
+        }
+    }
+}

--- a/Basis/Packages/com.basis.shim/Shims/BasisUIExtensions.cs.meta
+++ b/Basis/Packages/com.basis.shim/Shims/BasisUIExtensions.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 55bd4ceba403445eaeeec22900191b03
+timeCreated: 1783160968


### PR DESCRIPTION
## Summary
* Add `BasisActionTrigger` as an alternative to EventTrigger for Cilbox which uses typed delegates instead of UnityEvent
  * I used auto properties instead of fields to fit the conventions of existing shims and because it allows for easier fine-tuned shim control with Cilbox if necessary in the future.
* Add `BasisUIExtensions`
  * Toggle.onValueChanged is a public field of type `ToggleEvent` which is a child of `UnityEvent`. I'm still not well-read on all the attack vectors relating to UnityEvent but it seemed like a cleaner solution was to avoid access to the field in general.
  * In the future it might be good to take a closer look at Button.onClick _property_ as well; currently it is permitted through the permissive UnityEngine.UI.* whitelist and no method restrictions

## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [x] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — `BasisEventDriver` runs the single per-frame tick that drives the whole framework (network apply, local player sim, blendshapes, JigglePhysics, nameplates, and more) as one sequential chain. An unhandled exception anywhere in that chain aborts the rest of the tick, so every step after the throwing one is silently skipped for that frame. New work added to the driver must either be guaranteed not to throw, or be wrapped in a `try`/`catch` that contains the failure and surfaces it through `BasisDebug` — logged once / rate-limited, never every frame (see the existing `HVRBasisBuiltInAddresses.Simulate()` guard for the pattern). Expect this to be scrutinized closely in review.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [x] Windows
- [ ] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [ ] Tested in VR (note headset under **Notes**)
- [x] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [ ] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [ ] N/A — change does not touch any of the above

## Notes
<!-- Optional context for reviewers. Headset model, why a required box is N/A, anything else worth knowing. -->
