### PR TITLE
docs(mediaplayer): refresh README for RTSP UDP, seek, progressive MP4 and drift sync

### DIFF
--- a/Basis/Packages/com.basis.mediaplayer/README.md
+++ b/Basis/Packages/com.basis.mediaplayer/README.md
@@ -14,10 +14,11 @@ VP9, no `UnityEngine.Video.MediaPlayer`.
 
 | Scheme | Use | Example |
 |---|---|---|
-| `rtspt://` | PC/VR low latency (RTP interleaved over TCP) | `rtspt://stream.vrcdn.live/live/vrcdn` |
+| `rtsp://`  | PC/VR low latency — UDP first, TCP-interleaved fallback | `rtsp://stream.vrcdn.live/live/vrcdn` |
+| `rtspt://` | PC/VR low latency, TCP-interleaved pinned (legacy; prefer `rtsp://` unless a host needs forced TCP) | `rtspt://stream.vrcdn.live/live/vrcdn` |
 | `rtmp://`  | RTMP pull | `rtmp://stream.vrcdn.live/live/vrcdn` |
 | `rist://`  | RIST live ingest (UDP, loss recovery + optional AES) | `rist://stream.example:5000?secret=KEY&aes-type=128` |
-| `https://…​.mp4` | fragmented MP4 over HTTPS | `https://stream.vrcdn.live/live/vrcdn.live.mp4` |
+| `https://…​.mp4` | MP4 over HTTPS — fragmented (live) or progressive VOD (faststart or trailing moov, seekable) | `https://stream.vrcdn.live/live/vrcdn.live.mp4` |
 | `https://…​.ts`  | MPEG-TS over HTTPS (Quest) | `https://stream.vrcdn.live/live/vrcdn.live.ts` |
 | `https://…​.m3u8` | HLS / Low-Latency HLS | `https://stream.example/live/index.m3u8` |
 | `https://….wav` | WAV audio (integer PCM, mono up to 7.1) | `https://stream.example/audio/track.wav` |
@@ -53,6 +54,15 @@ RIST is **opt-in at build time** — the default plugin links only OS frameworks
 Build with `-DBASIS_WITH_RIST=ON` against prebuilt librist (see *Building the
 native plugin* below).
 
+### RTSP transport
+
+`rtsp://` negotiates its transport: it attempts **UDP** (RTP/AVP) first and falls back to
+**RTP interleaved over the TCP** control channel on refusal, a socket error, or a no-data
+timer — and remembers a host that fails UDP so later loads go straight to TCP. `rtspt://`
+skips the probe and **pins TCP-interleaved**, for hosts or networks where UDP never works.
+The settled transport is logged once per load and exposed on
+`BasisMediaPlayer.CurrentTransport`.
+
 ## Live vs on-demand
 
 Every source is either **live** (presented at the live edge, lowest latency) or
@@ -81,6 +91,20 @@ The live jitter buffer is tunable via `BasisMediaPlayer.BufferMilliseconds` /
 `BufferMode` (Fixed, or auto-tuning Dynamic — lower = less latency, higher = smoother).
 On-demand currently presents on a fixed internal buffer; `BufferMilliseconds` applies
 to the live path only.
+
+## Seeking
+
+Sources with a known duration (`BasisMediaPlayer.Duration > 0` — a progressive MP4, a WAV)
+are seekable. `Seek(TimeSpan position)` requests an **absolute** seek; the demuxer
+repositions at the next sample boundary and resumes from the preceding keyframe, so playback
+lands **at or shortly before** the target — watch `Position`, and `OnSeekCompleted` fires
+once it settles. `TrySeekBack(TimeSpan)` is a relative rewind. Seeking a live or unindexed
+source throws `NotSupportedException`.
+
+```csharp
+if (player.Duration > TimeSpan.Zero)
+    player.Seek(TimeSpan.FromSeconds(30));
+```
 
 ## Split-stream (separate video + audio)
 
@@ -229,7 +253,7 @@ internal static class MyResolverInstaller
 ```csharp
 var player = gameObject.AddComponent<BasisMediaPlayer>();
 gameObject.AddComponent<BasisVideoMaterialOutput>().TargetRenderer = quadRenderer;
-player.LoadUrl("rtspt://stream.vrcdn.live/live/vrcdn"); // auto-plays
+player.LoadUrl("rtsp://stream.vrcdn.live/live/vrcdn"); // auto-plays
 ```
 
 Or drop the `Prefabs/MediaPlayerStreaming` prefab in a scene and set the URL on
@@ -269,14 +293,12 @@ shared load tight, the owner broadcasts a page URL up front so peers resolve it 
 rather than only after the owner is playing, and re-loading a URL (even the same one)
 restarts every client together.
 
-> **On-demand position sync is start-together, not catch-up.** Clients stay aligned by
-> beginning the same source at the same time; there is no continuous re-syncing of an
-> on-demand playhead. A client that joins late, or whose load lands later, starts from the
-> beginning and will not match an already-running playhead until the next shared (re)load.
-> This is a current limitation of the native decode backend, which exposes no absolute or
-> forward seek (only relative rewind), so a behind client cannot be advanced to catch up.
-> Live streams are unaffected — they converge to the live edge. Direct, seekable sources do
-> apply position/pause on load.
+> **On-demand clients drift-correct by seeking.** The owner broadcasts its playhead, and a
+> client whose position drifts more than `DriftSeekThresholdSeconds` (default 2 s) seeks to
+> catch up; set it to 0 to disable. Catch-up needs a **seekable** source — a client on a live
+> or unindexed stream can't be advanced, so those converge to the live edge instead. A late
+> joiner starts the shared source and is pulled into alignment on the next position broadcast;
+> an owner seek propagates to the room.
 
 ## Building the native plugin
 


### PR DESCRIPTION
## Summary
The media-player README had drifted from the code — these features shipped in earlier PRs without a README update. Docs only, no code change.

- **RTSP transport (#943).** `rtsp://` negotiates UDP first with a TCP-interleaved fallback; `rtspt://` pins TCP. The table listed only `rtspt://`. Added the `rtsp://` row, reframed `rtspt://` as legacy pinned-TCP, and documented the negotiation + `BasisMediaPlayer.CurrentTransport`.
- **Progressive MP4 (#946, #950).** Faststart and trailing-moov VOD with seek are supported; the `.mp4` row said "fragmented MP4" only.
- **Seeking.** The absolute-seek API (`Seek`/`Position`/`Duration`/`TrySeekBack`/`OnSeekCompleted`) was undocumented; added a section.
- **Networked drift sync.** On-demand clients drift-correct by seeking (`DriftSeekThresholdSeconds`). The old note claimed start-together-only sync "because the backend exposes no absolute or forward seek" — both untrue now; rewritten.

## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [x] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — `BasisEventDriver` runs the single per-frame tick that drives the whole framework (network apply, local player sim, blendshapes, JigglePhysics, nameplates, and more) as one sequential chain. An unhandled exception anywhere in that chain aborts the rest of the tick, so every step after the throwing one is silently skipped for that frame. New work added to the driver must either be guaranteed not to throw, or be wrapped in a `try`/`catch` that contains the failure and surfaces it through `BasisDebug` — logged once / rate-limited, never every frame (see the existing `HVRBasisBuiltInAddresses.Simulate()` guard for the pattern). Expect this to be scrutinized closely in review.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [ ] Windows
- [ ] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [ ] Tested in VR (note headset under **Notes**)
- [ ] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [x] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [x] N/A — change does not touch any of the above

## Notes
**Documentation only — no code, no runtime surface.** The required-checks list targets Unity C# runtime patterns; none apply to a Markdown change, so they're ticked N/A. Nothing to build or run; the "Tested" box reflects that the change is docs-only. Verified the rest of the README against the code (backends, RIST build, WAV/HEVC/RTMP caveats, split-stream, resolver, playlists, metadata) — still accurate.
