### PR TITLE
fix(mediaplayer): move streaming prefabs onto the new object sync

### DIFF
--- a/Basis/Packages/com.basis.mediaplayer/Prefabs/MediaPlayerMultiChannelStreaming.prefab
+++ b/Basis/Packages/com.basis.mediaplayer/Prefabs/MediaPlayerMultiChannelStreaming.prefab
@@ -258,8 +258,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: BasisSDK::BasisProp
   BasisBundleDescription:
-    AssetBundleName: BasisMediaPlayer
-    AssetBundleDescription: 0.01 Made by the basis team
+    AssetBundleName: Basis Multichannel Media Player
+    AssetBundleDescription: 0.1.0 Made by the Basis team
     AssetBundleIcon: {fileID: 0}
     Tags:
     - MediaPlayer

--- a/Basis/Packages/com.basis.mediaplayer/Prefabs/MediaPlayerMultiChannelStreaming.prefab
+++ b/Basis/Packages/com.basis.mediaplayer/Prefabs/MediaPlayerMultiChannelStreaming.prefab
@@ -216,6 +216,7 @@ MonoBehaviour:
   MaterialIndex: 0
   TexturePropertyName: _BaseMap
   UseSharedMaterial: 0
+  AdditionalTargets: []
   PlaceholderTexture: {fileID: 2800000, guid: 93f0d4f9be07b5e4094ac46f24473eb1, type: 3}
   RestorePlaceholderOnEnded: 1
   FlipVertically: 0
@@ -384,37 +385,100 @@ MonoBehaviour:
   IsOwnedLocallyOnServer: 0
   IsOwnedLocallyOnClient: 0
   CurrentOwnerId: 0
-  BasisPickupInteractable: {fileID: 0}
+  SendIntervalSeconds: 0.05
+  KeyframeIntervalSeconds: 0.5
+  ContinuousEpsilon: 0.0001
+  RotationSendThresholdDegrees: 0.5
+  UseDirectP2P: 1
+  ForceP2POnly: 0
+  OverrideP2PRate: 0
+  P2PSendIntervalSeconds: 0.033
+  P2PKeyframeIntervalSeconds: 0.5
+  Delivery: 4
+  KeyframeDelivery: 2
+  Extrapolate: 0
+  MaxExtrapolationSeconds: 0.2
+  JitterBufferDepth: 2
+  UseTeleportThreshold: 0
+  TeleportThreshold: 3
+  DistanceReduction: 1
+  RelevanceCulling: 0
+  RelevanceRadius: 50
+  UseChecksum: 1
+  _serializedVersion: 3
+  Target: {fileID: 4539219426615105233}
+  SyncPosition: 1
+  PositionX: 1
+  PositionY: 1
+  PositionZ: 1
+  SyncRotation: 1
+  RotationMode: 0
+  SmallestThreeBits: 9
+  RotationX: 1
+  RotationY: 1
+  RotationZ: 1
+  SyncScale: 1
+  ScaleUniform: 0
+  ScaleX: 1
+  ScaleY: 1
+  ScaleZ: 1
+  WorldSpace: 0
+  RelativeTo: {fileID: 0}
+  InterpolatePosition: 1
+  InterpolateRotation: 1
+  InterpolateScale: 1
+  PosCompX:
+    Mode: 0
+    Min: -1024
+    Max: 1024
+    Bits: 16
+  PosCompY:
+    Mode: 0
+    Min: -1024
+    Max: 1024
+    Bits: 16
+  PosCompZ:
+    Mode: 0
+    Min: -1024
+    Max: 1024
+    Bits: 16
+  RotCompX:
+    Mode: 0
+    Min: 0
+    Max: 360
+    Bits: 16
+  RotCompY:
+    Mode: 0
+    Min: 0
+    Max: 360
+    Bits: 16
+  RotCompZ:
+    Mode: 0
+    Min: 0
+    Max: 360
+    Bits: 16
+  ScaleCompX:
+    Mode: 0
+    Min: 0
+    Max: 64
+    Bits: 16
+  ScaleCompY:
+    Mode: 0
+    Min: 0
+    Max: 64
+    Bits: 16
+  ScaleCompZ:
+    Mode: 0
+    Min: 0
+    Max: 64
+    Bits: 16
+  BasisPickupInteractable: {fileID: 8032660331847527714}
   CanNetworkSteal: 1
   IsStatic: 0
-  LocalLastData:
-    x: 0
-    y: 0
-    z: 0
-    Rotation: 0
-    Scalex: 0
-    Scaley: 0
-    Scalez: 0
-  BTU:
-    TargetPosition:
-      x: 0
-      y: 0
-      z: 0
-    TargetRotation:
-      value:
-        x: 0
-        y: 0
-        z: 0
-        w: 0
-    TargetScales:
-      x: 0
-      y: 0
-      z: 0
-    LerpMultipliers: 0
   pendingStealRequest: {fileID: 0}
-  CatchupLerp: 5
-  buffer: 00000000000000000000000000000000
-  SelfTransform: {fileID: 0}
+  RemoteDeadReckon: 0
+  AttachToHandOnGrab: 1
+  FullRateWhileHeld: 1
 --- !u!54 &5614413552750403139
 Rigidbody:
   m_ObjectHideFlags: 0

--- a/Basis/Packages/com.basis.mediaplayer/Prefabs/MediaPlayerStreaming.prefab
+++ b/Basis/Packages/com.basis.mediaplayer/Prefabs/MediaPlayerStreaming.prefab
@@ -806,8 +806,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: BasisSDK::BasisProp
   BasisBundleDescription:
-    AssetBundleName: BasisMediaPlayer
-    AssetBundleDescription: 0.02 Made by the basis team
+    AssetBundleName: Basis Media Player
+    AssetBundleDescription: 0.1.0 Made by the Basis team
     AssetBundleIcon: {fileID: 0}
     Tags:
     - MediaPlayer

--- a/Basis/Packages/com.basis.mediaplayer/Prefabs/MediaPlayerStreaming.prefab
+++ b/Basis/Packages/com.basis.mediaplayer/Prefabs/MediaPlayerStreaming.prefab
@@ -764,6 +764,7 @@ MonoBehaviour:
   MaterialIndex: 0
   TexturePropertyName: _BaseMap
   UseSharedMaterial: 0
+  AdditionalTargets: []
   PlaceholderTexture: {fileID: 2800000, guid: 93f0d4f9be07b5e4094ac46f24473eb1, type: 3}
   RestorePlaceholderOnEnded: 1
   FlipVertically: 0
@@ -932,37 +933,100 @@ MonoBehaviour:
   IsOwnedLocallyOnServer: 0
   IsOwnedLocallyOnClient: 0
   CurrentOwnerId: 0
-  BasisPickupInteractable: {fileID: 0}
+  SendIntervalSeconds: 0.05
+  KeyframeIntervalSeconds: 0.5
+  ContinuousEpsilon: 0.0001
+  RotationSendThresholdDegrees: 0.5
+  UseDirectP2P: 1
+  ForceP2POnly: 0
+  OverrideP2PRate: 0
+  P2PSendIntervalSeconds: 0.033
+  P2PKeyframeIntervalSeconds: 0.5
+  Delivery: 4
+  KeyframeDelivery: 2
+  Extrapolate: 0
+  MaxExtrapolationSeconds: 0.2
+  JitterBufferDepth: 2
+  UseTeleportThreshold: 0
+  TeleportThreshold: 3
+  DistanceReduction: 1
+  RelevanceCulling: 0
+  RelevanceRadius: 50
+  UseChecksum: 1
+  _serializedVersion: 3
+  Target: {fileID: 4507114126077030822}
+  SyncPosition: 1
+  PositionX: 1
+  PositionY: 1
+  PositionZ: 1
+  SyncRotation: 1
+  RotationMode: 0
+  SmallestThreeBits: 9
+  RotationX: 1
+  RotationY: 1
+  RotationZ: 1
+  SyncScale: 1
+  ScaleUniform: 0
+  ScaleX: 1
+  ScaleY: 1
+  ScaleZ: 1
+  WorldSpace: 0
+  RelativeTo: {fileID: 0}
+  InterpolatePosition: 1
+  InterpolateRotation: 1
+  InterpolateScale: 1
+  PosCompX:
+    Mode: 0
+    Min: -1024
+    Max: 1024
+    Bits: 16
+  PosCompY:
+    Mode: 0
+    Min: -1024
+    Max: 1024
+    Bits: 16
+  PosCompZ:
+    Mode: 0
+    Min: -1024
+    Max: 1024
+    Bits: 16
+  RotCompX:
+    Mode: 0
+    Min: 0
+    Max: 360
+    Bits: 16
+  RotCompY:
+    Mode: 0
+    Min: 0
+    Max: 360
+    Bits: 16
+  RotCompZ:
+    Mode: 0
+    Min: 0
+    Max: 360
+    Bits: 16
+  ScaleCompX:
+    Mode: 0
+    Min: 0
+    Max: 64
+    Bits: 16
+  ScaleCompY:
+    Mode: 0
+    Min: 0
+    Max: 64
+    Bits: 16
+  ScaleCompZ:
+    Mode: 0
+    Min: 0
+    Max: 64
+    Bits: 16
+  BasisPickupInteractable: {fileID: 3404733239259574964}
   CanNetworkSteal: 1
   IsStatic: 0
-  LocalLastData:
-    x: 0
-    y: 0
-    z: 0
-    Rotation: 0
-    Scalex: 0
-    Scaley: 0
-    Scalez: 0
-  BTU:
-    TargetPosition:
-      x: 0
-      y: 0
-      z: 0
-    TargetRotation:
-      value:
-        x: 0
-        y: 0
-        z: 0
-        w: 0
-    TargetScales:
-      x: 0
-      y: 0
-      z: 0
-    LerpMultipliers: 0
   pendingStealRequest: {fileID: 0}
-  CatchupLerp: 5
-  buffer: 00000000000000000000000000000000
-  SelfTransform: {fileID: 0}
+  RemoteDeadReckon: 0
+  AttachToHandOnGrab: 1
+  FullRateWhileHeld: 1
 --- !u!54 &7733138127675236971
 Rigidbody:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## Summary
Both streaming media-player prefabs — `MediaPlayerStreaming` and `MediaPlayerMultiChannelStreaming` — were still serialised against the pre-migration object sync. This moves them onto the current `BasisSyncedTransform`-based sync:

- **Re-serialised onto the current schema (v3).** The legacy pickup-sync fields (`LocalLastData`, `BTU`, `CatchupLerp`, `buffer`, `SelfTransform`) are dropped and the position/rotation/scale channels come across via the component's built-in migration.
- **`Target` wired to each prefab's own root transform.** It was unassigned (`{fileID: 0}`), which the inspector flagged as an error even though `Awake` defaults it — now it's explicit.
- **Attach To Hand While Held enabled.** While a player carries the screen, it streams the hand-relative grab offset instead of the world pose, so it stays glued to the holder's hand bone on every client with no interpolation lag.

It also gives the two prefabs distinct, human-readable prop bundle names (`Basis Media Player` / `Basis Multichannel Media Player`) and sets the bundle description to `0.1.0` — a separate commit from the sync change.

Prefab assets only — no C# changes.

## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [x] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — `BasisEventDriver` runs the single per-frame tick that drives the whole framework (network apply, local player sim, blendshapes, JigglePhysics, nameplates, and more) as one sequential chain. An unhandled exception anywhere in that chain aborts the rest of the tick, so every step after the throwing one is silently skipped for that frame. New work added to the driver must either be guaranteed not to throw, or be wrapped in a `try`/`catch` that contains the failure and surfaces it through `BasisDebug` — logged once / rate-limited, never every frame (see the existing `HVRBasisBuiltInAddresses.Simulate()` guard for the pattern). Expect this to be scrutinized closely in review.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [x] Windows
- [ ] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [ ] Tested in VR (note headset under **Notes**)
- [x] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [ ] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [x] N/A — change does not touch any of the above

## Notes
This PR only touches two prefab assets — there's no C# in it — so the code-path required checks (transform access, `GetComponent`, `BasisEventDriver`, jobification, `{ get; set; }`, camera driver, logging, scene discovery, allocations, hot-path collections, Addressables) don't apply and are ticked N/A. The behaviour they gate lives in the already-shipped `BasisPickupSyncNetworking` / `BasisSyncedTransform`, which this change only configures.

Verification was in-editor on Windows: both prefabs reimported clean onto the v3 schema with no console errors, `Target` resolves to each prefab's root transform, and the inspector no longer flags an unassigned target. A two-client VR grab test (to watch Attach-To-Hand on a remote) is still worth doing before/at review — happy to run it if you'd like me to hold the PR for that.
