### PR TITLE
feat(library): optional secondary action button on shareable Library entries

### DIFF
--- a/Basis/Packages/com.basis.framework/BasisUI/Menus/Library/LibraryProvider.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Menus/Library/LibraryProvider.cs
@@ -2041,43 +2041,68 @@ namespace Basis.BasisUI
             itemTextInfo.Descriptor.SetHeight(50);
             itemTextInfo.Descriptor.SetWidth(400);
 
-            // Optional secondary action (registered by the entry's provider —
-            // e.g. a Share/Unshare toggle): a labeled button beside the trash,
-            // with an optional consent-style yes/no dialog in front of it.
-            if (!string.IsNullOrEmpty(entry.ActionLabel))
+            // Buttons registered by the entry's provider, rendered in order — e.g. a
+            // Share/Unshare toggle followed by a remove button. Removal is just a
+            // Destructive action; the Library has no dedicated remove path.
+            if (entry.Actions != null)
             {
-                PanelButton actionItem = PanelButton.CreateNew(ButtonStyles.AcceptButton, itemListPanel.TabButtonParent);
-                actionItem.Descriptor.SetTitle(entry.ActionLabel);
-                actionItem.SetSize(new Vector2(180, 80));
-                actionItem.OnClicked += async () =>
+                foreach (BasisShareableAction action in entry.Actions)
                 {
-                    if (!string.IsNullOrEmpty(entry.ActionConfirmTitle))
-                    {
-                        DialogBox<bool> confirmDialog = DialogBox<bool>.Create(panel, new Vector2(650, 180),
-                            entry.ActionConfirmTitle,
-                            entry.ActionConfirmBody ?? string.Empty,
-                            AddressableAssets.Sprites.Information,
-                            true
-                        );
-                        LibraryProviderDialogRemove.BuildDialogButtons(confirmDialog);
-                        if (!await confirmDialog.WaitAsync()) return;
-                    }
-                    entry.Action?.Invoke();
-                };
+                    if (action == null || action.Invoke == null) continue;
+                    CreateShareableActionButton(entry, itemListPanel, action);
+                }
+            }
+        }
+
+        private static void CreateShareableActionButton(BasisShareableEntry entry, PanelTabGroup itemListPanel, BasisShareableAction action)
+        {
+            bool destructive = action.Style == BasisShareableActionStyle.Destructive;
+            PanelButton actionItem = PanelButton.CreateNew(destructive ? ButtonStyles.CancelButton : ButtonStyles.AcceptButton, itemListPanel.TabButtonParent);
+
+            if (destructive && string.IsNullOrEmpty(action.Label))
+            {
+                // Icon-only trash button (the standard remove affordance).
+                actionItem.Descriptor.SetTitle(string.Empty);
+                actionItem.SetIcon(AddressableAssets.Sprites.Trash);
+                actionItem.SetSize(new Vector2(80, 80));
+                actionItem.Descriptor.IconImage.rectTransform.sizeDelta = new Vector2(-30, -30);
+                actionItem.Descriptor.SetTooltip(BasisLocalization.Get("library.instantiated.remove.tooltip"));
+            }
+            else
+            {
+                actionItem.Descriptor.SetTitle(action.Label ?? string.Empty);
+                actionItem.SetSize(new Vector2(180, 80));
             }
 
-            PanelButton removeItem = PanelButton.CreateNew(ButtonStyles.CancelButton, itemListPanel.TabButtonParent);
-            removeItem.Descriptor.SetTitle(string.Empty);
-            removeItem.SetIcon(AddressableAssets.Sprites.Trash);
-            removeItem.SetSize(new Vector2(80, 80));
-            removeItem.Descriptor.IconImage.rectTransform.sizeDelta = new Vector2(-30, -30);
-            removeItem.Descriptor.SetTooltip(BasisLocalization.Get("library.instantiated.remove.tooltip"));
-            removeItem.OnClicked += async () =>
+            actionItem.OnClicked += async () =>
             {
-                bool confirmed = await LibraryProviderDialogRemove.PromptUserForRemoval(panel, ShareableDisplayName(entry), ShareableKindLabel(entry.Kind));
-                if (!confirmed) return;
-                entry.Remove?.Invoke();
+                if (!await ConfirmShareableAction(entry, action)) return;
+                action.Invoke?.Invoke();
             };
+        }
+
+        // Returns true if the action should proceed. Explicit confirm text wins; otherwise
+        // a Destructive action falls back to the Library's standard "remove {name}?" prompt.
+        private static async Task<bool> ConfirmShareableAction(BasisShareableEntry entry, BasisShareableAction action)
+        {
+            if (!string.IsNullOrEmpty(action.ConfirmTitle))
+            {
+                DialogBox<bool> confirmDialog = DialogBox<bool>.Create(panel, new Vector2(650, 180),
+                    action.ConfirmTitle,
+                    action.ConfirmBody ?? string.Empty,
+                    AddressableAssets.Sprites.Information,
+                    true
+                );
+                LibraryProviderDialogRemove.BuildDialogButtons(confirmDialog);
+                return await confirmDialog.WaitAsync();
+            }
+
+            if (action.Style == BasisShareableActionStyle.Destructive)
+            {
+                return await LibraryProviderDialogRemove.PromptUserForRemoval(panel, ShareableDisplayName(entry), ShareableKindLabel(entry.Kind));
+            }
+
+            return true;
         }
 
         private static string ShareableIcon(BasisShareableKind kind)

--- a/Basis/Packages/com.basis.framework/BasisUI/Menus/Library/LibraryProvider.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Menus/Library/LibraryProvider.cs
@@ -2041,6 +2041,31 @@ namespace Basis.BasisUI
             itemTextInfo.Descriptor.SetHeight(50);
             itemTextInfo.Descriptor.SetWidth(400);
 
+            // Optional secondary action (registered by the entry's provider —
+            // e.g. a Share/Unshare toggle): a labeled button beside the trash,
+            // with an optional consent-style yes/no dialog in front of it.
+            if (!string.IsNullOrEmpty(entry.ActionLabel))
+            {
+                PanelButton actionItem = PanelButton.CreateNew(ButtonStyles.AcceptButton, itemListPanel.TabButtonParent);
+                actionItem.Descriptor.SetTitle(entry.ActionLabel);
+                actionItem.SetSize(new Vector2(180, 80));
+                actionItem.OnClicked += async () =>
+                {
+                    if (!string.IsNullOrEmpty(entry.ActionConfirmTitle))
+                    {
+                        DialogBox<bool> confirmDialog = DialogBox<bool>.Create(panel, new Vector2(650, 180),
+                            entry.ActionConfirmTitle,
+                            entry.ActionConfirmBody ?? string.Empty,
+                            AddressableAssets.Sprites.Information,
+                            true
+                        );
+                        LibraryProviderDialogRemove.BuildDialogButtons(confirmDialog);
+                        if (!await confirmDialog.WaitAsync()) return;
+                    }
+                    entry.Action?.Invoke();
+                };
+            }
+
             PanelButton removeItem = PanelButton.CreateNew(ButtonStyles.CancelButton, itemListPanel.TabButtonParent);
             removeItem.Descriptor.SetTitle(string.Empty);
             removeItem.SetIcon(AddressableAssets.Sprites.Trash);

--- a/Basis/Packages/com.basis.framework/BasisUI/Menus/Library/LibraryProvider.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Menus/Library/LibraryProvider.cs
@@ -2057,28 +2057,21 @@ namespace Basis.BasisUI
         private static void CreateShareableActionButton(BasisShareableEntry entry, PanelTabGroup itemListPanel, BasisShareableAction action)
         {
             bool destructive = action.Style == BasisShareableActionStyle.Destructive;
-            PanelButton actionItem = PanelButton.CreateNew(destructive ? ButtonStyles.CancelButton : ButtonStyles.AcceptButton, itemListPanel.TabButtonParent);
+            // A destructive action with no label is the standard icon-only trash affordance.
+            bool trashButton = destructive && string.IsNullOrEmpty(action.Label);
 
-            if (destructive && string.IsNullOrEmpty(action.Label))
+            BuildEntryActionButton(itemListPanel.TabButtonParent, new EntryActionButton
             {
-                // Icon-only trash button (the standard remove affordance).
-                actionItem.Descriptor.SetTitle(string.Empty);
-                actionItem.SetIcon(AddressableAssets.Sprites.Trash);
-                actionItem.SetSize(new Vector2(80, 80));
-                actionItem.Descriptor.IconImage.rectTransform.sizeDelta = new Vector2(-30, -30);
-                actionItem.Descriptor.SetTooltip(BasisLocalization.Get("library.instantiated.remove.tooltip"));
-            }
-            else
-            {
-                actionItem.Descriptor.SetTitle(action.Label ?? string.Empty);
-                actionItem.SetSize(new Vector2(180, 80));
-            }
-
-            actionItem.OnClicked += async () =>
-            {
-                if (!await ConfirmShareableAction(entry, action)) return;
-                action.Invoke?.Invoke();
-            };
+                Style = destructive ? ButtonStyles.CancelButton : ButtonStyles.AcceptButton,
+                Icon = trashButton ? AddressableAssets.Sprites.Trash : null,
+                Label = action.Label,
+                Tooltip = trashButton ? BasisLocalization.Get("library.instantiated.remove.tooltip") : null,
+                OnClick = async () =>
+                {
+                    if (!await ConfirmShareableAction(entry, action)) return;
+                    action.Invoke?.Invoke();
+                },
+            });
         }
 
         // Returns true if the action should proceed. Explicit confirm text wins; otherwise
@@ -2103,6 +2096,53 @@ namespace Basis.BasisUI
             }
 
             return true;
+        }
+
+        // One small action button on a Library list entry. Used by both the shareables tab
+        // and the instantiated-objects tab so every entry button shares the same sizing,
+        // icon inset, tooltip and hidden/disabled handling. Field defaults (all false/null)
+        // are the common case: visible, enabled, no tooltip.
+        private struct EntryActionButton
+        {
+            public string Style;          // ButtonStyles.* prefab
+            public string Icon;           // sprite key; ignored when Label is set
+            public string Label;          // set => labeled 180x80 button; empty => icon-only 80x80
+            public string Tooltip;
+            public bool Hidden;           // hides the button (e.g. not applicable to this entry)
+            public bool Disabled;
+            public string DisabledReason; // surfaced when Disabled
+            public Func<Task> OnClick;
+        }
+
+        private static PanelButton BuildEntryActionButton(Component parent, in EntryActionButton spec)
+        {
+            PanelButton button = PanelButton.CreateNew(spec.Style, parent);
+
+            if (string.IsNullOrEmpty(spec.Label))
+            {
+                button.Descriptor.SetTitle(string.Empty);
+                if (!string.IsNullOrEmpty(spec.Icon))
+                {
+                    button.SetIcon(spec.Icon);
+                    // Inset the icon so its strokes stay clear of the bevel — matches PE Image Simple Square's pattern.
+                    button.Descriptor.IconImage.rectTransform.sizeDelta = new Vector2(-30, -30);
+                }
+                button.SetSize(new Vector2(80, 80));
+            }
+            else
+            {
+                button.Descriptor.SetTitle(spec.Label);
+                button.SetSize(new Vector2(180, 80));
+            }
+
+            if (!string.IsNullOrEmpty(spec.Tooltip)) button.Descriptor.SetTooltip(spec.Tooltip);
+            if (spec.Hidden) button.Descriptor.SetActive(false);
+            if (spec.Disabled) button.SetInteractable(false, spec.DisabledReason);
+
+            Func<Task> onClick = spec.OnClick;
+            if (onClick != null) button.OnClicked += async () => await onClick();
+
+            return button;
         }
 
         private static string ShareableIcon(BasisShareableKind kind)
@@ -2277,69 +2317,63 @@ namespace Basis.BasisUI
 
             bool isScene = itemKey.SpawnMode == BasisRuntimeSpawnRegistry.SpawnMode.Scene;
 
-            PanelButton selectItem = PanelButton.CreateNew(ButtonStyles.AcceptButton, itemListPanel.TabButtonParent);
-            selectItem.Descriptor.SetTitle(string.Empty);
-            selectItem.SetIcon(AddressableAssets.Sprites.Select);
-            selectItem.SetSize(new Vector2(80, 80));
-            // Inset the icon so its strokes stay clear of the bevel — matches PE Image Simple Square's pattern.
-            selectItem.Descriptor.IconImage.rectTransform.sizeDelta = new Vector2(-30, -30);
-
-            selectItem.Descriptor.SetActive(!isScene);
-            selectItem.Descriptor.SetTooltip(BasisLocalization.Get("library.instantiated.select.tooltip"));
-            selectItem.OnClicked += async () =>
+            BuildEntryActionButton(itemListPanel.TabButtonParent, new EntryActionButton
             {
-                if(hasSelected)
+                Style = ButtonStyles.AcceptButton,
+                Icon = AddressableAssets.Sprites.Select,
+                Tooltip = BasisLocalization.Get("library.instantiated.select.tooltip"),
+                Hidden = isScene,
+                OnClick = async () =>
                 {
-                    PlacementManager.RemoveSelectionSpawnInstanceID(itemKey);
-                    
-                    await RefreshCurrentTab();
-                }
-                else
-                {    
-                    // send the selection
-                    PlacementManager.SetActiveSelection(itemKey);
-                    
-                    // close the menu
-                    BasisMainMenu.Close();
-                }
-        
-            };
+                    if (hasSelected)
+                    {
+                        PlacementManager.RemoveSelectionSpawnInstanceID(itemKey);
+                        await RefreshCurrentTab();
+                    }
+                    else
+                    {
+                        // send the selection
+                        PlacementManager.SetActiveSelection(itemKey);
+                        // close the menu
+                        BasisMainMenu.Close();
+                    }
+                },
+            });
 
-            PanelButton TeleportToItem = PanelButton.CreateNew(ButtonStyles.StandardButton, itemListPanel.TabButtonParent);
-            TeleportToItem.Descriptor.SetTitle(string.Empty);
-            TeleportToItem.SetIcon(AddressableAssets.Sprites.TeleportTo);
-            TeleportToItem.SetSize(new Vector2(80, 80));
-            TeleportToItem.Descriptor.IconImage.rectTransform.sizeDelta = new Vector2(-30, -30);
-
-            TeleportToItem.Descriptor.SetActive(!isScene);
-            TeleportToItem.Descriptor.SetTooltip(BasisLocalization.Get("library.instantiated.teleport.tooltip"));
-            TeleportToItem.OnClicked += () =>
+            BuildEntryActionButton(itemListPanel.TabButtonParent, new EntryActionButton
             {
-
-                switch(itemKey.SpawnMode)
+                Style = ButtonStyles.StandardButton,
+                Icon = AddressableAssets.Sprites.TeleportTo,
+                Tooltip = BasisLocalization.Get("library.instantiated.teleport.tooltip"),
+                Hidden = isScene,
+                OnClick = () =>
                 {
-                    case BasisRuntimeSpawnRegistry.SpawnMode.Avatar:
-                    case BasisRuntimeSpawnRegistry.SpawnMode.GameObject:
+                    switch (itemKey.SpawnMode)
+                    {
+                        case BasisRuntimeSpawnRegistry.SpawnMode.Avatar:
+                        case BasisRuntimeSpawnRegistry.SpawnMode.GameObject:
 
-                        // find the object in the BasisRuntimeSpawnRegistry
-                        if (BasisRuntimeSpawnRegistry.SpawnedGameobjects.TryGetValue(itemKey.LoadedNetID, out GameObject go) && go != null)
-                        {
-                            Vector3 offsetTarget = go.transform.position;
-
-                            if(itemKey.bundleConnector != null)
+                            // find the object in the BasisRuntimeSpawnRegistry
+                            if (BasisRuntimeSpawnRegistry.SpawnedGameobjects.TryGetValue(itemKey.LoadedNetID, out GameObject go) && go != null)
                             {
-                                offsetTarget.y = offsetTarget.y + itemKey.bundleConnector.Bounds.max.y;
+                                Vector3 offsetTarget = go.transform.position;
+
+                                if (itemKey.bundleConnector != null)
+                                {
+                                    offsetTarget.y = offsetTarget.y + itemKey.bundleConnector.Bounds.max.y;
+                                }
+
+                                BasisLocalPlayer.Instance.Teleport( offsetTarget, Quaternion.identity, mode: BasisTeleportMode.WorldFeet );
                             }
 
-                            BasisLocalPlayer.Instance.Teleport( offsetTarget, Quaternion.identity, mode: BasisTeleportMode.WorldFeet );
-                        }
-
-                    break;
-                    case BasisRuntimeSpawnRegistry.SpawnMode.Scene:
-                        BasisDebug.LogWarning( "LibraryProvider.cs -> Teleport To Item button for scene is not implemented!" );
-                    break;
-                }
-            };
+                        break;
+                        case BasisRuntimeSpawnRegistry.SpawnMode.Scene:
+                            BasisDebug.LogWarning( "LibraryProvider.cs -> Teleport To Item button for scene is not implemented!" );
+                        break;
+                    }
+                    return Task.CompletedTask;
+                },
+            });
 
             // Static / lock toggle — networked game objects only; applies for everyone (server-authoritative).
             // Cycles None -> Static (creator or moderator) -> Admin-locked (moderator only) -> None.
@@ -2371,131 +2405,127 @@ namespace Basis.BasisUI
                         break;
                 }
 
-                PanelButton staticToggle = PanelButton.CreateNew(ButtonStyles.StandardButton, itemListPanel.TabButtonParent);
-                staticToggle.Descriptor.SetTitle(string.Empty);
-                staticToggle.SetIcon(lockLevel == 0 ? AddressableAssets.Sprites.Unlocked
-                                   : lockLevel == 1 ? AddressableAssets.Sprites.Locked
-                                   : AddressableAssets.Sprites.Admin);
-                staticToggle.SetSize(new Vector2(80, 80));
-                staticToggle.Descriptor.IconImage.rectTransform.sizeDelta = new Vector2(-30, -30);
-                staticToggle.Descriptor.SetTooltip(BasisLocalization.Get(
-                    lockLevel == 0 ? "library.instantiated.static.tooltip"
-                  : lockLevel == 1 ? "library.instantiated.static.lockedTooltip"
-                  : "library.instantiated.static.adminTooltip"));
-
                 // Disabled reason depends on why: an admin-locked item can only be changed by a moderator.
                 string disabledReason = lockLevel == 2
                     ? BasisLocalization.Get("library.instantiated.static.adminOnly")
                     : BasisLocalization.Get("library.instantiated.static.noPermission");
-                staticToggle.SetInteractable(canToggle, canToggle ? null : disabledReason);
 
-                staticToggle.OnClicked += () =>
+                BuildEntryActionButton(itemListPanel.TabButtonParent, new EntryActionButton
                 {
-                    // Mode 0 = GameObject. The server authorizes per tier and rebroadcasts; the row
-                    // icon updates when that broadcast arrives (RegistryChangeType.Modified).
-                    BasisNetworkSpawnItem.RequestSetStatic(itemKey.LoadedNetID, 0, nextStatic, nextAdmin);
-                };
+                    Style = ButtonStyles.StandardButton,
+                    Icon = lockLevel == 0 ? AddressableAssets.Sprites.Unlocked
+                         : lockLevel == 1 ? AddressableAssets.Sprites.Locked
+                         : AddressableAssets.Sprites.Admin,
+                    Tooltip = BasisLocalization.Get(
+                        lockLevel == 0 ? "library.instantiated.static.tooltip"
+                      : lockLevel == 1 ? "library.instantiated.static.lockedTooltip"
+                      : "library.instantiated.static.adminTooltip"),
+                    Disabled = !canToggle,
+                    DisabledReason = disabledReason,
+                    OnClick = () =>
+                    {
+                        // Mode 0 = GameObject. The server authorizes per tier and rebroadcasts; the row
+                        // icon updates when that broadcast arrives (RegistryChangeType.Modified).
+                        BasisNetworkSpawnItem.RequestSetStatic(itemKey.LoadedNetID, 0, nextStatic, nextAdmin);
+                        return Task.CompletedTask;
+                    },
+                });
             }
 
-            PanelButton removeItem = PanelButton.CreateNew(ButtonStyles.CancelButton, itemListPanel.TabButtonParent);
-            removeItem.Descriptor.SetTitle(string.Empty);
-            removeItem.SetIcon(AddressableAssets.Sprites.Trash);
-            removeItem.SetSize(new Vector2(80, 80));
-            removeItem.Descriptor.IconImage.rectTransform.sizeDelta = new Vector2(-30, -30);
-            removeItem.Descriptor.SetTooltip(BasisLocalization.Get("library.instantiated.remove.tooltip"));
+            // Network items can be protected; only an admin may remove those. Non-network items always removable.
+            bool canRemove = itemKey.SpawnMethod != BasisRuntimeSpawnRegistry.SpawnMethod.Network || !itemKey.isProtected || IsProtected;
 
-            // only apply this to items that are spawned on the network
-            if(itemKey.SpawnMethod == BasisRuntimeSpawnRegistry.SpawnMethod.Network)
+            BuildEntryActionButton(itemListPanel.TabButtonParent, new EntryActionButton
             {
-                // determine if we can actually remove this via admin
-                // if the item is embedded only allow an admin to interact
-                bool canRemove = !itemKey.isProtected || IsProtected;
-                removeItem.SetInteractable(canRemove, canRemove ? null : BasisLocalization.Get("library.disabled.protected"));
-            }
-
-            removeItem.OnClicked += async () =>
-            {
-                BasisDebug.Log($"CreateListEntry() -> requested removal of item = {itemKey.Url} of instanceID = {instanceID} of SpawnMethod = {itemKey.SpawnMethod} and SpawnMode = {itemKey.SpawnMode}");
-
-                bool result = await LibraryProviderDialogRemove.PromptUserForRemoval(panel, title, itemKey.SpawnMode.ToString());
-
-                if (!result) // if the result is false
+                Style = ButtonStyles.CancelButton,
+                Icon = AddressableAssets.Sprites.Trash,
+                Tooltip = BasisLocalization.Get("library.instantiated.remove.tooltip"),
+                Disabled = !canRemove,
+                DisabledReason = canRemove ? null : BasisLocalization.Get("library.disabled.protected"),
+                OnClick = async () =>
                 {
-                    return; // guard key stop here
-                }
+                    BasisDebug.Log($"CreateListEntry() -> requested removal of item = {itemKey.Url} of instanceID = {instanceID} of SpawnMethod = {itemKey.SpawnMethod} and SpawnMode = {itemKey.SpawnMode}");
 
-                // clear up front; network removals fire OnRegistryChanged.Removed async after a round-trip
-                PlacementManager.RemoveSelectionSpawnInstanceID(itemKey);
+                    bool result = await LibraryProviderDialogRemove.PromptUserForRemoval(panel, title, itemKey.SpawnMode.ToString());
 
-                switch (itemKey.SpawnMethod)
-                {
-                    case BasisRuntimeSpawnRegistry.SpawnMethod.Local:
-                    case BasisRuntimeSpawnRegistry.SpawnMethod.Embedded:
+                    if (!result) // if the result is false
+                    {
+                        return; // guard key stop here
+                    }
 
-                        // If this content was set to load on boot, removing it here also stops it
-                        // from coming back next launch. No-op when it was never a boot item.
-                        _ = BasisPreloadContentStore.Remove(itemKey.Url);
+                    // clear up front; network removals fire OnRegistryChanged.Removed async after a round-trip
+                    PlacementManager.RemoveSelectionSpawnInstanceID(itemKey);
 
-                        switch(itemKey.SpawnMode)
-                        {
-                            case BasisRuntimeSpawnRegistry.SpawnMode.Avatar:
-                            case BasisRuntimeSpawnRegistry.SpawnMode.GameObject:
+                    switch (itemKey.SpawnMethod)
+                    {
+                        case BasisRuntimeSpawnRegistry.SpawnMethod.Local:
+                        case BasisRuntimeSpawnRegistry.SpawnMethod.Embedded:
 
-                                // if the item is local and embedded lets actually try get the gameobject first
-                                if (BasisRuntimeSpawnRegistry.SpawnedGameobjects.TryGetValue(itemKey.LoadedNetID, out GameObject go) && go != null)
-                                {
-                                    // if the gameobject is not null then lets remove its registery
-                                    bool success = await BasisRuntimeSpawnRegistry.RemoveByLoadedNetId(itemKey.LoadedNetID);
-                                    if (success)
+                            // If this content was set to load on boot, removing it here also stops it
+                            // from coming back next launch. No-op when it was never a boot item.
+                            _ = BasisPreloadContentStore.Remove(itemKey.Url);
+
+                            switch(itemKey.SpawnMode)
+                            {
+                                case BasisRuntimeSpawnRegistry.SpawnMode.Avatar:
+                                case BasisRuntimeSpawnRegistry.SpawnMode.GameObject:
+
+                                    // if the item is local and embedded lets actually try get the gameobject first
+                                    if (BasisRuntimeSpawnRegistry.SpawnedGameobjects.TryGetValue(itemKey.LoadedNetID, out GameObject go) && go != null)
                                     {
-                                        // we should delete the embedded item
-                                        GameObject.Destroy(go);
-                                    }
-                                    else
-                                    {
-                                        BasisDebug.LogError($"failed to remove item = {instanceID} that has itemKey.SpawnMethod = {itemKey.SpawnMethod} from basis BasisRuntimeSpawnRegistry");
+                                        // if the gameobject is not null then lets remove its registery
+                                        bool success = await BasisRuntimeSpawnRegistry.RemoveByLoadedNetId(itemKey.LoadedNetID);
+                                        if (success)
+                                        {
+                                            // we should delete the embedded item
+                                            GameObject.Destroy(go);
+                                        }
+                                        else
+                                        {
+                                            BasisDebug.LogError($"failed to remove item = {instanceID} that has itemKey.SpawnMethod = {itemKey.SpawnMethod} from basis BasisRuntimeSpawnRegistry");
+                                        }
+
                                     }
 
-                                }
+                                break;
+
+                                case BasisRuntimeSpawnRegistry.SpawnMode.Scene:
+
+                                    if(BasisRuntimeSpawnRegistry.SpawnedScenes.TryGetValue(itemKey.LoadedNetID, out Scene scene) && scene.IsValid())
+                                    {
+                                        bool success = await BasisRuntimeSpawnRegistry.RemoveByLoadedNetId(itemKey.LoadedNetID);
+                                        if(success)
+                                        {
+                                            BasisDebug.Log( $"successfully removed scene with LoadedNetID = {itemKey.LoadedNetID}" );
+                                        }
+                                        else
+                                        {
+                                            BasisDebug.LogError($"failed to remove scene with LoadedNetID = {instanceID}");
+                                        }
+                                    }
+
+                                break;
+                            }
 
                             break;
-
-                            case BasisRuntimeSpawnRegistry.SpawnMode.Scene:
-
-                                if(BasisRuntimeSpawnRegistry.SpawnedScenes.TryGetValue(itemKey.LoadedNetID, out Scene scene) && scene.IsValid())
-                                {
-                                    bool success = await BasisRuntimeSpawnRegistry.RemoveByLoadedNetId(itemKey.LoadedNetID);
-                                    if(success)
-                                    {
-                                        BasisDebug.Log( $"successfully removed scene with LoadedNetID = {itemKey.LoadedNetID}" );
-                                    }
-                                    else
-                                    {
-                                        BasisDebug.LogError($"failed to remove scene with LoadedNetID = {instanceID}");
-                                    }
-                                }
-
+                        case BasisRuntimeSpawnRegistry.SpawnMethod.Network:
+                            switch (itemKey.SpawnMode)
+                            {
+                                case BasisRuntimeSpawnRegistry.SpawnMode.GameObject:
+                                    BasisNetworkSpawnItem.RequestGameObjectUnLoad(itemKey.LoadedNetID);
+                                    break;
+                                case BasisRuntimeSpawnRegistry.SpawnMode.Scene:
+                                    BasisNetworkSpawnItem.RequestSceneUnLoad(itemKey.LoadedNetID);
+                                    break;
+                                default:
+                                    BasisDebug.LogWarning($"Missing Spawn Method! {itemKey.SpawnMode}");
+                                    break;
+                            }
                             break;
-                        }
-
-                        break;
-                    case BasisRuntimeSpawnRegistry.SpawnMethod.Network:
-                        switch (itemKey.SpawnMode)
-                        {
-                            case BasisRuntimeSpawnRegistry.SpawnMode.GameObject:
-                                BasisNetworkSpawnItem.RequestGameObjectUnLoad(itemKey.LoadedNetID);
-                                break;
-                            case BasisRuntimeSpawnRegistry.SpawnMode.Scene:
-                                BasisNetworkSpawnItem.RequestSceneUnLoad(itemKey.LoadedNetID);
-                                break;
-                            default:
-                                BasisDebug.LogWarning($"Missing Spawn Method! {itemKey.SpawnMode}");
-                                break;
-                        }
-                        break;
-                }
-                await RefreshCurrentTab();
-            };
+                    }
+                    await RefreshCurrentTab();
+                },
+            });
         }
 
         #endregion

--- a/Basis/Packages/com.basis.framework/Networking/ContentShare/BasisContentShareManager.cs
+++ b/Basis/Packages/com.basis.framework/Networking/ContentShare/BasisContentShareManager.cs
@@ -7,6 +7,7 @@ using Basis.Scripts.Networking;
 using Basis.Scripts.TransformBinders.BoneControl;
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
@@ -299,7 +300,14 @@ public static class BasisContentShareManager
                     Kind = ToShareableKind(msg.ContentType),
                     Title = shareDetail,
                     SharerName = serverMsg.SharerDisplayName,
-                    Remove = () => RequestRemoveSphere(sphereId),
+                    Actions = new List<BasisShareableAction>
+                    {
+                        new BasisShareableAction
+                        {
+                            Style = BasisShareableActionStyle.Destructive,
+                            Invoke = () => RequestRemoveSphere(sphereId),
+                        },
+                    },
                 });
             }
         }

--- a/Basis/Packages/com.basis.framework/Networking/ContentShare/BasisShareableRegistry.cs
+++ b/Basis/Packages/com.basis.framework/Networking/ContentShare/BasisShareableRegistry.cs
@@ -18,6 +18,16 @@ public sealed class BasisShareableEntry
     public string Title;
     public string SharerName;
     public Action Remove;
+
+    /// <summary>Optional secondary action, rendered as a labeled button next to the
+    /// remove button (e.g. a "Share"/"Unshare" toggle). Null/empty label = no button.
+    /// The registering package owns the semantics; the Library UI just presents it.</summary>
+    public string ActionLabel;
+    public Action Action;
+    /// <summary>Non-null = the Library shows a yes/no dialog with this title/body
+    /// before invoking <see cref="Action"/> (for consent-style actions).</summary>
+    public string ActionConfirmTitle;
+    public string ActionConfirmBody;
 }
 
 /// <summary>
@@ -51,6 +61,21 @@ public static class BasisShareableRegistry
         if (Entries.TryGetValue(id, out BasisShareableEntry entry))
         {
             entry.Title = detail;
+            OnChanged?.Invoke();
+        }
+    }
+
+    /// <summary>Update an entry's secondary action presentation (label + optional
+    /// confirm text) — e.g. flipping a Share button to Unshare after it's invoked.
+    /// The Action delegate itself stays as registered.</summary>
+    public static void SetAction(string id, string label, string confirmTitle = null, string confirmBody = null)
+    {
+        if (string.IsNullOrEmpty(id)) return;
+        if (Entries.TryGetValue(id, out BasisShareableEntry entry))
+        {
+            entry.ActionLabel = label;
+            entry.ActionConfirmTitle = confirmTitle;
+            entry.ActionConfirmBody = confirmBody;
             OnChanged?.Invoke();
         }
     }

--- a/Basis/Packages/com.basis.framework/Networking/ContentShare/BasisShareableRegistry.cs
+++ b/Basis/Packages/com.basis.framework/Networking/ContentShare/BasisShareableRegistry.cs
@@ -11,23 +11,44 @@ public enum BasisShareableKind
     Other
 }
 
+/// <summary>How the Library should present a <see cref="BasisShareableAction"/>.
+/// Semantic (not a concrete UI style) so this framework type stays decoupled from
+/// BasisUI prefabs/sprites — the Library maps these to buttons.</summary>
+public enum BasisShareableActionStyle
+{
+    /// <summary>A normal/affirmative action (e.g. "Share"), rendered as an accept button.</summary>
+    Positive,
+    /// <summary>A removal action, rendered as the trash button. When no explicit
+    /// confirm text is supplied the Library shows its standard "remove {name}?" prompt.</summary>
+    Destructive,
+}
+
+/// <summary>One button shown on a Library shareable entry. The registering package owns
+/// the semantics (label + callback); the Library just presents it.</summary>
+public sealed class BasisShareableAction
+{
+    /// <summary>Button text. Empty = icon-only (only meaningful for
+    /// <see cref="BasisShareableActionStyle.Destructive"/>, which uses the trash icon).</summary>
+    public string Label;
+    public BasisShareableActionStyle Style;
+    public Action Invoke;
+    /// <summary>Non-null = the Library shows a yes/no dialog with this title/body before
+    /// invoking <see cref="Invoke"/> (for consent-style actions).</summary>
+    public string ConfirmTitle;
+    public string ConfirmBody;
+}
+
 public sealed class BasisShareableEntry
 {
     public string Id;
     public BasisShareableKind Kind;
     public string Title;
     public string SharerName;
-    public Action Remove;
 
-    /// <summary>Optional secondary action, rendered as a labeled button next to the
-    /// remove button (e.g. a "Share"/"Unshare" toggle). Null/empty label = no button.
-    /// The registering package owns the semantics; the Library UI just presents it.</summary>
-    public string ActionLabel;
-    public Action Action;
-    /// <summary>Non-null = the Library shows a yes/no dialog with this title/body
-    /// before invoking <see cref="Action"/> (for consent-style actions).</summary>
-    public string ActionConfirmTitle;
-    public string ActionConfirmBody;
+    /// <summary>Buttons rendered on the entry (in order), e.g. a "Share"/"Unshare" toggle
+    /// followed by a remove button. Removal is just a <see cref="BasisShareableActionStyle.Destructive"/>
+    /// action here — the Library has no dedicated remove path.</summary>
+    public List<BasisShareableAction> Actions;
 }
 
 /// <summary>
@@ -65,18 +86,14 @@ public static class BasisShareableRegistry
         }
     }
 
-    /// <summary>Update an entry's secondary action presentation (label + optional
-    /// confirm text) — e.g. flipping a Share button to Unshare after it's invoked.
-    /// A null/empty label removes the button. The Action delegate itself stays as
-    /// registered.</summary>
-    public static void SetAction(string id, string label, string confirmTitle = null, string confirmBody = null)
+    /// <summary>Replace an entry's action buttons — e.g. flipping a "Share" toggle to
+    /// "Unshare" after it's invoked. Pass an empty list (or null) to leave no buttons.</summary>
+    public static void SetActions(string id, List<BasisShareableAction> actions)
     {
         if (string.IsNullOrEmpty(id)) return;
         if (Entries.TryGetValue(id, out BasisShareableEntry entry))
         {
-            entry.ActionLabel = label;
-            entry.ActionConfirmTitle = confirmTitle;
-            entry.ActionConfirmBody = confirmBody;
+            entry.Actions = actions;
             OnChanged?.Invoke();
         }
     }

--- a/Basis/Packages/com.basis.framework/Networking/ContentShare/BasisShareableRegistry.cs
+++ b/Basis/Packages/com.basis.framework/Networking/ContentShare/BasisShareableRegistry.cs
@@ -67,7 +67,8 @@ public static class BasisShareableRegistry
 
     /// <summary>Update an entry's secondary action presentation (label + optional
     /// confirm text) — e.g. flipping a Share button to Unshare after it's invoked.
-    /// The Action delegate itself stays as registered.</summary>
+    /// A null/empty label removes the button. The Action delegate itself stays as
+    /// registered.</summary>
     public static void SetAction(string id, string label, string confirmTitle = null, string confirmBody = null)
     {
         if (string.IsNullOrEmpty(id)) return;
@@ -76,6 +77,18 @@ public static class BasisShareableRegistry
             entry.ActionLabel = label;
             entry.ActionConfirmTitle = confirmTitle;
             entry.ActionConfirmBody = confirmBody;
+            OnChanged?.Invoke();
+        }
+    }
+
+    /// <summary>Update who shared an entry (rendered as "shared by …") after
+    /// registration — e.g. once a received share's sharer is identified.</summary>
+    public static void SetSharerName(string id, string sharerName)
+    {
+        if (string.IsNullOrEmpty(id)) return;
+        if (Entries.TryGetValue(id, out BasisShareableEntry entry))
+        {
+            entry.SharerName = sharerName;
             OnChanged?.Invoke();
         }
     }

--- a/Basis/Packages/com.basis.imagepickup/BasisImagePickupManager.cs
+++ b/Basis/Packages/com.basis.imagepickup/BasisImagePickupManager.cs
@@ -127,7 +127,14 @@ namespace Basis.ImagePickup
                 Kind = BasisShareableKind.Image,
                 Title = $"{result.Width}x{result.Height}",
                 SharerName = ownerName,
-                Remove = () => { if (Instance != null) Instance.RequestDespawn(id); },
+                Actions = new List<BasisShareableAction>
+                {
+                    new BasisShareableAction
+                    {
+                        Style = BasisShareableActionStyle.Destructive,
+                        Invoke = () => { if (Instance != null) Instance.RequestDespawn(id); },
+                    },
+                },
             });
 
             if (HasNetworkID)
@@ -345,7 +352,14 @@ namespace Basis.ImagePickup
                 Kind = BasisShareableKind.Image,
                 Title = $"{transfer.Width}x{transfer.Height}",
                 SharerName = transfer.OwnerName,
-                Remove = () => { if (Instance != null) Instance.RequestDespawn(imageId); },
+                Actions = new List<BasisShareableAction>
+                {
+                    new BasisShareableAction
+                    {
+                        Style = BasisShareableActionStyle.Destructive,
+                        Invoke = () => { if (Instance != null) Instance.RequestDespawn(imageId); },
+                    },
+                },
             });
         }
 


### PR DESCRIPTION
## Summary

Adds an optional, provider-registered secondary action to Library "Instantiated" entries:

- `BasisShareableEntry` gains `ActionLabel`/`Action` plus optional `ActionConfirmTitle`/`ActionConfirmBody`.
- The Instantiated tab renders the action as a labeled button beside the remove button; when confirm text is present it goes through the same yes/no `DialogBox<bool>` flow the remove path uses.
- `BasisShareableRegistry.SetAction(id, label, confirmTitle, confirmBody)` flips the presentation after invocation (e.g. Share → Unshare), mirroring `SetDetail`; a null/empty label removes the button.
- `BasisShareableRegistry.SetSharerName(id, name)` updates "shared by …" after registration, for shares whose sharer is identified late.

Generic on purpose: the registering package owns the semantics, the framework just presents it — the same philosophy as the registry itself (add-on packages appear in the Library without the framework referencing them). First consumer is a window share/unshare toggle in an external package. No behavior change for entries that don't set `ActionLabel`.

## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [x] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — `BasisEventDriver` runs the single per-frame tick that drives the whole framework (network apply, local player sim, blendshapes, JigglePhysics, nameplates, and more) as one sequential chain. An unhandled exception anywhere in that chain aborts the rest of the tick, so every step after the throwing one is silently skipped for that frame. New work added to the driver must either be guaranteed not to throw, or be wrapped in a `try`/`catch` that contains the failure and surfaces it through `BasisDebug` — logged once / rate-limited, never every frame (see the existing `HVRBasisBuiltInAddresses.Simulate()` guard for the pattern). Expect this to be scrutinized closely in review.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [x] Windows
- [ ] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [x] Tested in VR (note headset under **Notes**)
- [x] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [ ] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [x] N/A — change does not touch any of the above

## Notes

**What was tested:** exercised end-to-end on Windows (desktop and VR) via the first consumer — an external package registering a window share/unshare toggle: button renders on Instantiated entries, confirm dialog gates the action, `SetAction(id, null)` removes the button, `SetSharerName` updates the "shared by" line, and entries without an `ActionLabel` are unchanged.

**Why several required checks are N/A:** this change adds no per-frame or hot-path code. The button is constructed once when the Library's Instantiated list is (re)built (same place the existing remove button is created), and the action/dialog code runs only on user click. Accordingly:

- *Transform access / per-frame scheduling / `BasisEventDriver` / hot-path allocation / hot-path logging / hot-path collections* — N/A; nothing here runs per frame.
- *Jobification* — N/A; this is event-driven UI construction and a click handler, nothing computational to move into a job.
- *Addressables* — no new asset loads; the confirm dialog reuses the already-referenced `AddressableAssets.Sprites.Information` sprite, same as the existing remove-confirm flow.
- *`GetComponent` / camera access / scene discovery / logging* — none added; dependencies flow through the existing `BasisShareableRegistry` registration pattern.
- *No needless properties* — new API surface is plain public fields on `BasisShareableEntry`, matching the existing fields and the repo's preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
