### PR TITLE
docs(mediaplayer): regression-testing guide + self-hostable test-stream stack

### DIFF
--- a/Basis/Packages/com.basis.integration.ytdlp/TESTING.md
+++ b/Basis/Packages/com.basis.integration.ytdlp/TESTING.md
@@ -1,0 +1,71 @@
+# Testing the yt-dlp integration
+
+How to verify page-URL resolution (YouTube, Twitch, and friends) after changing this package.
+The base player's guide —
+[`com.basis.mediaplayer/TESTING.md`](../com.basis.mediaplayer/TESTING.md) — covers everything
+downstream of resolution and deliberately uses **direct stream URLs only**; page URLs belong
+here, because they only work when this integration (and its `com.yewnyx.ytdlp` dependency)
+is installed.
+
+## Prerequisites
+
+- `com.basis.mediaplayer` and `com.yewnyx.ytdlp` present — this package compiles to nothing
+  without both (asmdef define constraints), so first confirm it's actually active: loading a
+  page URL without it reports that a resolver is needed.
+- **Windows** — the yt-dlp native plugin is Windows-first.
+- The base player passing its own matrix. If direct streams are broken, nothing here will
+  tell you anything about the resolver.
+
+## Rule zero: separate resolver bugs from player bugs
+
+Resolution and playback are different failure domains. Before blaming either:
+
+```csharp
+// Inspect what resolution actually produced, without playing it:
+BasisMediaSource source = await BasisYtDlpResolver.ResolveSourceAsync(pageUrl);
+```
+
+If the resolved `Url`/`AudioUri` look sane, load them **directly** in the player — if that
+also fails, it's a player bug and the base guide applies. If resolution itself fails,
+remember the other moving part: **the sites change constantly.** YouTube rotates signature
+challenges; a resolution failure on unchanged code is usually an aged yt-dlp, not your
+regression. Confirm the yt-dlp runtime is current before filing anything.
+
+## What to test
+
+Pick stable, public content you have the right to view — long-standing official uploads
+(e.g. the Blender Foundation films) beat trending links that vanish. Twitch: any live channel
+from the front page, plus a recent VOD from the same channel.
+
+| Scenario | Expected |
+| --- | --- |
+| YouTube VOD, >360p | Resolves to **split stream** (H.264 video-only + AAC audio-only), plays paced as on-demand, A/V locked |
+| YouTube VOD, ≤360p (or format-forced) | Single muxed stream, delivery auto-detected |
+| YouTube live | Single HLS playlist, plays as live |
+| Twitch live | HLS live; join near the live edge |
+| Twitch VOD | HLS VOD |
+| Format cap | Chosen video is `avc1` ≤1080p with `mp4a` audio — never VP9/AV1, even on 4K uploads |
+| Metadata | Title / uploader / thumbnail appear on the player after resolve |
+| First-ever resolution | One-off multi-second pause while the bundled Python runtime unpacks — expected, not a hang; later loads skip it |
+| Every resolution | A few seconds of in-process resolving is normal; the player shows nothing during the gap by design |
+| Direct URLs with this package installed | `.mp4`/`.ts`/`.m3u8`/transport-scheme URLs load **untouched** — no resolver round-trip |
+| Extensionless direct HTTP stream | Known gap: routed to yt-dlp and fails; documented, not a regression |
+| Invalid / dead page URL | Clean failure surfaced to the player — no crash, no silent hang |
+| Package removed | Page URLs report "resolver needed"; direct streams unaffected |
+
+## Security and networking
+
+- Resolved stream URLs pass `BasisMediaPlayerSecurity` like any other URL — a resolver change
+  must never become a way around the host gate. Negative-test with a page URL crafted to
+  resolve somewhere refused (or verify the gate log lines fire on the resolved hosts).
+- In multiplayer, the **page URL** syncs and each client resolves independently. Two clients
+  on the same video may legitimately hold different CDN URLs; state (play/pause/position
+  intent) must still agree. Test with two clients minimum.
+- Resolution runs off the main thread — the Editor should stay responsive during the resolve
+  gap; a frozen editor during resolution is a regression.
+
+## Reporting
+
+Base-guide report contents apply, plus: the page URL, the yt-dlp runtime version, and —
+for resolution failures — whether `ResolveSourceAsync` fails too or only playback of the
+resolved result.

--- a/Basis/Packages/com.basis.mediaplayer/TESTING.md
+++ b/Basis/Packages/com.basis.mediaplayer/TESTING.md
@@ -61,7 +61,7 @@ Practical consequences:
 - **Quest/Android:** the OS cleartext policy blocks plain `http://` on the JNI fetch path —
   HTTP-TS and HLS lanes need `https://` with a certificate chain the device actually trusts
   (serve the full chain; standalone headsets are missing more roots than desktop browsers).
-  `rtspt://` is unaffected.
+  `rtsp://` is unaffected.
 - The separate world-content trust allowlist (`BasisDefaultTrustedUrls`, https-only) gates the
   sandboxed `VideoPlayer` shim path, not this package — but streams hosted on already-trusted
   domains spare testers a consent prompt when worlds use the same URL.
@@ -73,7 +73,7 @@ fine for interactive test sessions, not for soak loops.
 
 | URL | Exercises | Notes |
 | --- | --- | --- |
-| `rtspt://stream.vrcdn.live/live/vrcdn` | RTSPT live, H.264 720p + AAC 2.0 @ 48 kHz | VRCDN's own 24/7 channel; the primary PC low-latency lane; host is on the default trust list |
+| `rtsp://stream.vrcdn.live/live/vrcdn` | RTSP live, H.264 720p + AAC 2.0 @ 48 kHz | VRCDN's own 24/7 channel; the primary PC low-latency lane; host is on the default trust list. `rtspt://` works identically (both schemes take the TCP-interleaved path) |
 | `https://stream.vrcdn.live/live/vrcdn.live.ts` | MPEG-TS over HTTPS, live | Same channel, the standalone-friendly lane (https, so Quest-safe) |
 | `https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4` | Progressive MP4 VOD, range/`206` | Also good for seek/pause and delivery auto-detect testing |
 | `https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8` | HLS VOD, multi-variant master | Exercises the panel's bitrate dropdown |
@@ -117,8 +117,8 @@ Run the rows your change plausibly touches; run everything before a release-boun
 
 | Lane | Source | Verify additionally |
 | --- | --- | --- |
-| RTSPT live | VRCDN or stack `rtspt://<host>:8554/main` | Join latency ≈ GOP-bound; pause/resume recovers cleanly |
-| RTSPT adversarial join | stack `rtspt://<host>:8554/slowjoin` | Audio leads video by up to the GOP length on join, then locks — no permanent desync |
+| RTSP live | VRCDN or stack `rtsp://<host>:8554/main` | Join latency ≈ GOP-bound; pause/resume recovers cleanly |
+| RTSP adversarial join | stack `rtsp://<host>:8554/slowjoin` | Audio leads video by up to the GOP length on join, then locks — no permanent desync |
 | HTTP-TS live | VRCDN `.live.ts` or stack | Same checks over plain TS; on Quest use the https lane |
 | HLS VOD | Mux master or stack packaging | Variant switch via panel bitrate dropdown mid-play |
 | Progressive/fMP4 MP4 | Big Buck Bunny | `Delivery=Auto` detects OnDemand (needs the 206); seek slider works |

--- a/Basis/Packages/com.basis.mediaplayer/TESTING.md
+++ b/Basis/Packages/com.basis.mediaplayer/TESTING.md
@@ -1,0 +1,219 @@
+# Testing the media player
+
+How to test changes to `com.basis.mediaplayer` without fooling yourself. The README describes
+what the player does; this describes how to prove it still does it after your change.
+
+There is no automated test suite for playback — the player's job is realtime A/V against real
+networks and real hardware decoders, and regressions live exactly in the parts a mock can't
+reach. Testing is therefore structured manual verification: known-good streams, a repeatable
+matrix, and evidence capture.
+
+## Rule zero: prove the feed before you blame the player
+
+Most "player bugs" found during development turn out to be feeder problems: a stalled stream,
+an under-provisioned link, a server that lied about ranges. A player symptom only earns
+player-side investigation once the feed is proven healthy — probe it with something that isn't
+the player first:
+
+```
+# Stream shape + first decodable frame (RTSP; works for any transport ffmpeg speaks)
+ffprobe -rtsp_transport tcp -show_entries stream=codec_type,codec_name,channels rtsp://host:8554/path
+
+# Wall-time to first video frame — long GOPs make mid-stream joins slow by nature
+ffmpeg -v error -rtsp_transport tcp -i <url> -map 0:v:0 -frames:v 1 -f null -
+```
+
+Things that regularly masquerade as player bugs:
+
+- **Link capacity.** A 28 Mbps stream over a 22 Mbps path cannot play live, and no player-side
+  change will fix it. Measure the actual path throughput before investigating stutter (on
+  Windows, `curl.exe` under-reads badly — use a timed `urllib` read from Python instead).
+- **Mid-GOP joins.** Joining a live stream between keyframes delivers audio immediately and no
+  video until the next IDR. With a 10-second GOP that is a 10-second "video hang" that is
+  entirely the source's fault. Know your test stream's GOP.
+- **Single-client feeders.** `ffmpeg -listen 1` serves one client, then lingers in a stale
+  state that trickles junk. If a second connection behaves strangely, restart the feeder.
+- **Wrong delivery detection.** `Delivery = Auto` probes `Range: bytes=0-` and needs a real
+  `206 Partial Content` to detect on-demand content. `python -m http.server` and
+  `ffmpeg -listen` answer `200` and get treated as **live**. Serve VOD files from nginx (or
+  anything with real range support).
+
+The test-stream stack in [`tools/media-test-streams/`](../../../tools/media-test-streams/)
+ships a `preflight.py` that runs these probes across all of its lanes in ~30 seconds.
+
+## Where test streams may live (the security gates)
+
+`BasisMediaPlayerSecurity` validates every URL before the engine opens it
+(`Runtime/Core/BasisMediaPlayerSecurity.cs`). The rules shape where your streams must run:
+
+| Rule | Effect on testing |
+| --- | --- |
+| Loopback allowed **in the Editor only** | `localhost` streams work for fast in-editor iteration; the same URL is refused in a build |
+| RFC1918 / CGNAT / link-local always blocked | LAN servers (`192.168.*`, `10.*`, …) never work, Editor included — don't bother |
+| Hostnames are DNS-validated, fail-closed | A name that resolves to a private address (or doesn't resolve) is refused |
+| Scheme allowlist | `http`, `https`, `rtsp`, `rtspt`, `rtmp`, `rtmps`, `rist` — anything else (incl. `file://`) is refused |
+
+Practical consequences:
+
+- **Editor iteration:** run the test stack locally with Docker and use `localhost` URLs.
+- **Builds, Quest, multi-client tests:** the stream must come from a **public host with real
+  DNS**. Any cheap VPS running the same stack works.
+- **Quest/Android:** the OS cleartext policy blocks plain `http://` on the JNI fetch path —
+  HTTP-TS and HLS lanes need `https://` with a certificate chain the device actually trusts
+  (serve the full chain; standalone headsets are missing more roots than desktop browsers).
+  `rtspt://` is unaffected.
+- The separate world-content trust allowlist (`BasisDefaultTrustedUrls`, https-only) gates the
+  sandboxed `VideoPlayer` shim path, not this package — but streams hosted on already-trusted
+  domains spare testers a consent prompt when worlds use the same URL.
+
+## Public always-on endpoints (zero setup)
+
+These cover the common lanes without standing up anything. They are third-party services —
+fine for interactive test sessions, not for soak loops.
+
+| URL | Exercises | Notes |
+| --- | --- | --- |
+| `rtspt://stream.vrcdn.live/live/vrcdn` | RTSPT live, H.264 720p + AAC 2.0 @ 48 kHz | VRCDN's own 24/7 channel; the primary PC low-latency lane; host is on the default trust list |
+| `https://stream.vrcdn.live/live/vrcdn.live.ts` | MPEG-TS over HTTPS, live | Same channel, the standalone-friendly lane (https, so Quest-safe) |
+| `https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4` | Progressive MP4 VOD, range/`206` | Also good for seek/pause and delivery auto-detect testing |
+| `https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8` | HLS VOD, multi-variant master | Exercises the panel's bitrate dropdown |
+| [Fraunhofer AAC multichannel page](https://www2.iis.fraunhofer.de/AAC/multichannel.html) | AAC 5.1/7.1 VOD fixtures | Includes adversarial layouts: PCE-signalled 7.1 must fail **gracefully** on Windows (muted audio or a clean error — never a crash) |
+
+> Live endpoints join mid-GOP like any live stream — audio-before-video on join is expected
+> behaviour, not a regression, unless the gap exceeds the stream's GOP length.
+
+## What the public internet can't give you: the test-stream stack
+
+Some lanes have no reliable public endpoint. [`tools/media-test-streams/`](../../../tools/media-test-streams/)
+is a Docker Compose stack that provides them, runnable **locally for Editor work** (loopback
+is allowed in-editor) and **on any public VPS** for build/Quest/multi-client work:
+
+- RTSP/RTSPT under your control (including an adversarial long-GOP path for join testing)
+- HTTP-TS live feeds
+- nginx VOD with real range support
+- CEA-608 caption-bearing TS (generated fixture — no public stream carries captions reliably)
+- LPCM 5.1/7.1 over M2TS (the full-multichannel lane; AAC on Windows caps at 5.1)
+- RIST sender, plain and AES-encrypted (needs the opt-in `-DBASIS_WITH_RIST=ON` plugin build)
+- Split-stream video+audio pairs
+
+Its README covers deployment, asset preparation (bring your own content — real footage with
+visible lip-sync moments beats synthetic patterns for A/V sync work), and per-lane URLs.
+
+## The regression matrix
+
+Run the rows your change plausibly touches; run everything before a release-bound merge.
+"Verify" always includes: plays within a sane time, A/V stays in sync, no console errors
+(`BasisDebug` tag `Video`), clean stop/unload.
+
+### Transports
+
+| Lane | Source | Verify additionally |
+| --- | --- | --- |
+| RTSPT live | VRCDN or stack `rtspt://…:8554/main` | Join latency ≈ GOP-bound; pause/resume returns to live edge |
+| RTSPT adversarial join | stack `…/slowjoin` | Audio leads video by up to the GOP length on join, then locks — no permanent desync |
+| HTTP-TS live | VRCDN `.live.ts` or stack | Same checks over plain TS; on Quest use the https lane |
+| HLS VOD | Mux master or stack packaging | Variant switch via panel bitrate dropdown mid-play |
+| Progressive/fMP4 MP4 | Big Buck Bunny | `Delivery=Auto` detects OnDemand (needs the 206); seek slider works |
+| RTMP | stack | Minimal client — plain `rtmp://` pull only |
+| RIST plain + AES | stack (RIST profile) | Requires RIST-enabled plugin build; loss recovery under induced packet loss |
+| WAV audio-only | stack VOD | 16/24-bit, up to 8 ch; no video track is not an error |
+| Split-stream | stack pair | Windows-only today; `AudioUri` lane syncs to video |
+
+### Content and codecs
+
+| Fixture | Verify |
+| --- | --- |
+| H.264 + AAC stereo | The baseline — everything else assumes this passes |
+| H.265/HEVC | Windows needs the system HEVC codec present; absence degrades cleanly |
+| AAC 5.1 | Windows MF decodes ≤ 5.1; correct channel mapping (use content with known channel placement, judge by ear per output speaker) |
+| LPCM 7.1 M2TS | All 8 lanes audible and correctly placed — the only full-7.1 path on Windows |
+| PCE-signalled / >6-ch AAC | **Graceful refusal** on Windows (mute or clean error, never a crash) |
+| CEA-608 captions | Stack caption fixture: cues appear on time, accented characters correct, clear-cue clears, CC toggle + opacity sliders live-apply |
+| 44.1 kHz audio | Resamples cleanly to the DSP rate (dominant path is 48 kHz — don't let 44.1k rot) |
+
+### Platforms and backends
+
+| Target | Notes |
+| --- | --- |
+| Windows D3D11 | Default editor/player path |
+| Windows D3D12 | Launch with `-force-d3d12`; shared-handle texture path is separate code — video must appear, no `dxgi-fmt` errors in the log |
+| Android/Quest | Vulkan path, `AMediaCodec`; https for TS/HLS lanes; check `adb logcat` for codec errors; AAC 5.1 arrives in WAVE order |
+| Desktop ↔ VR swap | Toggle mode mid-playback — the external texture must survive the graphics-device swap |
+
+### Behaviour checklists
+
+**Playback lifecycle** — load → play → pause → resume → stop → replay same URL → load a
+different URL mid-play. No stale frames, no orphaned audio, position resets correctly.
+
+**Seek (VOD)** — slider to arbitrary positions; rapid successive seeks (input is debounced);
+seek-then-pause shows the sought frame.
+
+> On-demand multiplayer sync is **start-together, not catch-up**: the native backend exposes
+> no absolute seek, so a client that falls behind stays behind until the next shared (re)load.
+> Late-joiner-starts-at-zero on VOD is a known limit, not a regression.
+
+**Networking** — two clients minimum: owner loads URL → both play; non-owner requests control
+→ ownership transfers; owner pause/stop propagates; late joiner receives current state; each
+client resolves the URL independently (per-client CDN/bitrate differences are fine, state
+divergence is not).
+
+**Panel UI** ("Media Players" panel, `Runtime/UI/BasisMediaPlayerPanelProvider.cs`) — URL
+load, transport buttons, seek slider (VOD only), volume, bitrate dropdown (HLS multi-variant),
+audio-track dropdown (multi-audio content), captions toggle + opacity sliders. Controls that
+don't apply to the loaded media should be absent or inert, not broken.
+
+**Security gates** — negative tests matter: `http://192.168.1.10/x.ts` must refuse with a
+clear reason on every platform; `localhost` must refuse **in a build** (and work in the
+Editor); `file:///` must refuse. A regression that *opens* a gate is a security bug —
+flag it as such, not as a playback bug.
+
+**A/V sync judgement** — use real footage with visible speech; synthetic patterns hide sync
+drift. Watch a full minute at the live edge, not five seconds. For anything subtle, capture
+diagnostics (below) rather than trusting perception.
+
+**Orientation** — a horizontal mirror is invisible on symmetric content. Verify left/right
+with on-screen text or a logo, every time video-path code changes.
+
+## Diagnostics and evidence
+
+- **`BasisMediaPlayerDiagnostics`** (`Runtime/BasisMediaPlayerDiagnostics.cs`): add the
+  component next to a `BasisMediaPlayer`, enable `AutoStart` (or call `StartLogging()`), and
+  it samples ~50 snapshots/s to `Application.persistentDataPath/BasisMediaPlayerDiag.csv`
+  (Windows: `%USERPROFILE%\AppData\LocalLow\<company>\<product>\`). Useful signals:
+  `eng_ttff_ms` (time to first frame), `engine_pos_us` step distribution (late presents show
+  as double-steps coinciding with wall-clock gaps), `eng_lag_ms`/`eng_buf_ms` (clock vs
+  buffer health), `audio_queue_depth`/`eng_audio_trims` (audio starvation/overrun),
+  `cpu_*_drops/skips` (CPU-path frame accounting). Filter rows to `engine_state == Playing`
+  before drawing conclusions.
+- **Debug window**: `Basis → Debug → Media Player Debug` shows live engine state per player.
+- **Feedless harness**: `BasisSyntheticTestSource` (`Runtime/Sources/`) drives the player
+  without any network feed — isolates render-path changes from transport noise.
+- **Logs**: the package logs exclusively under the `Video` tag via `BasisDebug`. On Android,
+  `adb logcat -s Unity` plus the codec tags carry the native side.
+
+## Reporting a regression
+
+A report that can be acted on contains:
+
+1. The exact URL (or the stack lane + asset recipe) — full URL, not a fragment
+2. Platform, graphics API, Editor-or-build, headset if relevant
+3. What was expected, what happened, and how reliably it reproduces
+4. Console output around the failure (the `Video`-tagged lines) and, for timing/sync issues,
+   the diagnostics CSV covering the incident
+5. Whether the preflight/ffprobe of the same URL was green at the time
+
+## Acknowledgements
+
+The always-on live lanes above are [VRCDN](https://vrcdn.live/)'s own public channel, listed
+here with their permission — thanks to the VRCDN team for keeping a reliable 24/7 reference
+stream running and for letting this guide point testers at it. Be a good guest: use it for
+interactive test sessions, not automated soak loops, and stand up the self-hosted stack for
+anything sustained.
+
+## Native plugin changes
+
+Any change under `Native~/` needs the rebuilt binaries verified on **both** platforms it
+ships for (Windows x64 DLL, Android arm64 `.so`) — the shared C core means a protocol fix on
+one platform can regress the other. See the README's "Building the native plugin" section.
+Note the Windows DLL cannot be replaced while any Unity instance holds it loaded — close
+Unity, swap, reopen.

--- a/Basis/Packages/com.basis.mediaplayer/TESTING.md
+++ b/Basis/Packages/com.basis.mediaplayer/TESTING.md
@@ -73,7 +73,7 @@ fine for interactive test sessions, not for soak loops.
 
 | URL | Exercises | Notes |
 | --- | --- | --- |
-| `rtsp://stream.vrcdn.live/live/vrcdn` | RTSP live, H.264 720p + AAC 2.0 @ 48 kHz | VRCDN's own 24/7 channel; the primary PC low-latency lane; host is on the default trust list. `rtspt://` works identically (both schemes take the TCP-interleaved path) |
+| `rtsp://stream.vrcdn.live/live/vrcdn` | RTSP live, H.264 720p + AAC 2.0 @ 48 kHz | VRCDN's own 24/7 channel; the primary PC low-latency lane; host is on the default trust list |
 | `https://stream.vrcdn.live/live/vrcdn.live.ts` | MPEG-TS over HTTPS, live | Same channel, the standalone-friendly lane (https, so Quest-safe) |
 | `https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4` | Progressive MP4 VOD, range/`206` | Also good for seek/pause and delivery auto-detect testing |
 | `https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8` | HLS VOD, multi-variant master | Exercises the panel's bitrate dropdown |

--- a/Basis/Packages/com.basis.mediaplayer/TESTING.md
+++ b/Basis/Packages/com.basis.mediaplayer/TESTING.md
@@ -82,6 +82,14 @@ fine for interactive test sessions, not for soak loops.
 > Live endpoints join mid-GOP like any live stream — audio-before-video on join is expected
 > behaviour, not a regression, unless the gap exceeds the stream's GOP length.
 
+**Page URLs (YouTube, Twitch, …) are deliberately absent from this guide.** They only work
+through an optional resolver integration, so the base package can't assume they're testable.
+Everything in this document uses direct stream URLs; resolver-dependent testing lives in the
+integration package that provides it — e.g.
+[`com.basis.integration.ytdlp/TESTING.md`](../com.basis.integration.ytdlp/TESTING.md).
+The same split applies to any future integration: endpoints that need an integration package
+to function are tested in that package's own TESTING.md.
+
 ## What the public internet can't give you: the test-stream stack
 
 Some lanes have no reliable public endpoint. [`tools/media-test-streams/`](../../../tools/media-test-streams/)
@@ -109,12 +117,12 @@ Run the rows your change plausibly touches; run everything before a release-boun
 
 | Lane | Source | Verify additionally |
 | --- | --- | --- |
-| RTSPT live | VRCDN or stack `rtspt://…:8554/main` | Join latency ≈ GOP-bound; pause/resume returns to live edge |
-| RTSPT adversarial join | stack `…/slowjoin` | Audio leads video by up to the GOP length on join, then locks — no permanent desync |
+| RTSPT live | VRCDN or stack `rtspt://<host>:8554/main` | Join latency ≈ GOP-bound; pause/resume recovers cleanly |
+| RTSPT adversarial join | stack `rtspt://<host>:8554/slowjoin` | Audio leads video by up to the GOP length on join, then locks — no permanent desync |
 | HTTP-TS live | VRCDN `.live.ts` or stack | Same checks over plain TS; on Quest use the https lane |
 | HLS VOD | Mux master or stack packaging | Variant switch via panel bitrate dropdown mid-play |
 | Progressive/fMP4 MP4 | Big Buck Bunny | `Delivery=Auto` detects OnDemand (needs the 206); seek slider works |
-| RTMP | stack | Minimal client — plain `rtmp://` pull only |
+| RTMP | stack `rtmp://<host>:1935/main` | Minimal client — plain `rtmp://` pull only |
 | RIST plain + AES | stack (RIST profile) | Requires RIST-enabled plugin build; loss recovery under induced packet loss |
 | WAV audio-only | stack VOD | 16/24-bit, up to 8 ch; no video track is not an error |
 | Split-stream | stack pair | Windows-only today; `AudioUri` lane syncs to video |

--- a/tools/media-test-streams/README.md
+++ b/tools/media-test-streams/README.md
@@ -37,7 +37,8 @@ python3 scripts/preflight.py --host my.vps   # deployed
 | `rtspt://<host>:8554/main` | RTSPT live, 2 s GOP | The reference live path — joins land a frame within ~2 s |
 | `rtspt://<host>:8554/silent` | Video + silent stereo | Regression cover for effectively video-only sources |
 | `rtspt://<host>:8554/slowjoin` | **Adversarial** ~10 s GOP | Mid-stream joins wait up to 10 s for an IDR — deliberately; audio-first joins here are expected |
-| `rtspt://<host>:8554/captions` | CEA-608 in-band captions | Generated fixture (silent test pattern); cues every ~3 s incl. accents, music note, clear |
+| `http://<host>:8082/captions.ts` | CEA-608 in-band captions, HTTP-TS | Generated fixture (silent test pattern); cues every ~3 s incl. accents, music note, clear; single-client feeder |
+| `rtmp://<host>:1935/main` | RTMP pull | The player's minimal RTMP client (plain `rtmp://` only) |
 | `http://<host>:8081/live.ts` | HTTP-TS live | Single-client feeder: serves one connection, respawns on disconnect |
 | `http://<host>:8080/assets/mezzanine.mp4` | Progressive MP4 VOD | nginx answers real 206 → `Delivery=Auto` detects OnDemand |
 | `http://<host>:8080/assets/hls/index.m3u8` | HLS VOD | Single-rendition packaging of the mezzanine |
@@ -45,7 +46,7 @@ python3 scripts/preflight.py --host my.vps   # deployed
 | `http://<host>:8080/assets/w8.wav` | Multichannel WAV | Audio-only; name varies with source channel count |
 | `http://<host>:8080/assets/videoonly.mp4` + `audioonly.mp4` | Split-stream pair | Load the video URL with the audio URL as the separate audio leg |
 | `rist://<host>:5000` | RIST plain | `--profile rist`; see below |
-| `rist://<host>:5001?secret=…&aes-type=128` | RIST AES-128 | Same PSK on both ends; change the compose file's placeholder |
+| `rist://<host>:5001?secret=<psk>&aes-type=128` | RIST AES-128 | Same PSK on both ends; change the compose file's placeholder |
 
 `http://<host>:8080/assets/` autoindexes, so anything else you drop into `assets/` is served
 with range support too.
@@ -73,19 +74,19 @@ Change the AES lane's pre-shared key in `docker-compose.yml` before deploying an
 2. Copy this directory up, run `prepare-assets.sh` there (or copy a prepared `assets/`), then
    `docker compose up -d`.
 3. Open the inbound ports at **every** firewall layer (many providers gate ports in a panel
-   *in addition to* the OS firewall): `8554/tcp`, `8080/tcp`, `8081/tcp`, and for RIST
-   `5000-5001/udp`.
+   *in addition to* the OS firewall): `8554/tcp`, `1935/tcp`, `8080/tcp`, `8081-8082/tcp`,
+   and for RIST `5000-5001/udp`.
 4. Give it a DNS name. Hostnames are DNS-validated by the player, and Quest's cleartext
-   policy means the HTTP lanes (`8080`/`8081`) need to sit behind TLS with a certificate
+   policy means the HTTP lanes (`8080`–`8082`) need to sit behind TLS with a certificate
    chain standalone headsets actually trust (serve the full chain including intermediates —
    headset trust stores are sparser than desktop browsers'). `rtspt://` needs no TLS.
 5. `python3 scripts/preflight.py --host <name>` before every session.
 
 ## Gotchas
 
-- **One client per HTTP-TS slot.** The `tslive` feeder serves a single connection then exits
-  and respawns. If it wedges without exiting (stale ~0.5 Mbps trickle — the preflight's
-  bitrate floor catches this), `docker compose restart tslive`.
+- **One client per HTTP-TS slot.** The `tslive` and `cclive` feeders serve a single
+  connection then exit and respawn. If one wedges without exiting (stale ~0.5 Mbps trickle —
+  the preflight's bitrate floor catches this), `docker compose restart tslive` (or `cclive`).
 - **Don't benchmark with `curl.exe` on Windows** — it under-reads regardless of server. Use
   `preflight.py`'s sampled throughput.
 - **Slow joins on `slowjoin` are the point.** File a bug only if the join exceeds the GOP

--- a/tools/media-test-streams/README.md
+++ b/tools/media-test-streams/README.md
@@ -1,0 +1,97 @@
+# Media test-stream stack
+
+Self-hostable test streams for `com.basis.mediaplayer` development — the lanes that have no
+reliable public endpoint. The companion guide,
+[`Basis/Packages/com.basis.mediaplayer/TESTING.md`](../../Basis/Packages/com.basis.mediaplayer/TESTING.md),
+explains what to test against these streams and lists the public always-on endpoints that
+cover the common lanes with zero setup.
+
+Runs in two modes:
+
+- **Local (Editor iteration).** The player allows loopback URLs in the Editor, so
+  `docker compose up -d` on your dev machine and `rtspt://localhost:8554/main` in the Editor
+  is the fastest loop. Builds refuse loopback — local mode is Editor-only by design.
+- **Public VPS (builds, Quest, multi-client).** The same stack on any cheap VPS with a public
+  IP and a DNS name. Private/LAN addresses are refused on every platform, so there is no
+  in-between: it's localhost-in-Editor or properly public.
+
+## Quick start
+
+```bash
+# 1. Prepare assets from your own test clip (real footage with visible speech
+#    recommended; 6-8 audio channels unlock the multichannel lanes)
+scripts/prepare-assets.sh ~/my-test-clip.mp4
+
+# 2. Start the stack
+docker compose up -d
+
+# 3. Prove the feeds are healthy before testing the player
+python3 scripts/preflight.py                 # local
+python3 scripts/preflight.py --host my.vps   # deployed
+```
+
+## Lanes
+
+| URL (`<host>` = `localhost` or your VPS) | Lane | Notes |
+| --- | --- | --- |
+| `rtspt://<host>:8554/main` | RTSPT live, 2 s GOP | The reference live path — joins land a frame within ~2 s |
+| `rtspt://<host>:8554/silent` | Video + silent stereo | Regression cover for effectively video-only sources |
+| `rtspt://<host>:8554/slowjoin` | **Adversarial** ~10 s GOP | Mid-stream joins wait up to 10 s for an IDR — deliberately; audio-first joins here are expected |
+| `rtspt://<host>:8554/captions` | CEA-608 in-band captions | Generated fixture (silent test pattern); cues every ~3 s incl. accents, music note, clear |
+| `http://<host>:8081/live.ts` | HTTP-TS live | Single-client feeder: serves one connection, respawns on disconnect |
+| `http://<host>:8080/assets/mezzanine.mp4` | Progressive MP4 VOD | nginx answers real 206 → `Delivery=Auto` detects OnDemand |
+| `http://<host>:8080/assets/hls/index.m3u8` | HLS VOD | Single-rendition packaging of the mezzanine |
+| `http://<host>:8080/assets/lpcm.m2ts` | LPCM multichannel M2TS | Only produced from a ≥6-ch source; the full-7.1 lane |
+| `http://<host>:8080/assets/w8.wav` | Multichannel WAV | Audio-only; name varies with source channel count |
+| `http://<host>:8080/assets/videoonly.mp4` + `audioonly.mp4` | Split-stream pair | Load the video URL with the audio URL as the separate audio leg |
+| `rist://<host>:5000` | RIST plain | `--profile rist`; see below |
+| `rist://<host>:5001?secret=…&aes-type=128` | RIST AES-128 | Same PSK on both ends; change the compose file's placeholder |
+
+`http://<host>:8080/assets/` autoindexes, so anything else you drop into `assets/` is served
+with range support too.
+
+## RIST lanes
+
+```bash
+docker compose --profile rist up -d
+```
+
+Two extra requirements:
+
+- **Player side**: the native plugin must be built with `-DBASIS_WITH_RIST=ON` (see the
+  package README's build section) — stock builds refuse `rist://`.
+- **Sender side**: the ffmpeg in the container must include librist. Verify with
+  `docker compose run --rm rist-plain -protocols 2>/dev/null | grep rist`; if it's missing,
+  point the two rist services at any ffmpeg image with librist, or run the same commands with
+  a host ffmpeg "full" build.
+
+Change the AES lane's pre-shared key in `docker-compose.yml` before deploying anywhere shared.
+
+## Deploying on a VPS
+
+1. Any small VPS works — the publishers `-c copy` pre-encoded assets, so CPU stays near idle.
+2. Copy this directory up, run `prepare-assets.sh` there (or copy a prepared `assets/`), then
+   `docker compose up -d`.
+3. Open the inbound ports at **every** firewall layer (many providers gate ports in a panel
+   *in addition to* the OS firewall): `8554/tcp`, `8080/tcp`, `8081/tcp`, and for RIST
+   `5000-5001/udp`.
+4. Give it a DNS name. Hostnames are DNS-validated by the player, and Quest's cleartext
+   policy means the HTTP lanes (`8080`/`8081`) need to sit behind TLS with a certificate
+   chain standalone headsets actually trust (serve the full chain including intermediates —
+   headset trust stores are sparser than desktop browsers'). `rtspt://` needs no TLS.
+5. `python3 scripts/preflight.py --host <name>` before every session.
+
+## Gotchas
+
+- **One client per HTTP-TS slot.** The `tslive` feeder serves a single connection then exits
+  and respawns. If it wedges without exiting (stale ~0.5 Mbps trickle — the preflight's
+  bitrate floor catches this), `docker compose restart tslive`.
+- **Don't benchmark with `curl.exe` on Windows** — it under-reads regardless of server. Use
+  `preflight.py`'s sampled throughput.
+- **Slow joins on `slowjoin` are the point.** File a bug only if the join exceeds the GOP
+  length or A/V never locks after the first IDR.
+- **Link capacity is a real variable.** A stream whose bitrate exceeds your path to the VPS
+  cannot play live regardless of player behaviour; check the preflight throughput numbers
+  against the asset bitrate before chasing "stutter".
+- **Asset licensing.** `prepare-assets.sh` derives everything from the clip you supply; use
+  content you have the rights to put on a public endpoint.

--- a/tools/media-test-streams/docker-compose.yml
+++ b/tools/media-test-streams/docker-compose.yml
@@ -8,15 +8,17 @@
 #   rist           RIST senders (needs an ffmpeg image built with librist)
 
 services:
-  # RTSP server, TCP-interleaved only (rtspt://<host>:8554/<path>).
-  # Publishers push in over RTMP on the compose-internal network: RTMP carries
-  # whole access units, while ffmpeg's RTSP output fragments large AAC frames
-  # in ways ingest depacketisers reject.
+  # RTSP server, TCP-interleaved only (rtspt://<host>:8554/<path>), plus the
+  # RTMP pull lane on 1935 (rtmp://<host>:1935/<path>).
+  # Publishers also push in over RTMP: it carries whole access units, while
+  # ffmpeg's RTSP output fragments large AAC frames in ways ingest
+  # depacketisers reject.
   mediamtx:
     image: bluenviron/mediamtx:latest
     restart: unless-stopped
     ports:
       - "8554:8554"      # RTSP (TCP)
+      - "1935:1935"      # RTMP (ingest + player pull lane)
     volumes:
       - ./mediamtx.yml:/mediamtx.yml:ro
 
@@ -51,14 +53,22 @@ services:
       -re -stream_loop -1 -i /assets/slowjoin.mp4
       -c copy -f flv rtmp://mediamtx:1935/slowjoin
 
-  # CEA-608 caption fixture (silent test pattern with in-band captions in the
-  # H.264 SEIs; -c copy preserves them through RTMP and RTSP).
-  pub-captions:
-    <<: *publisher
+  # CEA-608 caption fixture over HTTP-TS: http://<host>:8082/captions.ts
+  # (silent test pattern with in-band captions in the H.264 SEIs; -c copy
+  # preserves them). Served raw rather than via RTMP: the fixture loops, and
+  # the player treats the per-loop timestamp wrap as a new timeline, while the
+  # FLV mux does not tolerate it. Single-client feeder like tslive.
+  cclive:
+    image: linuxserver/ffmpeg:latest
+    restart: unless-stopped
+    ports:
+      - "8082:8082"
+    volumes:
+      - ./assets:/assets:ro
     command: >-
       -hide_banner -loglevel warning
       -re -stream_loop -1 -i /assets/test_cc.ts
-      -c copy -f flv rtmp://mediamtx:1935/captions
+      -c copy -f mpegts -listen 1 http://0.0.0.0:8082/captions.ts
 
   # VOD over HTTP with real range support (nginx answers 206, so the player's
   # Delivery=Auto probe detects OnDemand). Serves everything in ./assets.

--- a/tools/media-test-streams/docker-compose.yml
+++ b/tools/media-test-streams/docker-compose.yml
@@ -1,0 +1,122 @@
+# Test-stream stack for the Basis media player. See README.md for usage.
+#
+# Runs locally (Editor allows loopback URLs) or on any public VPS (builds/Quest
+# require a public host). Prepare ./assets first: scripts/prepare-assets.sh
+#
+# Profiles:
+#   default        rtsp/rtspt lanes + VOD + HTTP-TS live
+#   rist           RIST senders (needs an ffmpeg image built with librist)
+
+services:
+  # RTSP server, TCP-interleaved only (rtspt://<host>:8554/<path>).
+  # Publishers push in over RTMP on the compose-internal network: RTMP carries
+  # whole access units, while ffmpeg's RTSP output fragments large AAC frames
+  # in ways ingest depacketisers reject.
+  mediamtx:
+    image: bluenviron/mediamtx:latest
+    restart: unless-stopped
+    ports:
+      - "8554:8554"      # RTSP (TCP)
+    volumes:
+      - ./mediamtx.yml:/mediamtx.yml:ro
+
+  # Looping publishers. -c copy from pre-encoded assets: zero transcode CPU.
+  pub-main: &publisher
+    image: linuxserver/ffmpeg:latest
+    restart: unless-stopped
+    depends_on: [mediamtx]
+    volumes:
+      - ./assets:/assets:ro
+    command: >-
+      -hide_banner -loglevel warning
+      -re -stream_loop -1 -i /assets/mezzanine.mp4
+      -c copy -f flv rtmp://mediamtx:1935/main
+
+  # Silent-audio variant (video + silent stereo): regression cover for sources
+  # whose SDP would otherwise be video-only.
+  pub-silent:
+    <<: *publisher
+    command: >-
+      -hide_banner -loglevel warning
+      -re -stream_loop -1 -i /assets/silent.mp4
+      -c copy -f flv rtmp://mediamtx:1935/silent
+
+  # Adversarial long-GOP path: a mid-stream join waits up to the full GOP for
+  # an IDR — deliberate repro for slow-join symptoms. Slow joins here are
+  # expected, not bugs.
+  pub-slowjoin:
+    <<: *publisher
+    command: >-
+      -hide_banner -loglevel warning
+      -re -stream_loop -1 -i /assets/slowjoin.mp4
+      -c copy -f flv rtmp://mediamtx:1935/slowjoin
+
+  # CEA-608 caption fixture (silent test pattern with in-band captions in the
+  # H.264 SEIs; -c copy preserves them through RTMP and RTSP).
+  pub-captions:
+    <<: *publisher
+    command: >-
+      -hide_banner -loglevel warning
+      -re -stream_loop -1 -i /assets/test_cc.ts
+      -c copy -f flv rtmp://mediamtx:1935/captions
+
+  # VOD over HTTP with real range support (nginx answers 206, so the player's
+  # Delivery=Auto probe detects OnDemand). Serves everything in ./assets.
+  vod:
+    image: nginx:alpine
+    restart: unless-stopped
+    ports:
+      - "8080:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./assets:/srv/assets:ro
+
+  # HTTP-TS live lane: http://<host>:8081/live.ts
+  # ffmpeg -listen serves ONE client, then exits; restart: unless-stopped
+  # respawns a fresh slot. A wedged (connected-but-stale) slot needs a manual
+  # `docker compose restart tslive`.
+  tslive:
+    image: linuxserver/ffmpeg:latest
+    restart: unless-stopped
+    ports:
+      - "8081:8081"
+    volumes:
+      - ./assets:/assets:ro
+    command: >-
+      -hide_banner -loglevel warning
+      -re -stream_loop -1 -i /assets/mezzanine.mp4
+      -c copy -f mpegts -listen 1 http://0.0.0.0:8081/live.ts
+
+  # --- RIST lanes (profile: rist) ------------------------------------------
+  # The player side needs the plugin built with -DBASIS_WITH_RIST=ON.
+  # The sender side needs ffmpeg with librist compiled in — check with:
+  #   docker compose run --rm rist-plain -protocols 2>/dev/null | grep rist
+  # Sender runs in listener mode; the player connects to rist://<host>:5000.
+  rist-plain:
+    image: linuxserver/ffmpeg:latest
+    restart: unless-stopped
+    profiles: [rist]
+    ports:
+      - "5000:5000/udp"
+    volumes:
+      - ./assets:/assets:ro
+    command: >-
+      -hide_banner -loglevel warning
+      -re -stream_loop -1 -i /assets/mezzanine.mp4
+      -c copy -f mpegts -rist_profile main "rist://@:5000"
+
+  # AES-128 lane: rist://<host>:5001?secret=<PSK>&aes-type=128
+  # Replace the PSK below (and use the same value in the player URL).
+  rist-aes:
+    image: linuxserver/ffmpeg:latest
+    restart: unless-stopped
+    profiles: [rist]
+    ports:
+      - "5001:5001/udp"
+    volumes:
+      - ./assets:/assets:ro
+    command: >-
+      -hide_banner -loglevel warning
+      -re -stream_loop -1 -i /assets/mezzanine.mp4
+      -c copy -f mpegts -rist_profile main
+      "rist://@:5001?secret=change-this-preshared-key&aes-type=128"

--- a/tools/media-test-streams/mediamtx.yml
+++ b/tools/media-test-streams/mediamtx.yml
@@ -1,6 +1,6 @@
 # mediamtx config for the Basis media-player test stack.
-# RTSP over TCP only (the player's rtspt:// lane); RTMP is enabled solely as
-# the compose-internal ingest for the publisher containers.
+# RTSP over TCP only (the player's rtspt:// lane). RTMP doubles as the
+# publisher ingest and the player's rtmp:// pull lane.
 
 logLevel: info
 
@@ -9,7 +9,7 @@ rtspTransports: [tcp]
 rtspAddress: :8554
 
 rtmp: yes
-rtmpAddress: :1935   # not published to the host by docker-compose; ingest only
+rtmpAddress: :1935
 
 hls: no
 webrtc: no

--- a/tools/media-test-streams/mediamtx.yml
+++ b/tools/media-test-streams/mediamtx.yml
@@ -1,0 +1,19 @@
+# mediamtx config for the Basis media-player test stack.
+# RTSP over TCP only (the player's rtspt:// lane); RTMP is enabled solely as
+# the compose-internal ingest for the publisher containers.
+
+logLevel: info
+
+rtsp: yes
+rtspTransports: [tcp]
+rtspAddress: :8554
+
+rtmp: yes
+rtmpAddress: :1935   # not published to the host by docker-compose; ingest only
+
+hls: no
+webrtc: no
+srt: no
+
+paths:
+  all_others:

--- a/tools/media-test-streams/nginx.conf
+++ b/tools/media-test-streams/nginx.conf
@@ -1,0 +1,13 @@
+# VOD lane: static files with real range support (nginx answers 206 Partial
+# Content, which the player's Delivery=Auto probe requires to detect VOD).
+server {
+    listen 80;
+    root /srv;
+
+    location /assets/ {
+        autoindex on;
+        # Large media files: stream from disk, don't buffer whole files in RAM.
+        sendfile on;
+        tcp_nopush on;
+    }
+}

--- a/tools/media-test-streams/scripts/gen_cc_ts.py
+++ b/tools/media-test-streams/scripts/gen_cc_ts.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+Generate a looping MPEG-TS test clip carrying in-band CEA-608 (CC1) captions, to
+exercise the media player's caption decoder end to end.
+
+ffmpeg can read/repack captions but not synthesise them, so this builds the
+caption bytes itself: it encodes pop-on CEA-608 command sequences, wraps them in
+ATSC A/53 (GA94) cc_data SEI NAL units, and splices one in at each caption-change
+frame of an H.264 Annex B elementary stream produced by ffmpeg. A second ffmpeg
+pass muxes the result to MPEG-TS.
+
+Usage:  gen_cc_ts.py [output.ts]        (default: test_cc.ts beside this script)
+Verify: ffprobe -show_frames output.ts | grep -i caption   ("ATSC A53" side data)
+"""
+import os
+import subprocess
+import sys
+import tempfile
+
+FPS = 30
+DUR = 20            # seconds
+W, H = 854, 480
+
+# Schedule: (frame_index, caption_text or None-for-clear). Pop-on; the cue persists
+# until the next entry, so a change every ~3s reads comfortably.
+SCHEDULE = [
+    (0,   "CEA-608 CAPTION TEST"),
+    (90,  "THE QUICK BROWN FOX"),
+    (180, "JUMPS OVER THE LAZY DOG"),
+    (270, None),                       # clear
+    (330, "ACCENTS: cafe résumé piñata"),
+    (420, "MUSIC: ♪ la la la ♪"),
+    (510, "LAST LINE - LOOP RESTARTS"),
+]
+
+# ---- CEA-608 encoding ----------------------------------------------------
+
+def odd_parity(b):
+    b &= 0x7F
+    ones = bin(b).count("1")
+    return b | (0x00 if ones % 2 else 0x80)
+
+# Basic North American set: accented characters with dedicated codepoints.
+BASIC = {"á": 0x2A, "é": 0x5C, "í": 0x5E, "ó": 0x5F, "ú": 0x60,
+         "ç": 0x7B, "÷": 0x7C, "Ñ": 0x7D, "ñ": 0x7E}
+# Special chars live in a control pair (0x11, 0x30-0x3F).
+SPECIAL = {"♪": 0x37}   # music note
+
+def char_pairs(text):
+    """Yield (b0,b1) byte pairs for the text body (no parity yet)."""
+    pending = []
+    out = []
+    for ch in text:
+        if ch in SPECIAL:                 # special char is its own control pair
+            if len(pending) == 1:
+                out.append((pending[0], 0x00)); pending = []
+            out.append((0x11, SPECIAL[ch]))
+            continue
+        code = BASIC.get(ch)
+        if code is None:
+            o = ord(ch)
+            code = o if 0x20 <= o <= 0x7F else 0x20   # fall back to space
+        pending.append(code)
+        if len(pending) == 2:
+            out.append((pending[0], pending[1])); pending = []
+    if pending:
+        out.append((pending[0], 0x00))
+    return out
+
+RCL = (0x14, 0x20); ENM = (0x14, 0x2E); EDM = (0x14, 0x2C); EOC = (0x14, 0x2F)
+PAC_R15 = (0x14, 0x60)   # row 15, white, column 0
+
+def encode_caption(text):
+    if text is None:
+        return [EDM]
+    return [RCL, ENM, PAC_R15] + char_pairs(text) + [EOC]
+
+# ---- SEI / NAL assembly --------------------------------------------------
+
+def cc_data(pairs):
+    n = len(pairs)
+    assert n <= 31
+    b = bytearray()
+    b.append(0xC0 | n)        # reserved=1, process_cc_data_flag=1, additional=0, cc_count
+    b.append(0xFF)            # em_data
+    for d1, d2 in pairs:
+        b.append(0xFC)        # marker(11111) | cc_valid(1) | cc_type(00 = 608 field 1)
+        b.append(odd_parity(d1))
+        b.append(odd_parity(d2))
+    b.append(0xFF)            # trailing marker
+    return bytes(b)
+
+def user_data(pairs):
+    p = bytearray()
+    p += bytes([0xB5, 0x00, 0x31])          # country USA, provider ATSC
+    p += b"GA94"                            # user_identifier
+    p.append(0x03)                          # user_data_type_code = cc_data
+    p += cc_data(pairs)
+    return bytes(p)
+
+def emulation_escape(rbsp):
+    out = bytearray()
+    zeros = 0
+    for byte in rbsp:
+        if zeros >= 2 and byte <= 0x03:
+            out.append(0x03)
+            zeros = 0
+        out.append(byte)
+        zeros = zeros + 1 if byte == 0 else 0
+    return bytes(out)
+
+def sei_nal(pairs):
+    payload = user_data(pairs)
+    msg = bytearray()
+    msg.append(0x04)                        # payloadType = user_data_registered_itu_t_t35
+    size = len(payload)
+    while size >= 255:
+        msg.append(0xFF); size -= 255
+    msg.append(size)
+    msg += payload
+    rbsp = bytes(msg) + b"\x80"             # rbsp_trailing_bits
+    return b"\x00\x00\x00\x01" + b"\x06" + emulation_escape(rbsp)
+
+# ---- Annex B splicing ----------------------------------------------------
+
+def find_nals(data):
+    """Yield (start_index_of_startcode, nal_type) for each NAL."""
+    i, n = 0, len(data)
+    while i + 3 < n:
+        if data[i] == 0 and data[i+1] == 0 and data[i+2] == 1:
+            sc = 3
+        elif data[i] == 0 and data[i+1] == 0 and data[i+2] == 0 and data[i+3] == 1:
+            sc = 4
+        else:
+            i += 1; continue
+        nal_type = data[i+sc] & 0x1F
+        yield (i, nal_type)
+        i += sc + 1
+
+def splice(data, schedule):
+    """Insert an SEI NAL into each scheduled access unit, in AU order: after
+    AUD/SPS/PPS and immediately before the first VCL slice NAL."""
+    by_frame = dict(schedule)
+    nals = list(find_nals(data))
+    out = bytearray()
+    au_index = -1
+    pending = None                          # caption pairs awaiting the slice NAL
+    for k, (off, ntype) in enumerate(nals):
+        end = nals[k+1][0] if k + 1 < len(nals) else len(data)
+        if ntype == 9:                      # AUD => start of a new access unit
+            au_index += 1
+            pending = encode_caption(by_frame[au_index]) if au_index in by_frame else None
+        if 1 <= ntype <= 5 and pending is not None:
+            out += sei_nal(pending)         # prefix SEI sits before the coded picture
+            pending = None
+        out += data[off:end]
+    return bytes(out)
+
+# ---- pipeline ------------------------------------------------------------
+
+def run(cmd):
+    print("+", " ".join(cmd))
+    subprocess.run(cmd, check=True)
+
+def main():
+    out_path = sys.argv[1] if len(sys.argv) > 1 else \
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_cc.ts")
+    with tempfile.TemporaryDirectory() as tmp:
+        base = os.path.join(tmp, "base.h264")
+        mod = os.path.join(tmp, "mod.h264")
+        # No B-frames (bframes=0): the raw-H.264 demuxer in the copy pass can't
+        # derive DTS for reordered frames, which makes the MPEG-TS muxer reject
+        # the stream.
+        run(["ffmpeg", "-y", "-f", "lavfi", "-i", f"testsrc2=s={W}x{H}:r={FPS}:d={DUR}",
+             "-pix_fmt", "yuv420p", "-c:v", "libx264", "-profile:v", "baseline",
+             "-g", str(FPS), "-keyint_min", str(FPS), "-bf", "0",
+             "-x264-params", "aud=1:scenecut=0", "-f", "h264", base])
+        data = open(base, "rb").read()
+        spliced = splice(data, SCHEDULE)
+        open(mod, "wb").write(spliced)
+        print(f"  spliced {len(SCHEDULE)} caption SEIs ({len(data)} -> {len(spliced)} bytes)")
+        run(["ffmpeg", "-y", "-framerate", str(FPS), "-i", mod, "-c", "copy",
+             "-muxrate", "3M", "-f", "mpegts", out_path])
+    print(f"\nWrote {out_path}")
+
+if __name__ == "__main__":
+    main()

--- a/tools/media-test-streams/scripts/preflight.py
+++ b/tools/media-test-streams/scripts/preflight.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Preflight probe for the test-stream stack.
+
+Run BEFORE any media-player test session (~30s):
+
+    python3 preflight.py                  # probe everything on localhost
+    python3 preflight.py --host my.vps    # probe a deployed stack
+    python3 preflight.py --host my.vps main captions   # matching lanes only
+
+Catches sick feeders in seconds instead of after a confusing editor session:
+a symptom seen in the player only earns player-side investigation time if the
+preflight is green.
+
+Requires ffmpeg + ffprobe on PATH. Do NOT use curl.exe on Windows for
+throughput checks (it under-reads badly); this script uses urllib.
+"""
+import argparse
+import json
+import subprocess
+import time
+import urllib.request
+
+# (name, kind, path_template, threshold)
+#   rtsp: threshold = max seconds to first decoded frame (None = informational;
+#         slowjoin waits for an IDR in a ~10s GOP by design)
+#   http: threshold = min Mbps over a short sample (catches stale ~0.5Mbps
+#         feeder slots, not nominal bitrate — -re paced feeds dip on quiet scenes)
+#   vod:  threshold unused; checks for a real 206 Partial Content
+LANES = [
+    ("main",     "rtsp", "rtsp://{host}:8554/main",          6.0),
+    ("silent",   "rtsp", "rtsp://{host}:8554/silent",        6.0),
+    ("slowjoin", "rtsp", "rtsp://{host}:8554/slowjoin",      None),
+    ("captions", "rtsp", "rtsp://{host}:8554/captions",      6.0),
+    ("vod",      "vod",  "http://{host}:8080/assets/mezzanine.mp4", None),
+    ("hls-vod",  "vod",  "http://{host}:8080/assets/hls/index.m3u8", None),
+    ("tslive",   "http", "http://{host}:8081/live.ts",       1.0),
+]
+
+
+def probe_rtsp(name, url, limit):
+    """Time-to-first-decoded-video-frame over RTSP/TCP + stream shape."""
+    t0 = time.monotonic()
+    try:
+        out = subprocess.run(
+            ["ffmpeg", "-v", "error", "-rtsp_transport", "tcp", "-i", url,
+             "-map", "0:v:0", "-frames:v", "1", "-f", "null", "-"],
+            capture_output=True, text=True, timeout=25)
+    except subprocess.TimeoutExpired:
+        return f"FAIL  {name}: no decodable video frame within 25s"
+    ttff = time.monotonic() - t0
+    if out.returncode != 0:
+        err = [l for l in out.stderr.strip().splitlines()
+               if "Missing reference" not in l and "mmco" not in l]
+        return f"FAIL  {name}: {err[-1] if err else 'ffmpeg error'}"
+    streams = subprocess.run(
+        ["ffprobe", "-v", "error", "-rtsp_transport", "tcp", "-show_entries",
+         "stream=codec_type,codec_name,channels", "-of", "json", url],
+        capture_output=True, text=True, timeout=25)
+    shape = ",".join(
+        f"{s['codec_name']}({s.get('channels')}ch)" if s["codec_type"] == "audio"
+        else s["codec_name"]
+        for s in json.loads(streams.stdout or '{"streams":[]}')["streams"])
+    verdict = "PASS" if (limit is None or ttff < limit) else "SLOW"
+    note = "" if limit else "  (long-GOP adversarial path: slow join is expected)"
+    return f"{verdict}  {name}: first frame {ttff:.1f}s, streams [{shape}]{note}"
+
+
+def probe_http(name, url, min_mbps, seconds=5):
+    """First-byte latency + short bitrate sample. Consumes a single-client
+    feeder slot; the container respawns a fresh one on disconnect."""
+    t0 = time.monotonic()
+    try:
+        resp = urllib.request.urlopen(url, timeout=10)
+        first = resp.read(64 * 1024)
+        fb = time.monotonic() - t0
+        total = len(first)
+        t1 = time.monotonic()
+        while time.monotonic() - t1 < seconds:
+            chunk = resp.read(256 * 1024)
+            if not chunk:
+                break
+            total += len(chunk)
+        resp.close()
+    except Exception as ex:
+        return f"FAIL  {name}: {ex}"
+    mbps = total * 8 / max(time.monotonic() - t0, 0.001) / 1e6
+    verdict = "PASS" if mbps >= min_mbps else "FAIL"
+    return f"{verdict}  {name}: first byte {fb:.2f}s, {mbps:.1f} Mbps sampled"
+
+
+def probe_vod(name, url):
+    """The player's Delivery=Auto probe needs a real 206 for OnDemand."""
+    req = urllib.request.Request(url, headers={"Range": "bytes=0-1023"})
+    try:
+        resp = urllib.request.urlopen(req, timeout=10)
+        code = resp.getcode()
+        resp.read(1024)
+        resp.close()
+    except Exception as ex:
+        return f"FAIL  {name}: {ex}"
+    if code == 206:
+        return f"PASS  {name}: 206 Partial Content (detected as OnDemand)"
+    return f"FAIL  {name}: got {code}, not 206 — will be treated as LIVE"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--host", default="localhost")
+    ap.add_argument("filters", nargs="*", help="only lanes whose name contains a filter")
+    args = ap.parse_args()
+
+    results = []
+    for name, kind, tmpl, threshold in LANES:
+        if args.filters and not any(f in name for f in args.filters):
+            continue
+        url = tmpl.format(host=args.host)
+        if kind == "rtsp":
+            results.append(probe_rtsp(name, url, threshold))
+        elif kind == "http":
+            results.append(probe_http(name, url, threshold))
+        else:
+            results.append(probe_vod(name, url))
+        print(results[-1], flush=True)
+
+    fails = sum(1 for r in results if r.startswith("FAIL"))
+    print(f"\n{len(results)} lanes probed, {fails} failing")
+    raise SystemExit(1 if fails else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/media-test-streams/scripts/preflight.py
+++ b/tools/media-test-streams/scripts/preflight.py
@@ -30,19 +30,21 @@ LANES = [
     ("main",     "rtsp", "rtsp://{host}:8554/main",          6.0),
     ("silent",   "rtsp", "rtsp://{host}:8554/silent",        6.0),
     ("slowjoin", "rtsp", "rtsp://{host}:8554/slowjoin",      None),
-    ("captions", "rtsp", "rtsp://{host}:8554/captions",      6.0),
+    ("rtmp",     "rtsp", "rtmp://{host}:1935/main",          6.0),
     ("vod",      "vod",  "http://{host}:8080/assets/mezzanine.mp4", None),
     ("hls-vod",  "vod",  "http://{host}:8080/assets/hls/index.m3u8", None),
     ("tslive",   "http", "http://{host}:8081/live.ts",       1.0),
+    ("captions", "http", "http://{host}:8082/captions.ts",   1.0),
 ]
 
 
 def probe_rtsp(name, url, limit):
-    """Time-to-first-decoded-video-frame over RTSP/TCP + stream shape."""
+    """Time-to-first-decoded-video-frame + stream shape (RTSP/TCP or RTMP)."""
+    transport = ["-rtsp_transport", "tcp"] if url.startswith("rtsp") else []
     t0 = time.monotonic()
     try:
         out = subprocess.run(
-            ["ffmpeg", "-v", "error", "-rtsp_transport", "tcp", "-i", url,
+            ["ffmpeg", "-v", "error"] + transport + ["-i", url,
              "-map", "0:v:0", "-frames:v", "1", "-f", "null", "-"],
             capture_output=True, text=True, timeout=25)
     except subprocess.TimeoutExpired:
@@ -53,7 +55,7 @@ def probe_rtsp(name, url, limit):
                if "Missing reference" not in l and "mmco" not in l]
         return f"FAIL  {name}: {err[-1] if err else 'ffmpeg error'}"
     streams = subprocess.run(
-        ["ffprobe", "-v", "error", "-rtsp_transport", "tcp", "-show_entries",
+        ["ffprobe", "-v", "error"] + transport + ["-show_entries",
          "stream=codec_type,codec_name,channels", "-of", "json", url],
         capture_output=True, text=True, timeout=25)
     shape = ",".join(

--- a/tools/media-test-streams/scripts/prepare-assets.sh
+++ b/tools/media-test-streams/scripts/prepare-assets.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Prepare the ./assets content the test-stream stack serves.
+#
+# Usage:  scripts/prepare-assets.sh <input-video>
+#
+# <input-video> is your own test clip. Prefer real footage with visible speech
+# (lip-sync moments make A/V drift visible; synthetic patterns hide it) and,
+# for the multichannel lanes, a source with 6 or 8 audio channels. Everything
+# is derived from this one file.
+#
+# Needs ffmpeg/ffprobe on PATH. The LPCM lane needs a build with the
+# pcm_bluray encoder and the caption fixture needs python3 (both optional —
+# skipped with a warning if unavailable).
+set -euo pipefail
+
+IN="${1:?usage: prepare-assets.sh <input-video>}"
+HERE="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="$HERE/assets"
+mkdir -p "$OUT"
+
+channels=$(ffprobe -v error -select_streams a:0 -show_entries stream=channels \
+    -of default=nw=1:nk=1 "$IN" 2>/dev/null || echo 0)
+echo "== input: $IN (audio channels: $channels)"
+
+# Canonical live mezzanine: fixed 2 s keyframe grid so live joins land a
+# decodable frame within ~2 s. Publishers -c copy from this; encode once here.
+echo "== mezzanine.mp4 (2s GOP)"
+ffmpeg -y -hide_banner -loglevel warning -i "$IN" \
+    -c:v libx264 -crf 18 -g 48 -keyint_min 48 -sc_threshold 0 -r 24 \
+    -c:a aac -b:a 384k \
+    "$OUT/mezzanine.mp4"
+
+echo "== silent.mp4 (video + silent stereo)"
+ffmpeg -y -hide_banner -loglevel warning -i "$OUT/mezzanine.mp4" \
+    -f lavfi -i anullsrc=channel_layout=stereo:sample_rate=48000 \
+    -map 0:v -map 1:a -c:v copy -c:a aac -shortest \
+    "$OUT/silent.mp4"
+
+# Adversarial long-GOP variant: joins mid-GOP wait up to ~10 s for an IDR.
+echo "== slowjoin.mp4 (10s GOP)"
+ffmpeg -y -hide_banner -loglevel warning -i "$IN" \
+    -c:v libx264 -crf 18 -g 240 -keyint_min 240 -sc_threshold 0 -r 24 \
+    -c:a aac -b:a 384k \
+    "$OUT/slowjoin.mp4"
+
+echo "== hls/ (HLS VOD packaging)"
+mkdir -p "$OUT/hls"
+ffmpeg -y -hide_banner -loglevel warning -i "$OUT/mezzanine.mp4" \
+    -c copy -f hls -hls_time 4 -hls_playlist_type vod \
+    -hls_segment_filename "$OUT/hls/seg%04d.ts" \
+    "$OUT/hls/index.m3u8"
+
+# Split-stream pair (video-only + audio-only) for the AudioUri lane.
+echo "== videoonly.mp4 / audioonly.mp4"
+ffmpeg -y -hide_banner -loglevel warning -i "$OUT/mezzanine.mp4" \
+    -map 0:v -c copy -an "$OUT/videoonly.mp4"
+ffmpeg -y -hide_banner -loglevel warning -i "$OUT/mezzanine.mp4" \
+    -map 0:a -c copy -vn "$OUT/audioonly.mp4"
+
+if [ "$channels" -ge 6 ]; then
+    # LPCM over M2TS: the full-multichannel lane (AAC on Windows caps at 5.1;
+    # LPCM plays all 8 lanes discretely).
+    if ffmpeg -hide_banner -encoders 2>/dev/null | grep -q pcm_bluray; then
+        echo "== lpcm.m2ts (LPCM ${channels}ch over M2TS)"
+        ffmpeg -y -hide_banner -loglevel warning -i "$IN" \
+            -c:v libx264 -crf 18 -g 48 -keyint_min 48 -sc_threshold 0 -r 24 \
+            -c:a pcm_bluray -ar 48000 \
+            -f mpegts "$OUT/lpcm.m2ts"
+    else
+        echo "!! skipping lpcm.m2ts: this ffmpeg lacks the pcm_bluray encoder (use a full build)"
+    fi
+
+    echo "== w${channels}.wav (multichannel WAV, 24-bit)"
+    ffmpeg -y -hide_banner -loglevel warning -i "$IN" \
+        -map 0:a -c:a pcm_s24le -ar 48000 -vn "$OUT/w${channels}.wav"
+else
+    echo "!! input has <6 audio channels: skipping LPCM/multichannel-WAV lanes"
+    echo "== wav (stereo, 24-bit)"
+    ffmpeg -y -hide_banner -loglevel warning -i "$IN" \
+        -map 0:a -c:a pcm_s24le -ar 48000 -vn "$OUT/stereo.wav"
+fi
+
+if command -v python3 >/dev/null 2>&1; then
+    echo "== test_cc.ts (CEA-608 caption fixture)"
+    python3 "$HERE/scripts/gen_cc_ts.py" "$OUT/test_cc.ts"
+else
+    echo "!! skipping test_cc.ts: python3 not found"
+fi
+
+echo "== done. assets in $OUT:"
+ls -lh "$OUT"


### PR DESCRIPTION
## Summary

This adds a structured regression-testing setup for the media player. Until now, knowing what to test (and against which streams) has been tribal knowledge:

- **`com.basis.mediaplayer/TESTING.md`** is the regression guide: how the URL security gate affects test hosting (loopback is Editor-only, RFC1918 never works), a table of public always-on endpoints for zero-setup smoke tests, the transport/codec/platform regression matrix, behaviour checklists (join/pause/seek/captions/multichannel), a diagnostics recipe, and a report template.
- **`com.basis.integration.ytdlp/TESTING.md`** covers page-URL (YouTube/Twitch) testing, which lives with the integration that provides it. The base guide deliberately covers direct stream URLs only, and the same split applies to any future integration.
- **`tools/media-test-streams/`** is a self-hostable Docker Compose stack for the lanes no public endpoint covers reliably: RTSP (including an adversarial long-GOP join path), HTTP-TS live, nginx VOD with real range support, a CEA-608 caption fixture, LPCM 5.1/7.1 over M2TS, and RIST plain+AES. It runs locally for Editor work or on any cheap VPS for build/Quest/multi-client testing, and `prepare-assets.sh` turns any clip you own into the full asset set.

VRCDN's public endpoints appear in the guide as the primary zero-setup live lanes. They've kindly given the thumbs-up for that, and the guide includes an acknowledgements section thanking them.

## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [x] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — `BasisEventDriver` runs the single per-frame tick that drives the whole framework (network apply, local player sim, blendshapes, JigglePhysics, nameplates, and more) as one sequential chain. An unhandled exception anywhere in that chain aborts the rest of the tick, so every step after the throwing one is silently skipped for that frame. New work added to the driver must either be guaranteed not to throw, or be wrapped in a `try`/`catch` that contains the failure and surfaces it through `BasisDebug` — logged once / rate-limited, never every frame (see the existing `HVRBasisBuiltInAddresses.Simulate()` guard for the pattern). Expect this to be scrutinized closely in review.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [x] Windows
- [ ] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [ ] Tested in VR (note headset under **Notes**)
- [ ] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [x] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [x] N/A — change does not touch any of the above

## Notes

- **Docs and tooling only.** No C# or native code changes, so the code-quality checks above are ticked as N/A per the template instruction.
- What "Tested" means here: the compose stack validates (`docker compose config`), both Python helpers pass `py_compile` and the shell script passes `bash -n`, the generated CEA-608 fixture carries A53 caption side data per ffprobe, the LPCM 7.1 M2TS mux path works, and every public endpoint in the guide was probed live (the VRCDN RTSP + HTTP-TS lanes were also played in the Editor on Windows).
- The guide documents current behaviour only; where a listed stream exercises a known limitation (AAC channel ceilings, HLS segment bound), the expected outcome is stated so testers don't mistake it for a regression.

