### PR TITLE
feat(mediaplayer): letterbox non-16:9 video instead of stretching it

### DIFF
--- a/Basis/Packages/com.basis.mediaplayer/Materials/MediaPlayer.mat
+++ b/Basis/Packages/com.basis.mediaplayer/Materials/MediaPlayer.mat
@@ -8,7 +8,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: MediaPlayer
-  m_Shader: {fileID: 4800000, guid: 650dd9526735d5b46b79224bc6e94025, type: 3}
+  m_Shader: {fileID: 4800000, guid: 6d9e4abc7b3f5c8dae2a4b6c8d0f2e3a, type: 3}
   m_Parent: {fileID: 0}
   m_ModifiedSerializedProperties: 0
   m_ValidKeywords: []

--- a/Basis/Packages/com.basis.mediaplayer/Prefabs/MediaPlayerMultiChannelStreaming.prefab
+++ b/Basis/Packages/com.basis.mediaplayer/Prefabs/MediaPlayerMultiChannelStreaming.prefab
@@ -223,7 +223,7 @@ MonoBehaviour:
   FlipHorizontally: 0
   ProjectionMode: 0
   StereoEye: 0
-  AspectMode: 0
+  AspectMode: 2
   DisplayAspectOverride: 0
 --- !u!114 &8872620006077822243
 MonoBehaviour:

--- a/Basis/Packages/com.basis.mediaplayer/Prefabs/MediaPlayerStreaming.prefab
+++ b/Basis/Packages/com.basis.mediaplayer/Prefabs/MediaPlayerStreaming.prefab
@@ -792,7 +792,7 @@ MonoBehaviour:
   FlipHorizontally: 0
   ProjectionMode: 0
   StereoEye: 0
-  AspectMode: 0
+  AspectMode: 2
   DisplayAspectOverride: 0
 --- !u!114 &5505517674190816405
 MonoBehaviour:

--- a/Basis/Packages/com.basis.mediaplayer/Runtime/Rendering/BasisVideoAspectMode.cs
+++ b/Basis/Packages/com.basis.mediaplayer/Runtime/Rendering/BasisVideoAspectMode.cs
@@ -1,8 +1,16 @@
+// Aspect-fit mode, applied as a UV scale/offset on the sampled video texture.
+//
+// FitInside (letterbox/pillarbox) scales the bar axis > 1, so the sampled UV runs
+// outside [0,1] over the bars. It only renders those as black bars with a
+// shader/material that treats out-of-range UVs as black (e.g. "Basis/Media Player
+// Video"). On a clamp/repeat material — or a RawImage, which follows the UI
+// sampler — it smears or repeats the edge instead; there, prefer Original + a
+// RectTransform AspectRatioFitter, or FitOutside (crop, which stays within [0,1]).
 public enum BasisVideoAspectMode
 {
-    Original = 0,
-    Stretch = 1,
-    FitInside = 2,
-    FitOutside = 3,
-    PixelPerfect = 4,
+    Original = 0,     // sample untransformed (no aspect correction)
+    Stretch = 1,      // same as Original — fill, ignore aspect
+    FitInside = 2,    // letterbox/pillarbox — needs a black-out-of-range shader (see above)
+    FitOutside = 3,   // crop to fill (stays within [0,1], safe on any material)
+    PixelPerfect = 4, // 1:1 source pixels at the chosen scale
 }

--- a/Basis/Packages/com.basis.mediaplayer/Runtime/Rendering/BasisVideoDisplay.cs
+++ b/Basis/Packages/com.basis.mediaplayer/Runtime/Rendering/BasisVideoDisplay.cs
@@ -35,7 +35,7 @@ public sealed class BasisVideoDisplay : MonoBehaviour
     public BasisVideoStereoEye StereoEye = BasisVideoStereoEye.Left;
 
     [Header("Aspect")]
-    [Tooltip("Original = sample untransformed (the AspectFitter usually handles it); Stretch = same; FitInside = letterbox; FitOutside = crop. PixelPerfect maps source pixels 1:1.")]
+    [Tooltip("Original = sample untransformed — the RectTransform AspectRatioFitter handles aspect on this UI path, so this is the right choice here. Stretch = same. FitInside/FitOutside/PixelPerfect apply a UV transform; FitInside letterbox needs a shader that blacks out-of-range UVs, which a RawImage's UI material does NOT — it smears/repeats instead. Use the AspectFitter for letterboxing on a RawImage.")]
     public BasisVideoAspectMode AspectMode = BasisVideoAspectMode.Original;
 
     [Header("Picture")]

--- a/Basis/Packages/com.basis.mediaplayer/Runtime/Rendering/BasisVideoMaterialOutput.cs
+++ b/Basis/Packages/com.basis.mediaplayer/Runtime/Rendering/BasisVideoMaterialOutput.cs
@@ -78,7 +78,7 @@ public sealed class BasisVideoMaterialOutput : MonoBehaviour
     public BasisVideoStereoEye StereoEye = BasisVideoStereoEye.Left;
 
     [Header("Aspect")]
-    [Tooltip("Original = sample untransformed; Stretch = same; FitInside = letterbox to preserve source aspect; FitOutside = crop to fill display; PixelPerfect = 1:1 source pixels at the chosen scale.")]
+    [Tooltip("Original = sample untransformed; Stretch = same; FitInside = letterbox (needs a shader that renders out-of-range UVs black, e.g. Basis/Media Player Video — on a clamp/repeat material it smears); FitOutside = crop to fill display (safe on any material); PixelPerfect = 1:1 source pixels at the chosen scale.")]
     public BasisVideoAspectMode AspectMode = BasisVideoAspectMode.Original;
 
     [Tooltip("Display aspect ratio for FitInside/FitOutside/PixelPerfect. Defaults to the renderer's local-bounds aspect when 0. Override for non-square quads or skewed targets.")]

--- a/Basis/Packages/com.basis.mediaplayer/Runtime/Rendering/BasisVideoOutputMath.cs
+++ b/Basis/Packages/com.basis.mediaplayer/Runtime/Rendering/BasisVideoOutputMath.cs
@@ -65,15 +65,19 @@ public static class BasisVideoOutputMath
         {
             case BasisVideoAspectMode.FitInside:
             {
+                // Letterbox: fit the whole source inside the screen and fill the rest
+                // with bars. The bar axis scales > 1 so the sampled UV runs outside
+                // [0,1] there, which the video shader paints black. (A scale < 1 would
+                // crop toward the centre instead of adding bars.)
                 if (videoAspect > displayAspect)
                 {
-                    float s = displayAspect / videoAspect;
+                    float s = videoAspect / displayAspect;
                     scale = new Vector2(1f, s);
                     offset = new Vector2(0f, (1f - s) * 0.5f);
                 }
                 else
                 {
-                    float s = videoAspect / displayAspect;
+                    float s = displayAspect / videoAspect;
                     scale = new Vector2(s, 1f);
                     offset = new Vector2((1f - s) * 0.5f, 0f);
                 }

--- a/Basis/Packages/com.basis.mediaplayer/Shaders.meta
+++ b/Basis/Packages/com.basis.mediaplayer/Shaders.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4b7c2e9a5f1d3a6b8c0e2f4a6b8d0c1e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Basis/Packages/com.basis.mediaplayer/Shaders/BasisMediaPlayerVideo.shader
+++ b/Basis/Packages/com.basis.mediaplayer/Shaders/BasisMediaPlayerVideo.shader
@@ -1,0 +1,307 @@
+Shader "Basis/Media Player Video"
+{
+    Properties
+    {
+        [MainTexture] _BaseMap("Texture", 2D) = "white" {}
+        [MainColor] _BaseColor("Color", Color) = (1, 1, 1, 1)
+        _Cutoff("AlphaCutout", Range(0.0, 1.0)) = 0.5
+
+        // BlendMode
+        _Surface("__surface", Float) = 0.0
+        _Blend("__mode", Float) = 0.0
+        _Cull("__cull", Float) = 2.0
+        [ToggleUI] _AlphaClip("__clip", Float) = 0.0
+        [HideInInspector] _BlendOp("__blendop", Float) = 0.0
+        [HideInInspector] _SrcBlend("__src", Float) = 1.0
+        [HideInInspector] _DstBlend("__dst", Float) = 0.0
+        [HideInInspector] _SrcBlendAlpha("__srcA", Float) = 1.0
+        [HideInInspector] _DstBlendAlpha("__dstA", Float) = 0.0
+        [HideInInspector] _ZWrite("__zw", Float) = 1.0
+        [HideInInspector] _AlphaToMask("__alphaToMask", Float) = 0.0
+        [HideInInspector] _AddPrecomputedVelocity("_AddPrecomputedVelocity", Float) = 0.0
+        [HideInInspector] _XRMotionVectorsPass("_XRMotionVectorsPass", Float) = 1.0
+
+        // Editmode props
+        _QueueOffset("Queue offset", Float) = 0.0
+
+        // ObsoleteProperties
+        [HideInInspector] _MainTex("BaseMap", 2D) = "white" {}
+        [HideInInspector] _Color("Base Color", Color) = (0.5, 0.5, 0.5, 1)
+        [HideInInspector] _SampleGI("SampleGI", float) = 0.0 // needed from bakedlit
+    }
+
+    SubShader
+    {
+        Tags
+        {
+            "RenderType" = "Opaque"
+            "IgnoreProjector" = "True"
+            "UniversalMaterialType" = "Unlit"
+            "RenderPipeline" = "UniversalPipeline"
+        }
+        LOD 100
+
+        // -------------------------------------
+        // Render State Commands
+        Blend [_SrcBlend][_DstBlend], [_SrcBlendAlpha][_DstBlendAlpha]
+        ZWrite [_ZWrite]
+        Cull [_Cull]
+
+        Pass
+        {
+            Name "Unlit"
+
+            // -------------------------------------
+            // Render State Commands
+            AlphaToMask[_AlphaToMask]
+
+            HLSLPROGRAM
+            #pragma target 2.0
+
+            // -------------------------------------
+            // Shader Stages
+            #pragma vertex UnlitPassVertex
+            #pragma fragment UnlitPassFragment
+
+            // -------------------------------------
+            // Material Keywords
+            #pragma shader_feature_local_fragment _SURFACE_TYPE_TRANSPARENT
+            #pragma shader_feature_local_fragment _ALPHATEST_ON
+            #pragma shader_feature_local_fragment _ALPHAMODULATE_ON
+
+            // -------------------------------------
+            // Unity defined keywords
+            #pragma multi_compile_fragment _ _SCREEN_SPACE_OCCLUSION
+            #pragma multi_compile_fragment _ _DBUFFER_MRT1 _DBUFFER_MRT2 _DBUFFER_MRT3
+            #pragma multi_compile _ DEBUG_DISPLAY
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/RenderingLayers.hlsl"
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Fog.hlsl"
+
+            //--------------------------------------
+            // GPU Instancing
+            #pragma multi_compile_instancing
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+
+            // -------------------------------------
+            // Includes
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/UnlitInput.hlsl"
+            #include "Packages/com.basis.mediaplayer/Shaders/BasisMediaPlayerVideoForwardPass.hlsl"
+            ENDHLSL
+        }
+
+        // Fill GBuffer data to prevent "holes", just in case someone wants to reuse GBuffer for non-lighting effects.
+        // Deferred lighting is stenciled out.
+        Pass
+        {
+            Name "GBuffer"
+            Tags
+            {
+                "LightMode" = "UniversalGBuffer"
+            }
+
+            HLSLPROGRAM
+            #pragma target 4.5
+
+            // Deferred Rendering Path does not support the OpenGL-based graphics API:
+            // Desktop OpenGL, OpenGL ES 3.0, WebGL 2.0.
+            #pragma exclude_renderers gles3 glcore
+
+            // -------------------------------------
+            // Shader Stages
+            #pragma vertex UnlitPassVertex
+            #pragma fragment UnlitPassFragment
+
+            // -------------------------------------
+            // Material Keywords
+            #pragma shader_feature_local_fragment _ALPHATEST_ON
+            #pragma shader_feature_local_fragment _ALPHAMODULATE_ON
+
+            // -------------------------------------
+            // Universal Pipeline keywords
+            #pragma multi_compile_fragment _ _RENDER_PASS_ENABLED
+
+            // -------------------------------------
+            // Unity defined keywords
+            #pragma multi_compile_fragment _ _SCREEN_SPACE_OCCLUSION
+            #pragma multi_compile_fragment _ _DBUFFER_MRT1 _DBUFFER_MRT2 _DBUFFER_MRT3
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
+            #pragma multi_compile_fragment _ _GBUFFER_NORMALS_OCT
+            #pragma multi_compile_fragment _ SHADOWS_SHADOWMASK
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/RenderingLayers.hlsl"
+
+            //--------------------------------------
+            // GPU Instancing
+            #pragma multi_compile_instancing
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+
+            // -------------------------------------
+            // Includes
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/UnlitInput.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/UnlitGBufferPass.hlsl"
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/GBufferOutputFormat.hlsl"
+            ENDHLSL
+        }
+
+        Pass
+        {
+            Name "DepthOnly"
+            Tags
+            {
+                "LightMode" = "DepthOnly"
+            }
+
+            // -------------------------------------
+            // Render State Commands
+            ZWrite On
+            ColorMask R
+
+            HLSLPROGRAM
+            #pragma target 2.0
+
+            // -------------------------------------
+            // Shader Stages
+            #pragma vertex DepthOnlyVertex
+            #pragma fragment DepthOnlyFragment
+
+            // -------------------------------------
+            // Material Keywords
+            #pragma shader_feature_local _ALPHATEST_ON
+
+            // -------------------------------------
+            // Unity defined keywords
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
+
+            //--------------------------------------
+            // GPU Instancing
+            #pragma multi_compile_instancing
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+
+            // -------------------------------------
+            // Includes
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/UnlitInput.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/DepthOnlyPass.hlsl"
+            ENDHLSL
+        }
+
+        Pass
+        {
+            Name "DepthNormalsOnly"
+            Tags
+            {
+                "LightMode" = "DepthNormalsOnly"
+            }
+
+            // -------------------------------------
+            // Render State Commands
+            ZWrite On
+
+            HLSLPROGRAM
+            #pragma target 2.0
+
+            // -------------------------------------
+            // Shader Stages
+            #pragma vertex DepthNormalsVertex
+            #pragma fragment DepthNormalsFragment
+
+            // -------------------------------------
+            // Material Keywords
+            #pragma shader_feature_local _ALPHATEST_ON
+
+            // -------------------------------------
+            // Universal Pipeline keywords
+            #pragma multi_compile_fragment _ _GBUFFER_NORMALS_OCT // forward-only variant
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/RenderingLayers.hlsl"
+
+            //--------------------------------------
+            // GPU Instancing
+            #pragma multi_compile_instancing
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/DOTS.hlsl"
+
+            // -------------------------------------
+            // Includes
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/UnlitInput.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/UnlitDepthNormalsPass.hlsl"
+            ENDHLSL
+        }
+
+        // This pass it not used during regular rendering, only for lightmap baking.
+        Pass
+        {
+            Name "Meta"
+            Tags
+            {
+                "LightMode" = "Meta"
+            }
+
+            // -------------------------------------
+            // Render State Commands
+            Cull Off
+
+            HLSLPROGRAM
+            #pragma target 2.0
+
+            // -------------------------------------
+            // Shader Stages
+            #pragma vertex UniversalVertexMeta
+            #pragma fragment UniversalFragmentMetaUnlit
+
+            // -------------------------------------
+            // Unity defined keywords
+            #pragma shader_feature EDITOR_VISUALIZATION
+
+            // -------------------------------------
+            // Includes
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/UnlitInput.hlsl"
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/UnlitMetaPass.hlsl"
+            ENDHLSL
+        }
+
+        Pass
+        {
+            Name "MotionVectors"
+            Tags { "LightMode" = "MotionVectors" }
+            ColorMask RG
+
+            HLSLPROGRAM
+            #pragma shader_feature_local _ALPHATEST_ON
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
+            #pragma shader_feature_local_vertex _ADD_PRECOMPUTED_VELOCITY
+
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/UnlitInput.hlsl"
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ObjectMotionVectors.hlsl"
+            ENDHLSL
+        }
+
+        Pass
+        {
+            Name "XRMotionVectors"
+            Tags { "LightMode" = "XRMotionVectors" }
+            ColorMask RGBA
+
+            // Stencil write for obj motion pixels
+            Stencil
+            {
+                WriteMask 1
+                Ref 1
+                Comp Always
+                Pass Replace
+            }
+
+            HLSLPROGRAM
+            #pragma shader_feature_local _ALPHATEST_ON
+            #pragma multi_compile _ LOD_FADE_CROSSFADE
+            #pragma shader_feature_local_vertex _ADD_PRECOMPUTED_VELOCITY
+            #pragma multi_compile _ APPLICATION_SPACE_WARP_MOTION_TRANSPARENT
+            #define APPLICATION_SPACE_WARP_MOTION 1
+
+            #include "Packages/com.unity.render-pipelines.universal/Shaders/UnlitInput.hlsl"
+            #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ObjectMotionVectors.hlsl"
+            ENDHLSL
+        }
+    }
+
+    FallBack "Hidden/Universal Render Pipeline/FallbackError"
+    CustomEditor "UnityEditor.Rendering.Universal.ShaderGUI.UnlitShader"
+}

--- a/Basis/Packages/com.basis.mediaplayer/Shaders/BasisMediaPlayerVideo.shader.meta
+++ b/Basis/Packages/com.basis.mediaplayer/Shaders/BasisMediaPlayerVideo.shader.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6d9e4abc7b3f5c8dae2a4b6c8d0f2e3a
+ShaderImporter:
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Basis/Packages/com.basis.mediaplayer/Shaders/BasisMediaPlayerVideoForwardPass.hlsl
+++ b/Basis/Packages/com.basis.mediaplayer/Shaders/BasisMediaPlayerVideoForwardPass.hlsl
@@ -1,0 +1,197 @@
+// Basis media-player video screen forward pass.
+//
+// A verbatim copy of URP's UnlitForwardPass.hlsl (com.unity.render-pipelines.universal
+// /Shaders) so the screen matches URP/Unlit exactly on desktop and in VR. The ONLY
+// change is the letterbox branch in the fragment (marked "Basis letterbox"):
+// BasisVideoMaterialOutput fits a non-16:9 source by baking the fit into _BaseMap_ST
+// with scale > 1, which pushes uv outside [0,1] over the bar region; URP would
+// clamp-smear the edge texel there, so we paint it black to letterbox on the fixed
+// screen instead.
+#ifndef BASIS_MEDIAPLAYER_VIDEO_FORWARD_PASS_INCLUDED
+#define BASIS_MEDIAPLAYER_VIDEO_FORWARD_PASS_INCLUDED
+
+#include "Packages/com.unity.render-pipelines.universal/Shaders/UnlitInput.hlsl"
+#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Unlit.hlsl"
+#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Lighting.hlsl"
+#if defined(LOD_FADE_CROSSFADE)
+    #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/LODCrossFade.hlsl"
+#endif
+
+struct Attributes
+{
+    float4 positionOS : POSITION;
+    float2 uv : TEXCOORD0;
+
+    #if defined(DEBUG_DISPLAY)
+    float3 normalOS : NORMAL;
+    float4 tangentOS : TANGENT;
+    #endif
+
+    UNITY_VERTEX_INPUT_INSTANCE_ID
+};
+
+struct Varyings
+{
+    float2 uv : TEXCOORD0;
+    float fogCoord : TEXCOORD1;
+    float4 positionCS : SV_POSITION;
+
+    #if defined(DEBUG_DISPLAY)
+    float3 positionWS : TEXCOORD2;
+    float3 normalWS : TEXCOORD3;
+    float3 viewDirWS : TEXCOORD4;
+    #endif
+
+    UNITY_VERTEX_INPUT_INSTANCE_ID
+    UNITY_VERTEX_OUTPUT_STEREO
+};
+
+void InitializeInputData(Varyings input, out InputData inputData)
+{
+    inputData = (InputData)0;
+
+    #if defined(DEBUG_DISPLAY)
+    inputData.positionWS = input.positionWS;
+    inputData.positionCS = input.positionCS;
+    inputData.normalWS = input.normalWS;
+    inputData.viewDirectionWS = input.viewDirWS;
+    #else
+    inputData.positionWS = float3(0, 0, 0);
+    inputData.normalWS = half3(0, 0, 1);
+    inputData.viewDirectionWS = half3(0, 0, 1);
+    #endif
+    inputData.shadowCoord = 0;
+    inputData.fogCoord = 0;
+    inputData.vertexLighting = half3(0, 0, 0);
+    inputData.bakedGI = half3(0, 0, 0);
+    inputData.normalizedScreenSpaceUV = 0;
+    inputData.shadowMask = half4(1, 1, 1, 1);
+}
+
+Varyings UnlitPassVertex(Attributes input)
+{
+    Varyings output = (Varyings)0;
+
+    UNITY_SETUP_INSTANCE_ID(input);
+    UNITY_TRANSFER_INSTANCE_ID(input, output);
+    UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
+
+    VertexPositionInputs vertexInput = GetVertexPositionInputs(input.positionOS.xyz);
+
+    output.positionCS = vertexInput.positionCS;
+    output.uv = TRANSFORM_TEX(input.uv, _BaseMap);
+    #if defined(_FOG_FRAGMENT)
+    output.fogCoord = vertexInput.positionVS.z;
+    #else
+    output.fogCoord = ComputeFogFactor(vertexInput.positionCS.z);
+    #endif
+
+    #if defined(DEBUG_DISPLAY)
+    // normalWS and tangentWS already normalize.
+    // this is required to avoid skewing the direction during interpolation
+    // also required for per-vertex lighting and SH evaluation
+    VertexNormalInputs normalInput = GetVertexNormalInputs(input.normalOS, input.tangentOS);
+    half3 viewDirWS = GetWorldSpaceViewDir(vertexInput.positionWS);
+
+    // already normalized from normal transform to WS.
+    output.positionWS = vertexInput.positionWS;
+    output.normalWS = normalInput.normalWS;
+    output.viewDirWS = viewDirWS;
+    #endif
+
+    return output;
+}
+
+void UnlitPassFragment(
+    Varyings input
+    , out half4 outColor : SV_Target0
+#ifdef _WRITE_RENDERING_LAYERS
+    , out uint outRenderingLayers : SV_Target1
+#endif
+)
+{
+    UNITY_SETUP_INSTANCE_ID(input);
+    UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
+
+    half2 uv = input.uv;
+
+    // --- Basis letterbox (the only change from URP UnlitForwardPass) ---
+    // The aspect fit samples outside the source over the bar region; render those
+    // pixels black instead of the clamped edge texel. UNITY_SETUP_INSTANCE_ID above
+    // has already run, so EncodeMeshRenderingLayer() is valid here.
+    if (any(uv < 0.0h) || any(uv > 1.0h))
+    {
+        outColor = half4(0.0h, 0.0h, 0.0h, 1.0h);
+#ifdef _WRITE_RENDERING_LAYERS
+        outRenderingLayers = EncodeMeshRenderingLayer();
+#endif
+        return;
+    }
+    // --- end Basis letterbox ---
+
+    half4 texColor = SAMPLE_TEXTURE2D(_BaseMap, sampler_BaseMap, uv);
+    half3 color = texColor.rgb * _BaseColor.rgb;
+    half alpha = texColor.a * _BaseColor.a;
+
+    alpha = AlphaDiscard(alpha, _Cutoff);
+    color = AlphaModulate(color, alpha);
+
+#ifdef LOD_FADE_CROSSFADE
+    LODFadeCrossFade(input.positionCS);
+#endif
+
+    InputData inputData;
+    InitializeInputData(input, inputData);
+    SETUP_DEBUG_TEXTURE_DATA(inputData, UNDO_TRANSFORM_TEX(input.uv, _BaseMap));
+
+#ifdef _DBUFFER
+    ApplyDecalToBaseColor(input.positionCS, color);
+#endif
+
+    half4 finalColor = UniversalFragmentUnlit(inputData, color, alpha);
+
+#if defined(_SCREEN_SPACE_OCCLUSION) && !defined(_SURFACE_TYPE_TRANSPARENT)
+    float2 normalizedScreenSpaceUV = GetNormalizedScreenSpaceUV(input.positionCS);
+    AmbientOcclusionFactor aoFactor = GetScreenSpaceAmbientOcclusion(normalizedScreenSpaceUV);
+    finalColor.rgb *= aoFactor.directAmbientOcclusion;
+#endif
+
+    half fogFactor = 0;
+#if defined(_FOG_FRAGMENT)
+    bool anyFogEnabled = false;
+    
+    #if defined(FOG_LINEAR_KEYWORD_DECLARED)
+    if (FOG_LINEAR)
+        anyFogEnabled = true;
+    #endif
+    
+    #if defined(FOG_EXP_KEYWORD_DECLARED)
+    if (FOG_EXP)
+        anyFogEnabled = true;
+    #endif
+    
+    #if defined(FOG_EXP2_KEYWORD_DECLARED)
+    if (FOG_EXP2)
+        anyFogEnabled = true;
+    #endif
+    
+    if (anyFogEnabled)
+    {
+        float viewZ = -input.fogCoord;
+        float nearToFarZ = max(viewZ - _ProjectionParams.y, 0);
+        fogFactor = ComputeFogFactorZ0ToFar(nearToFarZ);
+    }
+#else // #if defined(_FOG_FRAGMENT)
+    fogFactor = input.fogCoord;
+#endif // #if defined(_FOG_FRAGMENT)
+    finalColor.rgb = MixFog(finalColor.rgb, fogFactor);
+    finalColor.a = OutputAlpha(finalColor.a, IsSurfaceTypeTransparent());
+
+    outColor = finalColor;
+
+#ifdef _WRITE_RENDERING_LAYERS
+    outRenderingLayers = EncodeMeshRenderingLayer();
+#endif
+}
+
+#endif

--- a/Basis/Packages/com.basis.mediaplayer/Shaders/BasisMediaPlayerVideoForwardPass.hlsl.meta
+++ b/Basis/Packages/com.basis.mediaplayer/Shaders/BasisMediaPlayerVideoForwardPass.hlsl.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5c8d3fab6a2e4b7c9d1f3a5b7c9e1d2f
+ShaderIncludeImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Fixes #949.

## Summary
Non-16:9 video was stretched to fill the fixed 16:9 media-player screen. `AspectMode` defaulted to `Original`, and even `FitInside` applied the fit as a texture scale/offset — which can only crop within the source; a clamp-sampled texture can't draw black bars. So a 2.40:1 clip looked squashed with no way to letterbox.

## What changed
- **New `Basis/Media Player Video` shader** — a *verbatim* copy of URP's `Unlit` (all seven passes, VR single-pass-instanced stereo, fog, SRP batcher, motion vectors — unchanged) with **one** added branch in the forward pass: where the sampled UV falls outside `[0,1]`, output black. That's the only difference from stock URP Unlit, so there are no surprises on desktop or in VR.
- **`GetAspectUv` `FitInside` inverted** — the bar axis now scales **> 1** (leaving room outside `[0,1]` for the bars) instead of < 1 (which cropped toward the centre).
- **Default `AspectMode` → `FitInside`** on the components, and the two shipped prefabs set to match, so content letterboxes/pillarboxes to its true proportions out of the box. **16:9 is unchanged** (scale 1, no bars, identical to before).
- Material repointed to the new shader.

## Why a fixed screen (not resizing the quad)
The screen geometry stays fixed — the alternative (driving the quad's scale from the source aspect) would silently change a screen's in-world footprint, which is bad for world-creators who placed it at a known size. Bars on a fixed screen match what people expect from a video player.

## Verified
- **Windows (D3D, editor):** 2.40:1 letterboxes with correct bars; 16:9 fills the screen with no bars (no regression).
- **Quest Pro (Vulkan):** identical letterbox — same clean bars, undistorted content.

## Projection modes (follow-up)
The `BASIS_PROJ_*` keywords (equirect / VR180 / fisheye) are set in C# today but consumed by no shader. This custom shader is the natural place to implement them; left inert here to keep this PR to the aspect fix.

## Required checks
<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [x] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — `BasisEventDriver` runs the single per-frame tick that drives the whole framework (network apply, local player sim, blendshapes, JigglePhysics, nameplates, and more) as one sequential chain. An unhandled exception anywhere in that chain aborts the rest of the tick, so every step after the throwing one is silently skipped for that frame. New work added to the driver must either be guaranteed not to throw, or be wrapped in a `try`/`catch` that contains the failure and surfaces it through `BasisDebug` — logged once / rate-limited, never every frame (see the existing `HVRBasisBuiltInAddresses.Simulate()` guard for the pattern). Expect this to be scrutinized closely in review.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
- [x] Windows
- [ ] Linux
- [x] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [x] Tested in VR (Quest Pro)
- [x] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [ ] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [x] N/A — change does not touch any of the above

## Notes
- **Scope is a shader + a UV-math tweak + serialized defaults.** No managed hot-path, transform, camera, Addressables, `GetComponent`, allocation, or logging surface — the aspect UV is recomputed only on `OnOutputTextureChanged` (source/size change), not per frame; `GetAspectUv` returns via value-type `Vector2` (no heap alloc). Hence the required boxes are ticked as N/A where they don't apply.
- **URP-Unlit fidelity is deliberate.** The forward pass is copied byte-for-byte from `com.unity.render-pipelines.universal/Shaders/UnlitForwardPass.hlsl` with only the letterbox branch added (and the include-guard renamed + the one relative include made absolute), so behaviour on both the D3D external-texture and Vulkan RenderTexture paths matches stock Unlit everywhere except the bars.
- **Verified on Quest Pro (Vulkan) and the Windows editor (D3D).** 2.40:1 letterboxes correctly on both; 16:9 is unchanged.
- Two unrelated things surfaced while testing this, both pre-existing and out of scope here (tracked separately): a thin bottom line on the screen that reproduces on stock URP/Unlit too, and 5.1 AAC in a progressive MP4 decoding to silence on Android (plays on Windows) — neither touches the video shader.
