### PR TITLE
test(mediaplayer): demux output conformance gate (ffmpeg oracle, no committed media)

### DIFF
--- a/.github/workflows/media-native.yml
+++ b/.github/workflows/media-native.yml
@@ -23,11 +23,13 @@ on:
     paths:
       - "Basis/Packages/com.basis.mediaplayer/Native~/**"
       - "tools/media-fuzz/**"
+      - "tools/media-conformance/**"
       - ".github/workflows/media-native.yml"
   pull_request:
     paths:
       - "Basis/Packages/com.basis.mediaplayer/Native~/**"
       - "tools/media-fuzz/**"
+      - "tools/media-conformance/**"
       - ".github/workflows/media-native.yml"
 
 defaults:
@@ -88,3 +90,22 @@ jobs:
         run: ./tools/media-fuzz/build.sh
       - name: Replay pinned crash repros (regression gate)
         run: ./tools/media-fuzz/ci-replay.sh
+
+  # Prove the demuxers produce the CORRECT output on valid input (the fuzz gate
+  # proves they don't crash on hostile input). Generates synthetic fixtures with
+  # ffmpeg -- a static Basis-logo track plus a tone, nothing committed -- then
+  # diffs our demuxer's access units against ffprobe's packets, payload MD5 and
+  # all. ffmpeg is used only as an external CLI tool here (no libav* linked, no
+  # media in the repo). See tools/media-conformance/README.md.
+  conformance-demux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install ffmpeg + a C compiler
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg gcc
+      - name: Build the demux dumper
+        run: ./tools/media-conformance/build.sh
+      - name: Generate synthetic fixtures
+        run: ./tools/media-conformance/gen_fixtures.sh "$RUNNER_TEMP/fixtures"
+      - name: Diff demuxer output against ffprobe (regression gate)
+        run: python3 ./tools/media-conformance/demux_gate.py "$RUNNER_TEMP/fixtures"

--- a/tools/media-conformance/.gitignore
+++ b/tools/media-conformance/.gitignore
@@ -1,0 +1,10 @@
+# compiled dumper
+build/
+# generated fixtures are ephemeral (gen_fixtures.sh); never committed
+fixtures/
+*.mp4
+*.m4a
+*.ts
+*.m2ts
+*.webm
+*.wav

--- a/tools/media-conformance/README.md
+++ b/tools/media-conformance/README.md
@@ -1,0 +1,61 @@
+# media-conformance — demux output regression gate
+
+The fuzz harness (`tools/media-fuzz`) proves the parsers don't **crash** on hostile input.
+This proves they produce the **correct output** on valid input: it diffs our demuxer's
+access-unit stream against `ffprobe`'s packet stream, down to the MD5 of the payload where the
+container stores it as-is. A parser change that alters what the demuxer emits fails the gate.
+
+Only the demux lane lives here. The decode and A/V lanes need a GPU and a Unity editor, so they
+can't gate CI and aren't part of this.
+
+## No committed media, no ffmpeg dependency in the shipped code
+
+Fixtures are generated on the fly from a static Basis-logo video track plus a tone (multichannel
+where the fixture needs it) — content is irrelevant to demuxing, so a still image and a tone are
+ideal: tiny, deterministic, nothing to host. ffmpeg is used only as an external CLI tool (the
+reference oracle and the fixture generator); nothing links `libav*` and nothing ffmpeg-derived is
+committed. CI installs ffmpeg on the runner, uses it, and the ephemeral runner discards it.
+
+## Run it
+
+```
+./build.sh                          # compile basis_demux_dump (the real protocol/*.c + a sink)
+./gen_fixtures.sh /tmp/fx           # generate the fixture matrix with ffmpeg
+python demux_gate.py /tmp/fx        # diff each fixture against ffprobe; exit 1 on any divergence
+```
+
+Needs `ffmpeg`/`ffprobe` on PATH and a C compiler (`cc`/`gcc`/`clang`, or the LLVM install on
+Windows via Git Bash). `gen_fixtures.sh` skips any codec whose encoder the local ffmpeg lacks, so
+the gate covers whatever the runner supports.
+
+## What it checks, per fixture
+
+- **announce** — codec and (video) dimensions match ffprobe.
+- **count** — one access unit per demuxed packet.
+- **pts** — the timestamp sequence matches within 1 µs (integer-µs vs decimal-seconds rounding).
+- **md5** — the payload bytes match. Three framings are reconciled so the hashes line up:
+  - VP9/AV1/AAC-in-MP4 are stored as-is and compare directly.
+  - H.264/H.265 leave the demuxer as Annex B, so ffprobe is reframed with `*_mp4toannexb`, and
+    keyframes are exempt (the filter inlines SPS/PPS that the demuxer passes as extradata).
+  - AAC-in-TS is ADTS-framed; ffprobe is reframed with `aac_adtstoasc` to strip the header the
+    sink strips.
+  - LPCM has no canonical packetisation (the demuxer and ffmpeg chunk it differently), so it is
+    checked on announce only.
+
+## The matrix
+
+`gen_fixtures.sh` covers: MP4 H.264+AAC in faststart / trailing-moov / fragmented layouts; MP4
+HEVC (hvcC); MP4 + WebM VP9; MP4 + WebM AV1; MPEG-TS H.264+AAC (PAT/PMT/PES + ADTS); AAC-in-M4A;
+WAV 16-bit stereo and 5.1; Blu-ray LPCM 5.1 over M2TS. That exercises the MP4 box + sample-table
+parser, the TS section/PES parser, the WebM EBML parser, the WAV and M2TS LPCM paths, and the
+avcC/hvcC/esds/ADTS bitstream handling.
+
+## CI
+
+The `conformance-demux` job in `.github/workflows/media-native.yml` runs the three steps above on
+every change under `Native~/` or this directory. It's deterministic (the generate-and-compare is
+self-consistent: our dump is always checked against ffprobe's view of the *same* generated file,
+so ffmpeg version differences across runners don't matter).
+
+To add a format: extend `gen_fixtures.sh` with the ffmpeg recipe, and if it needs a new framing
+reconciliation, add it to `demux_gate.py`.

--- a/tools/media-conformance/build.sh
+++ b/tools/media-conformance/build.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Build basis_demux_dump: the real protocol/*.c demuxers compiled against an
+# observing sink that prints every access unit as JSON. Plain C, no Unity, no
+# Media Foundation -- builds on Linux/CI (cc/clang/gcc) and Windows (Git Bash +
+# the LLVM install, or set CC=cl in a VS dev shell).
+#
+#   ./build.sh
+#
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+native="$here/../../Basis/Packages/com.basis.mediaplayer/Native~"
+out="$here/build"
+mkdir -p "$out"
+
+CC="${CC:-cc}"
+if ! command -v "$CC" >/dev/null 2>&1; then
+    if command -v clang >/dev/null 2>&1; then CC="clang"
+    elif command -v gcc >/dev/null 2>&1; then CC="gcc"
+    else CC="/c/Program Files/LLVM/bin/clang.exe"; fi
+fi
+
+srcs=(
+    "$here/native/basis_demux_dump.c"
+    "$native/protocol/basis_webm.c"
+    "$native/protocol/basis_mp4.c"
+    "$native/protocol/basis_ts.c"
+    "$native/protocol/basis_wav.c"
+    "$native/protocol/basis_bitstream.c"
+    "$native/protocol/basis_caption.c"
+)
+
+echo "building basis_demux_dump with $CC ..."
+"$CC" -O2 -I "$native" "${srcs[@]}" -o "$out/basis_demux_dump"
+echo "  -> $out/basis_demux_dump"

--- a/tools/media-conformance/demux_gate.py
+++ b/tools/media-conformance/demux_gate.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Demux conformance gate: diff basis_demux_dump against ffprobe, per fixture.
+
+The protocol layer hands every access unit to a sink as (pts, dts, size, key,
+payload); ffprobe reports the same per packet. When the container stores the
+payload as-is the two compare down to the MD5 of the bytes, which makes this an
+exact-match gate rather than a threshold. A parser change that alters what the
+demuxer emits fails the gate.
+
+Two framing traps this handles:
+  * H.264/H.265 leave the demuxer as start-code Annex B while ffprobe hashes the
+    length-prefixed bytes MP4 stores, so those are compared through the matching
+    bitstream filter, and keyframes are exempt (the filter inlines SPS/PPS that
+    the demuxer passes as extradata).
+  * LPCM has no inherent packetisation, so its per-packet MD5 is not comparable;
+    it is checked on announce/count/pts, not payload hash.
+
+ffmpeg and ffprobe must be on PATH. Usage:
+    demux_gate.py <fixtures_dir> [--dump path/to/basis_demux_dump]
+Exit 0 if every fixture's checks pass, 1 otherwise.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+PTS_TOLERANCE_US = 1
+
+# dumper codec name -> the ffprobe codec_name(s) for the same thing
+CODEC_ALIASES = {
+    "h264": {"h264"},
+    "h265": {"hevc", "h265"},
+    "vp9": {"vp9"},
+    "av1": {"av1"},
+    "aac": {"aac"},
+    "lpcm": {"pcm_bluray", "pcm_s16le", "pcm_s24le", "pcm_s16be", "pcm_s24be"},
+}
+# ffprobe bitstream filter that reframes a stream into the sink's delivered form
+PACKET_FILTERS = {"h264": "h264_mp4toannexb", "h265": "hevc_mp4toannexb", "hevc": "hevc_mp4toannexb"}
+
+
+def run(cmd: list[str]) -> str:
+    p = subprocess.run(cmd, capture_output=True, text=True)
+    if p.returncode != 0:
+        tail = "\n".join((p.stderr or "").strip().splitlines()[-8:])
+        raise RuntimeError(f"{cmd[0]} exit {p.returncode}: {tail}")
+    return p.stdout
+
+
+def run_bin(cmd: list[str]) -> bytes:
+    p = subprocess.run(cmd, capture_output=True)
+    if p.returncode != 0:
+        raise RuntimeError(f"{cmd[0]} exit {p.returncode}: "
+                           f"{p.stderr.decode(errors='replace')[-400:]}")
+    return p.stdout
+
+
+def us(value) -> int | None:
+    if value in (None, "N/A"):
+        return None
+    try:
+        return round(float(value) * 1e6)
+    except (TypeError, ValueError):
+        return None
+
+
+def probe_streams(media: Path) -> list[dict]:
+    out = run(["ffprobe", "-v", "error", "-show_streams", "-of", "json", str(media)])
+    return json.loads(out or "{}").get("streams", [])
+
+
+def probe_packets(media: Path, stream: str) -> list[dict]:
+    out = run(["ffprobe", "-v", "error", "-select_streams", stream, "-show_packets",
+               "-show_data_hash", "md5", "-of", "json", str(media)])
+    pkts = []
+    for pkt in json.loads(out or "{}").get("packets", []):
+        digest = (pkt.get("data_hash") or "")
+        if digest.upper().startswith("MD5:"):
+            digest = digest[4:]
+        pkts.append({"pts_us": us(pkt.get("pts_time")),
+                     "size": int(pkt.get("size", 0)),
+                     "key": "K" in (pkt.get("flags") or ""),
+                     "md5": (digest.strip().lower() or None)})
+    return pkts
+
+
+def filtered_md5s(media: Path, bsf: str, stream: str) -> list[str]:
+    """Per-packet MD5 after reframing a stream to the sink's form (framemd5).
+
+    stream is an ffmpeg selector ('v:0' / 'a:0'); the bitstream filter kind
+    follows from it (v -> video, a -> audio).
+    """
+    kind = stream.split(":", 1)[0]
+    text = run_bin(["ffmpeg", "-v", "error", "-i", str(media), "-map", f"0:{stream}",
+                    "-c", "copy", f"-bsf:{kind}", bsf, "-f", "framemd5", "-"]).decode()
+    out = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = [p.strip() for p in line.split(",")]
+        if len(parts) >= 6:
+            out.append(parts[5].lower())
+    return out
+
+
+def dump(dumper: Path, media: Path) -> dict:
+    out = run_bin([str(dumper), str(media)])
+    return json.loads(out)
+
+
+class Checks:
+    def __init__(self):
+        self.rows: list[tuple[str, bool | None, str]] = []
+
+    def ok(self, name, cond, detail=""):
+        self.rows.append((name, bool(cond), detail))
+
+    def skip(self, name, detail=""):
+        self.rows.append((name, None, detail))
+
+    def failed(self):
+        return [r for r in self.rows if r[1] is False]
+
+
+def codec_matches(ours: str, theirs: str) -> bool:
+    return theirs in CODEC_ALIASES.get(ours, {ours})
+
+
+def check_track(c: Checks, d: dict, media: Path, kind: str) -> None:
+    """kind is 'video' or 'audio'."""
+    ann = d.get(kind)
+    stream = "v:0" if kind == "video" else "a:0"
+    ref_streams = [s for s in probe_streams(media)
+                   if s.get("codec_type") == kind and not s.get("disposition", {}).get("attached_pic")]
+    ref = ref_streams[0] if ref_streams else None
+
+    if ref is None:
+        # ffmpeg sees no such track: the demuxer must not have announced one.
+        if ann is not None:
+            c.ok(f"{kind}.absent", False, "demuxer announced a track ffmpeg does not see")
+        return
+    if ann is None:
+        c.ok(f"{kind}.announced", False, f"ffmpeg sees {kind}, demuxer announced none")
+        return
+
+    c.ok(f"{kind}.codec", codec_matches(ann["codec"], ref.get("codec_name", "?")),
+         f"ours={ann['codec']} ffmpeg={ref.get('codec_name')}")
+    if kind == "video":
+        c.ok("video.dimensions",
+             ann.get("width") == ref.get("width") and ann.get("height") == ref.get("height"),
+             f"ours={ann.get('width')}x{ann.get('height')} "
+             f"ffmpeg={ref.get('width')}x{ref.get('height')}")
+
+    codec = ann["codec"]
+    container_ts = d.get("demuxer") in {"ts"}
+
+    # LPCM has no canonical packetisation (the demuxer and ffmpeg chunk it
+    # differently), so count/pts/md5 are all meaningless. Announce + codec is
+    # what the demux layer actually owns for it.
+    if codec == "lpcm":
+        c.skip(f"{kind}.packets", "LPCM packetisation is arbitrary; not comparable")
+        return
+
+    pkts = probe_packets(media, stream)
+    aus = [a for a in d.get("access_units", []) if a["track"] == kind]
+
+    c.ok(f"{kind}.count", len(aus) == len(pkts), f"ours={len(aus)} ffmpeg={len(pkts)}")
+
+    # PTS sequence within tolerance (sorted, over the min common length).
+    n = min(len(aus), len(pkts))
+    our_pts = sorted(a["pts_us"] for a in aus[:n])
+    ref_pts = sorted(p["pts_us"] for p in pkts[:n] if p["pts_us"] is not None)
+    if len(ref_pts) == n and n:
+        worst = max((abs(a - b) for a, b in zip(our_pts, ref_pts)), default=0)
+        c.ok(f"{kind}.pts", worst <= PTS_TOLERANCE_US, f"worst delta {worst}us over {n}")
+    else:
+        c.skip(f"{kind}.pts", "reference has partial/absent timestamps")
+
+    # Payload MD5.
+    if codec == "aac" and container_ts:
+        # AAC in TS is ADTS-framed; the sink strips the 7-byte header, so strip
+        # it on the reference side too before hashing.
+        try:
+            their = filtered_md5s(media, "aac_adtstoasc", stream)
+        except RuntimeError as ex:
+            c.skip(f"{kind}.md5", f"adts reframe failed: {ex}")
+            return
+        m = min(len(aus), len(their))
+        c.ok(f"{kind}.md5", m > 0 and [a["md5"] for a in aus[:m]] == their[:m],
+             f"{sum(1 for a, t in zip(aus, their) if a['md5'] != t)} of {m} differ")
+    elif ann.get("payload_is_container_form"):
+        our = [a["md5"] for a in aus]
+        their = [p["md5"] for p in pkts]
+        m = min(len(our), len(their))
+        c.ok(f"{kind}.md5", m > 0 and our[:m] == their[:m],
+             f"{sum(1 for x, y in zip(our, their) if x != y)} of {m} differ")
+    elif codec in PACKET_FILTERS:
+        # H.26x: reframe ffprobe to Annex B; keyframes exempt (inline SPS/PPS).
+        try:
+            their = filtered_md5s(media, PACKET_FILTERS[codec], stream)
+        except RuntimeError as ex:
+            c.skip(f"{kind}.md5", f"bsf reframe failed: {ex}")
+            return
+        m = min(len(aus), len(their))
+        mism = [i for i in range(m) if not aus[i]["key"] and aus[i]["md5"] != their[i]]
+        c.ok(f"{kind}.md5", not mism, f"{len(mism)} non-key AUs differ of {m}")
+    else:
+        c.skip(f"{kind}.md5", f"no comparison rule for {codec}")
+
+
+def gate(fixtures: Path, dumper: Path) -> int:
+    media = sorted(p for p in fixtures.iterdir()
+                   if p.suffix.lower() in {".mp4", ".m4a", ".ts", ".m2ts", ".webm", ".wav"})
+    if not media:
+        print(f"no fixtures in {fixtures}")
+        return 1
+
+    any_fail = False
+    for m in media:
+        c = Checks()
+        try:
+            d = dump(dumper, m)
+        except Exception as ex:
+            print(f"[FAIL] {m.name}: dumper: {ex}")
+            any_fail = True
+            continue
+        c.ok("demuxer.ran", d.get("run_rc") == 0 and not d.get("error"),
+             d.get("error") or "")
+        check_track(c, d, m, "video")
+        check_track(c, d, m, "audio")
+
+        fails = c.failed()
+        tag = "FAIL" if fails else "ok"
+        if fails:
+            any_fail = True
+        checked = sum(1 for _, v, _ in c.rows if v is not None)
+        print(f"[{tag:>4}] {m.name}  ({checked} checks)")
+        for name, v, detail in c.rows:
+            if v is False:
+                print(f"         FAIL {name}: {detail}")
+        for name, v, detail in c.rows:
+            if v is None and detail:
+                print(f"         skip {name}: {detail}")
+
+    print()
+    print("PASS: all fixtures conform" if not any_fail
+          else "FAIL: a fixture's demux output diverged from ffprobe")
+    return 1 if any_fail else 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("fixtures", type=Path)
+    ap.add_argument("--dump", type=Path, default=None,
+                    help="path to basis_demux_dump (default: ./build/basis_demux_dump[.exe])")
+    args = ap.parse_args()
+
+    dumper = args.dump
+    if dumper is None:
+        base = Path(__file__).parent / "build" / "basis_demux_dump"
+        dumper = base if base.exists() else base.with_suffix(".exe")
+    if not dumper.exists():
+        print(f"dumper not found: {dumper} (run ./build.sh)")
+        return 1
+
+    return gate(args.fixtures, dumper)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/media-conformance/gen_fixtures.sh
+++ b/tools/media-conformance/gen_fixtures.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# Generate synthetic demux fixtures with ffmpeg: a static Basis-logo video track
+# plus a tone (multichannel where the fixture needs it). Content is irrelevant to
+# demuxing -- this exercises container/packet parsing (PTS, sizes, keyframes,
+# sample tables, PAT/PMT, EBML), so a static image and a tone are ideal: tiny and
+# deterministic. Nothing is committed; CI regenerates these each run.
+#
+#   ./gen_fixtures.sh <out_dir> [logo.png]
+#
+# Codecs whose encoder the local ffmpeg lacks are skipped with a note, so the gate
+# covers whatever the runner's ffmpeg supports.
+set -euo pipefail
+
+out="${1:?usage: gen_fixtures.sh <out_dir> [logo.png]}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+logo="${2:-$here/../../Basis/Images/BasisLogo.png}"
+mkdir -p "$out"
+
+[ -f "$logo" ] || { echo "logo not found: $logo"; exit 1; }
+command -v ffmpeg >/dev/null 2>&1 || { echo "ffmpeg not found on PATH"; exit 1; }
+
+has_enc() { ffmpeg -hide_banner -encoders 2>/dev/null | grep -qE "[[:space:]]$1[[:space:]]"; }
+
+DUR=2
+FPS=25
+# Static logo scaled to even dimensions (libx264/vp9 need mod-2), constant SAR.
+VSRC=(-loop 1 -i "$logo")
+VF="scale=320:240,setsar=1,format=yuv420p"
+# Stereo 440 Hz tone.
+ASTEREO=(-f lavfi -i "sine=frequency=440:sample_rate=48000")
+# 5.1 tone, a distinct pitch per channel (FL FR FC LFE BL BR).
+A51=(-f lavfi -i "aevalsrc=0.2*sin(220*2*PI*t)|0.2*sin(277*2*PI*t)|0.2*sin(330*2*PI*t)|0.1*sin(55*2*PI*t)|0.2*sin(440*2*PI*t)|0.2*sin(554*2*PI*t):channel_layout=5.1:s=48000")
+
+common_v=(-t "$DUR" -r "$FPS" -vf "$VF" -g "$FPS")
+q="-v error -y"
+
+made=()
+note() { echo "  + $1"; made+=("$1"); }
+skip() { echo "  - $1 (skipped: $2)"; }
+
+# ---- MP4: H.264 + AAC, three moov layouts ---------------------------------
+if has_enc libx264; then
+    ffmpeg $q "${VSRC[@]}" "${ASTEREO[@]}" "${common_v[@]}" -c:v libx264 \
+        -c:a aac -ac 2 -shortest -movflags +faststart "$out/h264_aac_faststart.mp4"
+    note "h264_aac_faststart.mp4"
+    # No +faststart => ffmpeg leaves moov after mdat (trailing-moov path).
+    ffmpeg $q "${VSRC[@]}" "${ASTEREO[@]}" "${common_v[@]}" -c:v libx264 \
+        -c:a aac -ac 2 -shortest "$out/h264_aac_tmoov.mp4"
+    note "h264_aac_tmoov.mp4"
+    # Fragmented (moof/mdat, empty moov).
+    ffmpeg $q "${VSRC[@]}" "${ASTEREO[@]}" "${common_v[@]}" -c:v libx264 \
+        -c:a aac -ac 2 -shortest -movflags +frag_keyframe+empty_moov "$out/h264_aac_frag.mp4"
+    note "h264_aac_frag.mp4"
+    # MPEG-TS: PAT/PMT/PES + ADTS audio.
+    ffmpeg $q "${VSRC[@]}" "${ASTEREO[@]}" "${common_v[@]}" -c:v libx264 \
+        -c:a aac -ac 2 -shortest -f mpegts "$out/h264_aac.ts"
+    note "h264_aac.ts"
+else
+    skip "H.264 fixtures" "no libx264"
+fi
+
+# ---- MP4: HEVC + AAC (hvcC) -----------------------------------------------
+if has_enc libx265; then
+    ffmpeg $q "${VSRC[@]}" "${ASTEREO[@]}" "${common_v[@]}" -c:v libx265 -tag:v hvc1 \
+        -c:a aac -ac 2 -shortest -movflags +faststart "$out/hevc_aac.mp4"
+    note "hevc_aac.mp4"
+else
+    skip "HEVC fixture" "no libx265"
+fi
+
+# ---- VP9 (vp09 in MP4, and V_VP9 in WebM video-only) ----------------------
+if has_enc libvpx-vp9; then
+    vp9=(-c:v libvpx-vp9 -deadline realtime -cpu-used 8 -b:v 300k)
+    ffmpeg $q "${VSRC[@]}" "${ASTEREO[@]}" "${common_v[@]}" "${vp9[@]}" \
+        -c:a aac -ac 2 -shortest "$out/vp9_aac.mp4"
+    note "vp9_aac.mp4"
+    ffmpeg $q "${VSRC[@]}" "${common_v[@]}" "${vp9[@]}" -an "$out/vp9.webm"
+    note "vp9.webm"
+else
+    skip "VP9 fixtures" "no libvpx-vp9"
+fi
+
+# ---- AV1 (av01 in MP4, V_AV1 in WebM), whichever encoder exists ------------
+av1=""
+if has_enc libsvtav1; then av1="-c:v libsvtav1 -preset 12"
+elif has_enc libaom-av1; then av1="-c:v libaom-av1 -cpu-used 8"; fi
+if [ -n "$av1" ]; then
+    ffmpeg $q "${VSRC[@]}" "${ASTEREO[@]}" "${common_v[@]}" $av1 \
+        -c:a aac -ac 2 -shortest "$out/av1_aac.mp4"
+    note "av1_aac.mp4"
+    ffmpeg $q "${VSRC[@]}" "${common_v[@]}" $av1 -an "$out/av1.webm"
+    note "av1.webm"
+else
+    skip "AV1 fixtures" "no libaom-av1 / libsvtav1"
+fi
+
+# ---- Audio-only: AAC in M4A -----------------------------------------------
+ffmpeg $q "${ASTEREO[@]}" -t "$DUR" -c:a aac -ac 2 "$out/aac.m4a"
+note "aac.m4a"
+
+# ---- WAV: 16-bit stereo, 16-bit 5.1 ---------------------------------------
+ffmpeg $q "${ASTEREO[@]}" -t "$DUR" -c:a pcm_s16le -ac 2 "$out/pcm16_stereo.wav"
+note "pcm16_stereo.wav"
+ffmpeg $q "${A51[@]}" -t "$DUR" -c:a pcm_s16le "$out/pcm16_51.wav"
+note "pcm16_51.wav"
+
+# ---- M2TS: Blu-ray LPCM 5.1 (the full-multichannel path) ------------------
+if has_enc pcm_bluray; then
+    ffmpeg $q "${A51[@]}" -t "$DUR" -c:a pcm_bluray -f mpegts -mpegts_m2ts_mode 1 "$out/lpcm51.m2ts"
+    note "lpcm51.m2ts"
+else
+    skip "LPCM m2ts fixture" "no pcm_bluray"
+fi
+
+echo "generated ${#made[@]} fixtures in $out"

--- a/tools/media-conformance/native/basis_demux_dump.c
+++ b/tools/media-conformance/native/basis_demux_dump.c
@@ -1,0 +1,478 @@
+/*
+ * basis_demux_dump — dump a container's elementary stream as JSON.
+ *
+ * Compiles the real protocol demuxers from Native~/protocol against an
+ * observing sink and prints every access unit the demuxer emits: index,
+ * pts_us, dts_us, size, keyframe flag, and an MD5 of the payload. Track
+ * announces, the reported duration and any error string come out alongside.
+ *
+ * The point is that ffprobe emits the same fields for the same file
+ * (-show_packets -show_data_hash md5), so the two can be diffed exactly. No
+ * decoder, no Unity, no PluginAPI headers — the protocol layer is plain C
+ * against a callback struct, so this links on any host with a C compiler.
+ *
+ * Build (VS dev prompt):
+ *   set NAT=..\..\..\Basis\Packages\com.basis.mediaplayer\Native~
+ *   cl /nologo /O2 /W4 /I %NAT% basis_demux_dump.c ^
+ *      %NAT%\protocol\basis_webm.c %NAT%\protocol\basis_mp4.c ^
+ *      %NAT%\protocol\basis_ts.c %NAT%\protocol\basis_wav.c ^
+ *      %NAT%\protocol\basis_bitstream.c
+ *
+ * Run:
+ *   basis_demux_dump [-demux webm|mp4|ts|wav] [-seek US] [-noreseek] FILE
+ *
+ * Annex-B note: for H.264/H.265 the demuxers hand out Annex-B access units,
+ * whereas ffprobe hashes the packet as stored in the container (avcC length-
+ * prefixed inside MP4). Payload MD5s therefore only line up for codecs stored
+ * as-is — VP9, AV1, AAC, LPCM. -au-md5-only-when-comparable records that per
+ * track via "payload_is_container_form" so the comparator knows to fall back
+ * to size/pts comparison for H.26x-in-MP4.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+/* 64-bit file seek: MSVC spells it _fseeki64; POSIX is fseeko with 64-bit off_t.
+ * This tool builds on Windows (local) and Linux (CI), so keep it portable. */
+#if defined(_WIN32)
+#define dump_fseek64(f, off) _fseeki64((f), (off), SEEK_SET)
+#else
+#include <sys/types.h>
+#define dump_fseek64(f, off) fseeko((f), (off_t)(off), SEEK_SET)
+#endif
+
+#include "basis_media_internal.h"
+#include "protocol/basis_webm.h"
+#include "protocol/basis_mp4.h"
+#include "protocol/basis_ts.h"
+#include "protocol/basis_wav.h"
+
+/* ---- MD5 (RFC 1321) ------------------------------------------------------ */
+
+typedef struct {
+    uint32_t a, b, c, d;
+    uint64_t len;
+    uint8_t buf[64];
+    size_t buf_len;
+} md5_t;
+
+static const uint32_t MD5_K[64] = {
+    0xd76aa478u, 0xe8c7b756u, 0x242070dbu, 0xc1bdceeeu,
+    0xf57c0fafu, 0x4787c62au, 0xa8304613u, 0xfd469501u,
+    0x698098d8u, 0x8b44f7afu, 0xffff5bb1u, 0x895cd7beu,
+    0x6b901122u, 0xfd987193u, 0xa679438eu, 0x49b40821u,
+    0xf61e2562u, 0xc040b340u, 0x265e5a51u, 0xe9b6c7aau,
+    0xd62f105du, 0x02441453u, 0xd8a1e681u, 0xe7d3fbc8u,
+    0x21e1cde6u, 0xc33707d6u, 0xf4d50d87u, 0x455a14edu,
+    0xa9e3e905u, 0xfcefa3f8u, 0x676f02d9u, 0x8d2a4c8au,
+    0xfffa3942u, 0x8771f681u, 0x6d9d6122u, 0xfde5380cu,
+    0xa4beea44u, 0x4bdecfa9u, 0xf6bb4b60u, 0xbebfbc70u,
+    0x289b7ec6u, 0xeaa127fau, 0xd4ef3085u, 0x04881d05u,
+    0xd9d4d039u, 0xe6db99e5u, 0x1fa27cf8u, 0xc4ac5665u,
+    0xf4292244u, 0x432aff97u, 0xab9423a7u, 0xfc93a039u,
+    0x655b59c3u, 0x8f0ccc92u, 0xffeff47du, 0x85845dd1u,
+    0x6fa87e4fu, 0xfe2ce6e0u, 0xa3014314u, 0x4e0811a1u,
+    0xf7537e82u, 0xbd3af235u, 0x2ad7d2bbu, 0xeb86d391u
+};
+
+static const int MD5_S[64] = {
+    7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22,
+    5,  9, 14, 20, 5,  9, 14, 20, 5,  9, 14, 20, 5,  9, 14, 20,
+    4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23,
+    6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21
+};
+
+static uint32_t md5_rol(uint32_t x, int c) { return (x << c) | (x >> (32 - c)); }
+
+static void md5_init(md5_t* m) {
+    m->a = 0x67452301u; m->b = 0xefcdab89u;
+    m->c = 0x98badcfeu; m->d = 0x10325476u;
+    m->len = 0; m->buf_len = 0;
+}
+
+static void md5_block(md5_t* m, const uint8_t* p) {
+    uint32_t M[16], A = m->a, B = m->b, C = m->c, D = m->d;
+    int i;
+    for (i = 0; i < 16; i++) {
+        M[i] = (uint32_t)p[i * 4] | ((uint32_t)p[i * 4 + 1] << 8) |
+               ((uint32_t)p[i * 4 + 2] << 16) | ((uint32_t)p[i * 4 + 3] << 24);
+    }
+    for (i = 0; i < 64; i++) {
+        uint32_t F;
+        int g;
+        if (i < 16)      { F = (B & C) | (~B & D);           g = i; }
+        else if (i < 32) { F = (D & B) | (~D & C);           g = (5 * i + 1) & 15; }
+        else if (i < 48) { F = B ^ C ^ D;                    g = (3 * i + 5) & 15; }
+        else             { F = C ^ (B | ~D);                 g = (7 * i) & 15; }
+        F += A + MD5_K[i] + M[g];
+        A = D; D = C; C = B;
+        B += md5_rol(F, MD5_S[i]);
+    }
+    m->a += A; m->b += B; m->c += C; m->d += D;
+}
+
+static void md5_update(md5_t* m, const uint8_t* p, size_t n) {
+    m->len += (uint64_t)n;
+    while (n) {
+        size_t take = 64 - m->buf_len;
+        if (take > n) take = n;
+        memcpy(m->buf + m->buf_len, p, take);
+        m->buf_len += take; p += take; n -= take;
+        if (m->buf_len == 64) { md5_block(m, m->buf); m->buf_len = 0; }
+    }
+}
+
+static void md5_final(md5_t* m, char out_hex[33]) {
+    static const uint8_t PAD[64] = { 0x80 };
+    uint64_t bits = m->len * 8;
+    uint8_t tail[8];
+    size_t padlen;
+    uint32_t words[4];
+    int i;
+
+    padlen = (m->buf_len < 56) ? (56 - m->buf_len) : (120 - m->buf_len);
+    md5_update(m, PAD, padlen);
+
+    for (i = 0; i < 8; i++) tail[i] = (uint8_t)(bits >> (8 * i));
+    md5_update(m, tail, 8);
+
+    words[0] = m->a; words[1] = m->b; words[2] = m->c; words[3] = m->d;
+    for (i = 0; i < 16; i++) {
+        uint8_t byte = (uint8_t)(words[i / 4] >> (8 * (i % 4)));
+        sprintf(out_hex + i * 2, "%02x", byte);
+    }
+    out_hex[32] = 0;
+}
+
+static void md5_hex(const uint8_t* p, int n, char out_hex[33]) {
+    md5_t m;
+    md5_init(&m);
+    md5_update(&m, p, (size_t)n);
+    md5_final(&m, out_hex);
+}
+
+/* ---- JSON string escaping ------------------------------------------------ */
+
+static void json_puts(FILE* f, const char* s) {
+    fputc('"', f);
+    for (; s && *s; s++) {
+        unsigned char c = (unsigned char)*s;
+        switch (c) {
+            case '"':  fputs("\\\"", f); break;
+            case '\\': fputs("\\\\", f); break;
+            case '\n': fputs("\\n", f);  break;
+            case '\r': fputs("\\r", f);  break;
+            case '\t': fputs("\\t", f);  break;
+            default:
+                if (c < 0x20) fprintf(f, "\\u%04x", c);
+                else fputc(c, f);
+        }
+    }
+    fputc('"', f);
+}
+
+/* ---- Harness ------------------------------------------------------------- */
+
+typedef struct {
+    FILE* f;
+    int allow_reseek;
+
+    /* video track */
+    int v_announced;
+    basis_codec_t v_codec;
+    int v_w, v_h, v_extradata_len;
+    long long v_aus, v_keys;
+
+    /* audio track */
+    int a_announced;
+    basis_codec_t a_codec;
+    int a_rate, a_channels, a_asc_len;
+    long long a_frames;
+
+    long long duration_us;
+    int duration_reported;
+    char error[512];
+    int ended;
+
+    /* seek driver */
+    long long seek_at_au;
+    long long seek_target;
+    int seek_pending, seek_taken;
+    long long resume_pts;
+    int resume_key, resume_seen;
+
+    /* output */
+    FILE* out;
+    int first_au_printed;
+} dump_t;
+
+static const char* codec_name(basis_codec_t c) {
+    switch (c) {
+        case BASIS_CODEC_H264: return "h264";
+        case BASIS_CODEC_H265: return "h265";
+        case BASIS_CODEC_VP9:  return "vp9";
+        case BASIS_CODEC_AV1:  return "av1";
+        case BASIS_CODEC_AAC:  return "aac";
+        case BASIS_CODEC_LPCM: return "lpcm";
+        case BASIS_CODEC_NONE: return "none";
+        default: return "unknown";
+    }
+}
+
+/* ffprobe hashes the packet as the container stores it. Our demuxers convert
+ * H.26x to Annex B, so only these codecs' payload MD5s are comparable. */
+static int payload_is_container_form(basis_codec_t c) {
+    return c == BASIS_CODEC_VP9 || c == BASIS_CODEC_AV1 ||
+           c == BASIS_CODEC_AAC || c == BASIS_CODEC_LPCM;
+}
+
+static int h_read(void* ctx, uint8_t* buf, int len) {
+    dump_t* h = (dump_t*)ctx;
+    size_t n = fread(buf, 1, (size_t)len, h->f);
+    return (int)n;
+}
+
+static int h_reseek(void* ctx, int64_t abs) {
+    dump_t* h = (dump_t*)ctx;
+    return dump_fseek64(h->f, abs) == 0 ? 0 : -1;
+}
+
+static void emit_au(dump_t* h, const char* kind, const uint8_t* data, int len,
+                    int64_t pts_us, int64_t dts_us, int key, long long index) {
+    char hex[33];
+    md5_hex(data, len, hex);
+    if (h->first_au_printed) fputs(",\n", h->out);
+    h->first_au_printed = 1;
+    fprintf(h->out,
+            "    {\"track\":\"%s\",\"index\":%lld,\"pts_us\":%lld,\"dts_us\":%lld,"
+            "\"size\":%d,\"key\":%s,\"md5\":\"%s\"}",
+            kind, index, (long long)pts_us, (long long)dts_us, len,
+            key ? "true" : "false", hex);
+}
+
+static void s_video_format(void* u, basis_codec_t codec, const uint8_t* ed, int el,
+                           int w, int h) {
+    dump_t* d = (dump_t*)u;
+    d->v_announced = 1;
+    d->v_codec = codec;
+    d->v_w = w; d->v_h = h;
+    d->v_extradata_len = el;
+    (void)ed;
+}
+
+static void s_video_au(void* u, const uint8_t* data, int len,
+                       int64_t pts_us, int64_t dts_us, int key) {
+    dump_t* d = (dump_t*)u;
+    emit_au(d, "video", data, len, pts_us, dts_us, key, d->v_aus);
+    d->v_aus++;
+    if (key) d->v_keys++;
+    if (d->seek_taken && !d->resume_seen) {
+        d->resume_seen = 1;
+        d->resume_pts = pts_us;
+        d->resume_key = key;
+    }
+    if (d->seek_at_au >= 0 && d->v_aus == d->seek_at_au && !d->seek_taken) {
+        d->seek_pending = 1;
+    }
+}
+
+static void s_audio_format(void* u, basis_codec_t codec, int rate, int ch,
+                           const uint8_t* asc, int asc_len) {
+    dump_t* d = (dump_t*)u;
+    d->a_announced = 1;
+    d->a_codec = codec;
+    d->a_rate = rate; d->a_channels = ch;
+    d->a_asc_len = asc_len;
+    (void)asc;
+}
+
+static void s_audio_frame(void* u, const uint8_t* data, int len, int64_t pts_us) {
+    dump_t* d = (dump_t*)u;
+    emit_au(d, "audio", data, len, pts_us, pts_us, 1, d->a_frames);
+    d->a_frames++;
+}
+
+static void s_state(void* u, basis_media_state_t s) { (void)u; (void)s; }
+
+static void s_error(void* u, const char* msg) {
+    dump_t* d = (dump_t*)u;
+    if (msg && !d->error[0]) {
+        strncpy(d->error, msg, sizeof(d->error) - 1);
+        d->error[sizeof(d->error) - 1] = 0;
+    }
+}
+
+static void s_eos(void* u) { ((dump_t*)u)->ended = 1; }
+
+static void s_duration(void* u, int64_t us) {
+    dump_t* d = (dump_t*)u;
+    d->duration_us = us;
+    d->duration_reported = 1;
+}
+
+static int s_take_seek(void* u, int64_t* out) {
+    dump_t* d = (dump_t*)u;
+    if (!d->seek_pending) return 0;
+    d->seek_pending = 0;
+    d->seek_taken = 1;
+    *out = d->seek_target;
+    return 1;
+}
+
+static int s_is_running(void* u) { (void)u; return 1; }
+
+/* ---- Container detection ------------------------------------------------- */
+
+/* Mirrors the engine's own dispatch (basis_media_core.c): sniff the 16-byte head
+ * for EBML/ftyp/RIFF, and fall through to MPEG-TS for everything else. TS is the
+ * default rather than a sniff hit, which is what lets m2ts through — its sync
+ * byte sits at offset 4 behind the TP_extra_header, so a head[0] test never
+ * matches it, and basis_ts_run detects the 192-byte packet size itself. */
+static const char* detect(FILE* f) {
+    uint8_t head[16];
+    size_t n = fread(head, 1, sizeof(head), f);
+    dump_fseek64(f, 0);
+    if (n >= 4 && head[0] == 0x1A && head[1] == 0x45 && head[2] == 0xDF && head[3] == 0xA3)
+        return "webm";
+    if (n >= 12 && (!memcmp(head + 4, "ftyp", 4) || !memcmp(head + 4, "styp", 4) ||
+                    !memcmp(head + 4, "moov", 4) || !memcmp(head + 4, "moof", 4)))
+        return "mp4";
+    if (n >= 12 && !memcmp(head, "RIFF", 4) && !memcmp(head + 8, "WAVE", 4))
+        return "wav";
+    return "ts";
+}
+
+int main(int argc, char** argv) {
+    const char* path = NULL;
+    const char* demux = NULL;
+    long long seek_target = -1;
+    int noreseek = 0;
+    dump_t h;
+    basis_media_sink_t sink;
+    int rc, i;
+    FILE* f;
+
+    for (i = 1; i < argc; i++) {
+        if (!strcmp(argv[i], "-demux") && i + 1 < argc)      demux = argv[++i];
+        else if (!strcmp(argv[i], "-seek") && i + 1 < argc)  seek_target = atoll(argv[++i]);
+        else if (!strcmp(argv[i], "-noreseek"))              noreseek = 1;
+        else if (argv[i][0] != '-')                          path = argv[i];
+        else {
+            fprintf(stderr, "unknown option: %s\n", argv[i]);
+            return 2;
+        }
+    }
+    if (!path) {
+        fprintf(stderr,
+                "usage: basis_demux_dump [-demux webm|mp4|ts|wav] [-seek US] "
+                "[-noreseek] FILE\n");
+        return 2;
+    }
+
+    f = fopen(path, "rb");
+    if (!f) { fprintf(stderr, "cannot open %s\n", path); return 2; }
+
+    if (!demux) {
+        demux = detect(f);
+        if (!demux) {
+            fprintf(stderr, "cannot detect container for %s (use -demux)\n", path);
+            fclose(f);
+            return 2;
+        }
+    }
+
+    memset(&h, 0, sizeof(h));
+    h.f = f;
+    h.out = stdout;
+    h.allow_reseek = !noreseek;
+    h.seek_at_au = (seek_target >= 0) ? 100 : -1;
+    h.seek_target = seek_target;
+    h.duration_us = 0;
+
+    memset(&sink, 0, sizeof(sink));
+    sink.user = &h;
+    sink.on_video_format = s_video_format;
+    sink.on_video_au = s_video_au;
+    sink.on_audio_format = s_audio_format;
+    sink.on_audio_frame = s_audio_frame;
+    sink.on_state = s_state;
+    sink.on_error = s_error;
+    sink.on_end_of_stream = s_eos;
+    sink.on_duration = s_duration;
+    sink.on_transport = NULL;
+    sink.take_seek = (seek_target >= 0) ? s_take_seek : NULL;
+    sink.is_running = s_is_running;
+
+    fputs("{\n  \"access_units\": [\n", h.out);
+
+    if (!strcmp(demux, "webm"))
+        rc = basis_webm_run(&sink, h_read, &h, h.allow_reseek ? h_reseek : NULL,
+                            h.allow_reseek ? &h : NULL);
+    else if (!strcmp(demux, "mp4"))
+        rc = basis_mp4_run(&sink, h_read, &h, h.allow_reseek ? h_reseek : NULL,
+                           h.allow_reseek ? &h : NULL);
+    else if (!strcmp(demux, "ts"))
+        rc = basis_ts_run(&sink, h_read, &h);
+    else if (!strcmp(demux, "wav"))
+        rc = basis_wav_run(&sink, h_read, &h);
+    else {
+        fprintf(stderr, "unknown demuxer: %s\n", demux);
+        fclose(f);
+        return 2;
+    }
+
+    fputs("\n  ],\n", h.out);
+
+    fprintf(h.out, "  \"demuxer\": ");        json_puts(h.out, demux);
+    fprintf(h.out, ",\n  \"file\": ");        json_puts(h.out, path);
+    fprintf(h.out, ",\n  \"run_rc\": %d", rc);
+    fprintf(h.out, ",\n  \"ended\": %s", h.ended ? "true" : "false");
+    fprintf(h.out, ",\n  \"error\": ");       json_puts(h.out, h.error);
+    fprintf(h.out, ",\n  \"duration_reported\": %s",
+            h.duration_reported ? "true" : "false");
+    fprintf(h.out, ",\n  \"duration_us\": %lld", h.duration_us);
+
+    fputs(",\n  \"video\": ", h.out);
+    if (h.v_announced) {
+        fprintf(h.out,
+                "{\"codec\":\"%s\",\"width\":%d,\"height\":%d,\"extradata_len\":%d,"
+                "\"au_count\":%lld,\"key_count\":%lld,"
+                "\"payload_is_container_form\":%s}",
+                codec_name(h.v_codec), h.v_w, h.v_h, h.v_extradata_len,
+                h.v_aus, h.v_keys,
+                payload_is_container_form(h.v_codec) ? "true" : "false");
+    } else {
+        fputs("null", h.out);
+    }
+
+    fputs(",\n  \"audio\": ", h.out);
+    if (h.a_announced) {
+        fprintf(h.out,
+                "{\"codec\":\"%s\",\"sample_rate\":%d,\"channels\":%d,"
+                "\"asc_len\":%d,\"frame_count\":%lld,"
+                "\"payload_is_container_form\":%s}",
+                codec_name(h.a_codec), h.a_rate, h.a_channels, h.a_asc_len,
+                h.a_frames,
+                payload_is_container_form(h.a_codec) ? "true" : "false");
+    } else {
+        fputs("null", h.out);
+    }
+
+    fputs(",\n  \"seek\": ", h.out);
+    if (seek_target >= 0) {
+        fprintf(h.out,
+                "{\"requested_us\":%lld,\"taken\":%s,\"resume_pts_us\":%lld,"
+                "\"resume_key\":%s}",
+                seek_target, h.seek_taken ? "true" : "false",
+                h.resume_seen ? h.resume_pts : -1,
+                h.resume_key ? "true" : "false");
+    } else {
+        fputs("null", h.out);
+    }
+
+    fputs("\n}\n", h.out);
+
+    fclose(f);
+    return 0;
+}


### PR DESCRIPTION
## Summary

Adds a **second CI gate beside `fuzz-demux`**, covering the other half of parser correctness. Fuzzing proves the demuxers don't *crash* on hostile input; this proves they produce the *correct output* on valid input.

`basis_demux_dump` compiles the real `protocol/*.c` demuxers against an observing sink and prints every access unit as JSON (pts, dts, size, keyframe flag, payload MD5). `demux_gate.py` diffs that against `ffprobe` — codec, dimensions, packet count, PTS within 1 µs, and payload MD5 — reconciling the three framings so the hashes line up:

- VP9/AV1/AAC-in-MP4 are stored as-is and compare directly.
- H.264/H.265 leave the demuxer as Annex B, so ffprobe is reframed with `*_mp4toannexb`; keyframes are exempt (the filter inlines SPS/PPS the demuxer passes as extradata).
- AAC-in-TS is ADTS-framed; ffprobe is reframed with `aac_adtstoasc`.
- LPCM has no canonical packetisation, so it's checked on announce only.

### No committed media, no `libav*` linkage

Fixtures are generated on the fly from a **static Basis-logo video track plus a tone** (multichannel where the fixture needs it). Content is irrelevant to demuxing — we're checking container/packet parsing, not motion — so a still image and a tone are ideal: tiny, deterministic, nothing to host. ffmpeg is used **only as an external CLI tool** (the fixture generator and the reference oracle); nothing links `libavcodec`/`libavformat`, and nothing ffmpeg-derived is committed. The `conformance-demux` CI job installs ffmpeg on the ephemeral runner, uses it, and it's discarded with the runner. The gate is deterministic because the generate-and-compare is self-consistent: our dump is always checked against ffprobe's view of the *same* generated file, so ffmpeg version differences across runners don't matter.

### Matrix

MP4 H.264+AAC (faststart / trailing-moov / fragmented), MP4 HEVC (hvcC), MP4 + WebM VP9, MP4 + WebM AV1, MPEG-TS H.264+AAC (PAT/PMT/PES + ADTS), AAC-in-M4A, WAV 16-bit stereo and 5.1, and Blu-ray LPCM 5.1 over M2TS. `gen_fixtures.sh` skips any codec whose encoder the runner's ffmpeg lacks, so the gate covers whatever's available.

The dumper's Windows-only `_fseeki64` was made portable (`fseeko` on POSIX) so it builds on the Linux runner.

## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [x] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — `BasisEventDriver` runs the single per-frame tick that drives the whole framework (network apply, local player sim, blendshapes, JigglePhysics, nameplates, and more) as one sequential chain. An unhandled exception anywhere in that chain aborts the rest of the tick, so every step after the throwing one is silently skipped for that frame. New work added to the driver must either be guaranteed not to throw, or be wrapped in a `try`/`catch` that contains the failure and surfaces it through `BasisDebug` — logged once / rate-limited, never every frame (see the existing `HVRBasisBuiltInAddresses.Simulate()` guard for the pattern). Expect this to be scrutinized closely in review.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [x] Windows
- [x] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [ ] Tested in VR (note headset under **Notes**)
- [ ] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [x] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [x] N/A — change does not touch any of the above

## Notes

**On the required-checks block:** this PR adds test tooling (a portable C dumper, a Python comparator, a shell generator) and a CI job — no Unity/C# runtime code, so none of the component, hot-path, MonoBehaviour, camera, or logging checks apply. Ticked as N/A.

**Verification:** built and ran the full sequence (build → generate → gate) locally on Windows against all 13 fixtures — every one conforms, with real bit-exact MD5 comparison on the H.264/HEVC/VP9/AV1/AAC paths. The `conformance-demux` CI job exercises the Linux path (gcc build + apt ffmpeg) end to end; it's marked Linux-tested on the strength of that job.

**Relationship to the wider conformance harness:** this is the demux lane only — the one lane that can gate CI (deterministic, no GPU, no Unity). The decode and A/V-sync lanes need a Unity editor and a human, so they stay out of CI by design.
