### PR TITLE
fix(mediaplayer): replace the dead Big Buck Bunny endpoint; steer .m4v/.m4a directly

### DIFF
--- a/Basis/Packages/com.basis.mediaplayer/Runtime/BasisMediaUrlRouter.cs
+++ b/Basis/Packages/com.basis.mediaplayer/Runtime/BasisMediaUrlRouter.cs
@@ -105,7 +105,7 @@ public static class BasisMediaUrlRouter
     /// True if the player can open <paramref name="url"/> directly, without a resolver:
     /// any non-HTTP scheme (transport like rtsp/rtmp/rist, or a local file), or an
     /// http(s) URL whose path ends in a media-container extension
-    /// (.mp4/.m4s/.ts/.m2ts/.mts/.m3u8/.wav). An http(s) URL with no media extension is a page URL
+    /// (.mp4/.m4v/.m4a/.m4s/.ts/.m2ts/.mts/.m3u8/.wav). An http(s) URL with no media extension is a page URL
     /// (e.g. a YouTube/Twitch watch page) and needs a resolver. This is the single
     /// source of truth for the live-vs-resolve steering; resolvers and callers both
     /// consult it. It classifies only — it never blocks (host trust is separate).
@@ -136,6 +136,8 @@ public static class BasisMediaUrlRouter
         // No .mpd — there is no DASH demuxer in the native engine, so a raw MPD must go
         // through a resolver (yt-dlp) rather than being treated as directly playable.
         return path.EndsWith(".mp4", StringComparison.OrdinalIgnoreCase)
+            || path.EndsWith(".m4v", StringComparison.OrdinalIgnoreCase)   // MP4 container, video flavour
+            || path.EndsWith(".m4a", StringComparison.OrdinalIgnoreCase)   // MP4 container, audio-only
             || path.EndsWith(".m4s", StringComparison.OrdinalIgnoreCase)
             || path.EndsWith(".ts", StringComparison.OrdinalIgnoreCase)
             || path.EndsWith(".m2ts", StringComparison.OrdinalIgnoreCase)   // Blu-ray-flavour MPEG-TS

--- a/Basis/Packages/com.basis.mediaplayer/TESTING.md
+++ b/Basis/Packages/com.basis.mediaplayer/TESTING.md
@@ -75,7 +75,7 @@ fine for interactive test sessions, not for soak loops.
 | --- | --- | --- |
 | `rtsp://stream.vrcdn.live/live/vrcdn` | RTSP live, H.264 720p + AAC 2.0 @ 48 kHz | VRCDN's own 24/7 channel; the primary PC low-latency lane; host is on the default trust list |
 | `https://stream.vrcdn.live/live/vrcdn.live.ts` | MPEG-TS over HTTPS, live | Same channel, the standalone-friendly lane (https, so Quest-safe) |
-| `https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4` | Progressive MP4 VOD, range/`206` | Also good for seek/pause and delivery auto-detect testing |
+| `https://download.blender.org/peach/bigbuckbunny_movies/BigBuckBunny_640x360.m4v` | Progressive MP4 VOD, range/`206` | Official Blender hosting of the full 10-minute film, H.264 + AAC (the `.m4v` extension is fine — the player sniffs the container). Good for seek/pause and delivery auto-detect testing |
 | `https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8` | HLS VOD, multi-variant master | Exercises the panel's bitrate dropdown |
 | [Fraunhofer AAC multichannel page](https://www2.iis.fraunhofer.de/AAC/multichannel.html) | AAC 5.1/7.1 VOD fixtures | Includes adversarial layouts: PCE-signalled 7.1 must fail **gracefully** on Windows (muted audio or a clean error — never a crash) |
 

--- a/Basis/Packages/com.basis.mediaplayer/TESTING.md
+++ b/Basis/Packages/com.basis.mediaplayer/TESTING.md
@@ -75,7 +75,7 @@ fine for interactive test sessions, not for soak loops.
 | --- | --- | --- |
 | `rtsp://stream.vrcdn.live/live/vrcdn` | RTSP live, H.264 720p + AAC 2.0 @ 48 kHz | VRCDN's own 24/7 channel; the primary PC low-latency lane; host is on the default trust list |
 | `https://stream.vrcdn.live/live/vrcdn.live.ts` | MPEG-TS over HTTPS, live | Same channel, the standalone-friendly lane (https, so Quest-safe) |
-| `https://download.blender.org/peach/bigbuckbunny_movies/BigBuckBunny_640x360.m4v` | Progressive MP4 VOD, range/`206` | Official Blender hosting of the full 10-minute film, H.264 + AAC (the `.m4v` extension is fine — the player sniffs the container). Good for seek/pause and delivery auto-detect testing |
+| `https://download.blender.org/peach/bigbuckbunny_movies/BigBuckBunny_640x360.m4v` | Progressive MP4 VOD, range/`206` | Official Blender hosting of the full 10-minute film, H.264 + AAC (`.m4v` is recognised as an MP4 extension). Good for seek/pause and delivery auto-detect testing |
 | `https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8` | HLS VOD, multi-variant master | Exercises the panel's bitrate dropdown |
 | [Fraunhofer AAC multichannel page](https://www2.iis.fraunhofer.de/AAC/multichannel.html) | AAC 5.1/7.1 VOD fixtures | Includes adversarial layouts: PCE-signalled 7.1 must fail **gracefully** on Windows (muted audio or a clean error — never a crash) |
 


### PR DESCRIPTION
## Summary

Follow-up to #941: the Google-hosted Big Buck Bunny URL in the endpoints table now returns 403 (thanks @cathiecode for catching it). This points the progressive-MP4 VOD row at Blender's own hosting of the film instead, and fixes the URL-steering gap the new endpoint exposed.

Replacement vetted before committing: `https://download.blender.org/peach/bigbuckbunny_movies/BigBuckBunny_640x360.m4v` answers a `Range` request with a proper 206, and ffprobe confirms H.264 + AAC over the full 10-minute runtime, so the row still exercises range support, seek/pause, and delivery auto-detect.

The steering fix: `BasisMediaUrlRouter.IsDirectlyPlayable` didn't list `.m4v`/`.m4a`, so on installs with a resolver present an https URL with either extension was classified as a page URL and handed to yt-dlp's generic extractor instead of playing directly. Both are plain MP4 containers the engine already demuxes (video and audio-only respectively), so they now steer direct like `.mp4` does. Without this, the new endpoint would have tested the resolver path on resolver installs rather than the direct progressive lane the row exists for.

## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [x] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — `BasisEventDriver` runs the single per-frame tick that drives the whole framework (network apply, local player sim, blendshapes, JigglePhysics, nameplates, and more) as one sequential chain. An unhandled exception anywhere in that chain aborts the rest of the tick, so every step after the throwing one is silently skipped for that frame. New work added to the driver must either be guaranteed not to throw, or be wrapped in a `try`/`catch` that contains the failure and surfaces it through `BasisDebug` — logged once / rate-limited, never every frame (see the existing `HVRBasisBuiltInAddresses.Simulate()` guard for the pattern). Expect this to be scrutinized closely in review.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [x] Windows
- [ ] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [ ] Tested in VR (note headset under **Notes**)
- [ ] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [x] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [x] N/A — change does not touch any of the above

## Notes

Docs fix plus a two-line extension addition in `IsDirectlyPlayable`; the hot-path/component checks are N/A for both. "Tested" here means the replacement URL was probed before committing (206 on a `Range` request, H.264 + AAC confirmed via ffprobe); the router change is a string-suffix match addition to the existing list, same pattern as its neighbours, ticked under the trivial-change convention rather than a full Editor pass.
