### PR TITLE
feat(constraints): Unity components for the Basis constraint system

### DIFF
--- a/Basis/Packages/com.basis.eventdriver/BasisEventDriver.cs
+++ b/Basis/Packages/com.basis.eventdriver/BasisEventDriver.cs
@@ -1,6 +1,7 @@
 using Basis.BTween;
 using Basis.Scripts.BasisSdk.Interactions;
 using Basis.Scripts.BasisSdk.Players;
+using Basis.Scripts.Constraints;
 using Basis.Scripts.Debugging;
 using Basis.Scripts.Device_Management;
 using Basis.Scripts.Drivers;
@@ -169,6 +170,7 @@ namespace Basis.EventDriver
                 Application.onBeforeRender -= OnBeforeRender;
                 RemoteBoneJobSystem.Dispose();
                 BasisAuthoredMotionSystem.Dispose();
+                BasisConstraintSystem.Dispose();
                 BasisAvatarBufferPool.Deinitialize();
             }
             finally
@@ -446,6 +448,13 @@ namespace Basis.EventDriver
             var authoredMotionJob = BasisAuthoredMotionSystem.Schedule();
             HVRCommsUpdateDriver.SimulateVariableNetworking();
             BasisAuthoredMotionSystem.Complete(authoredMotionJob);
+
+            // ── Constraints: resolve the BasisConstraint* components ──
+            // Sits after authored motion (so a constraint may source an authored bone) and ahead of
+            // the jiggle schedule below (so jiggle samples the constrained pose, not the stale one).
+            // Scheduled and completed back to back: the solve owns every constrained transform for
+            // the duration, and everything after this point reads bones on the main thread.
+            BasisConstraintSystem.Complete(BasisConstraintSystem.Schedule());
 
             // ── JigglePhysics schedule ──
             ProfileBegin(PROF_JIGGLE_SCHEDULE);

--- a/Basis/Packages/com.basis.framework/Constraints.meta
+++ b/Basis/Packages/com.basis.framework/Constraints.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 321f854da3c66734091eec18c49683f3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Basis/Packages/com.basis.framework/Constraints/BasisConstraintData.cs
+++ b/Basis/Packages/com.basis.framework/Constraints/BasisConstraintData.cs
@@ -1,0 +1,128 @@
+using System;
+using Unity.Mathematics;
+
+namespace Basis.Scripts.Constraints
+{
+    public enum BasisConstraintKind : byte
+    {
+        Position = 0,
+        Rotation = 1,
+        Scale = 2,
+        Parent = 3,
+        Aim = 4,
+        LookAt = 5,
+    }
+
+    public enum BasisWorldUpKind : byte
+    {
+        SceneUp = 0,
+        ObjectUp = 1,
+        ObjectRotationUp = 2,
+        Vector = 3,
+        None = 4,
+    }
+
+    [Flags]
+    public enum BasisConstraintAxis : byte
+    {
+        None = 0,
+        X = 1,
+        Y = 2,
+        Z = 4,
+        All = X | Y | Z,
+    }
+
+    public struct BasisConstraintSource
+    {
+        public int TransformIndex;
+        public float Weight;
+        public float3 PositionOffset;
+        public quaternion RotationOffset;
+    }
+
+    public struct BasisConstraintTransform
+    {
+        public float3 LocalPosition;
+        public quaternion LocalRotation;
+        public float3 LocalScale;
+        public int ParentIndex;
+    }
+
+    public struct BasisConstraintWorld
+    {
+        public float3 Position;
+        public quaternion Rotation;
+        public float3 Scale;
+    }
+
+    public struct BasisConstraintSlot
+    {
+        public int TargetIndex;
+        public int SourceStart;
+        public int SourceCount;
+        public int WorldUpIndex;
+        public int AvatarId;
+        public int Depth;
+
+        public float Weight;
+        public float Roll;
+
+        public float3 TranslationAtRest;
+        public quaternion RotationAtRest;
+        public float3 ScaleAtRest;
+
+        public float3 TranslationOffset;
+        public quaternion RotationOffset;
+        public float3 ScaleOffset;
+
+        public float3 AimVector;
+        public float3 UpVector;
+        public float3 WorldUpVector;
+
+        public BasisConstraintKind Kind;
+        public BasisWorldUpKind WorldUpKind;
+        public byte TranslationMask;
+        public byte RotationMask;
+        public byte ScaleMask;
+        public byte Active;
+        public byte Locked;
+        public byte UseUpObject;
+    }
+
+    public static class BasisConstraintDefaults
+    {
+        public const float WeightEpsilon = 1e-6f;
+
+        public static BasisConstraintSlot Identity(BasisConstraintKind kind)
+        {
+            return new BasisConstraintSlot
+            {
+                TargetIndex = -1,
+                SourceStart = 0,
+                SourceCount = 0,
+                WorldUpIndex = -1,
+                AvatarId = -1,
+                Depth = 0,
+                Weight = 1f,
+                Roll = 0f,
+                TranslationAtRest = float3.zero,
+                RotationAtRest = quaternion.identity,
+                ScaleAtRest = new float3(1f, 1f, 1f),
+                TranslationOffset = float3.zero,
+                RotationOffset = quaternion.identity,
+                ScaleOffset = new float3(1f, 1f, 1f),
+                AimVector = new float3(0f, 0f, 1f),
+                UpVector = new float3(0f, 1f, 0f),
+                WorldUpVector = new float3(0f, 1f, 0f),
+                Kind = kind,
+                WorldUpKind = BasisWorldUpKind.SceneUp,
+                TranslationMask = (byte)BasisConstraintAxis.All,
+                RotationMask = (byte)BasisConstraintAxis.All,
+                ScaleMask = (byte)BasisConstraintAxis.All,
+                Active = 1,
+                Locked = 1,
+                UseUpObject = 0,
+            };
+        }
+    }
+}

--- a/Basis/Packages/com.basis.framework/Constraints/BasisConstraintData.cs.meta
+++ b/Basis/Packages/com.basis.framework/Constraints/BasisConstraintData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bdd6c739756b74a418e0fbce0a895209

--- a/Basis/Packages/com.basis.framework/Constraints/BasisConstraintJobs.cs
+++ b/Basis/Packages/com.basis.framework/Constraints/BasisConstraintJobs.cs
@@ -1,0 +1,365 @@
+using Unity.Burst;
+using Unity.Collections;
+using Unity.Jobs;
+using Unity.Mathematics;
+using UnityEngine.Jobs;
+
+namespace Basis.Scripts.Constraints
+{
+    /// <summary>
+    /// One constraint's solved local pose, plus which channels it actually drives. A constraint
+    /// whose sources all carry zero weight writes nothing at all rather than snapping the transform
+    /// to a rest pose nobody asked for, which is what the per-channel flags encode.
+    /// </summary>
+    public struct BasisConstraintResult
+    {
+        public float3 LocalPosition;
+        public quaternion LocalRotation;
+        public float3 LocalScale;
+
+        public byte WritePosition;
+        public byte WriteRotation;
+        public byte WriteScale;
+    }
+
+    /// <summary>
+    /// Samples every tracked transform once — targets, sources, world-up references and the
+    /// targets' parents all live in the same array, so a source that is itself constrained is read
+    /// exactly once no matter how many constraints reference it.
+    /// </summary>
+    [BurstCompile]
+    public struct BasisConstraintReadJob : IJobParallelForTransform
+    {
+        public NativeArray<BasisConstraintWorld> World;
+        public NativeArray<BasisConstraintTransform> Local;
+
+        public void Execute(int index, TransformAccess transform)
+        {
+            if (!transform.isValid)
+            {
+                return;
+            }
+
+            float4x4 localToWorld = transform.localToWorldMatrix;
+            World[index] = new BasisConstraintWorld
+            {
+                Position = transform.position,
+                Rotation = transform.rotation,
+                Scale = LossyScale(localToWorld),
+            };
+
+            // ParentIndex is authored at rebuild and must survive the per-frame sample.
+            BasisConstraintTransform local = Local[index];
+            local.LocalPosition = transform.localPosition;
+            local.LocalRotation = transform.localRotation;
+            local.LocalScale = transform.localScale;
+            Local[index] = local;
+        }
+
+        /// <summary>
+        /// Column magnitudes of the local-to-world matrix. <c>Transform.lossyScale</c> is not
+        /// reachable through <see cref="TransformAccess"/>, and this is what it computes anyway
+        /// (sign of a mirrored basis is not recovered, matching Unity).
+        /// </summary>
+        public static float3 LossyScale(in float4x4 localToWorld)
+        {
+            return new float3(
+                math.length(localToWorld.c0.xyz),
+                math.length(localToWorld.c1.xyz),
+                math.length(localToWorld.c2.xyz));
+        }
+    }
+
+    /// <summary>
+    /// Solves every constraint in one pass, walking <see cref="Order"/> — a topological order over
+    /// the source→target dependency graph, so a constraint driven by another constraint's target
+    /// always sees the already-solved pose regardless of where either sits in the hierarchy. After
+    /// each slot resolves, the target's entry in <see cref="World"/> is recomposed from its parent,
+    /// which is what makes those chains work.
+    ///
+    /// Two caveats worth knowing. Only *constrained* transforms are recomposed: an unconstrained
+    /// transform sitting between a constrained parent and a constrained child is read at its
+    /// pre-solve world pose for the frame. And a dependency cycle has no valid order at all — it is
+    /// broken at the shallowest member, which lags one frame.
+    ///
+    /// Single-threaded by design. The work per slot is a handful of quaternion blends, and a
+    /// parallel job would have to give up the sequential dependency the depth ordering buys.
+    /// </summary>
+    [BurstCompile]
+    public struct BasisConstraintSolveJob : IJob
+    {
+        [ReadOnly] public NativeArray<BasisConstraintSlot> Slots;
+        [ReadOnly] public NativeArray<BasisConstraintSource> Sources;
+        [ReadOnly] public NativeArray<BasisConstraintTransform> Local;
+        [ReadOnly] public NativeArray<int> Order;
+
+        /// <summary>
+        /// Slot index → row in <see cref="Results"/>. Rows are per *target transform*, not per slot,
+        /// so stacking a position and a rotation constraint on one object merges into a single write
+        /// instead of two parallel writes racing over the same transform.
+        /// </summary>
+        [ReadOnly] public NativeArray<int> TargetRow;
+
+        public NativeArray<BasisConstraintWorld> World;
+        public NativeArray<BasisConstraintResult> Results;
+
+        public void Execute()
+        {
+            // Results accumulate across slots sharing a target, so start from a clean slate.
+            for (int Index = 0; Index < Results.Length; Index++)
+            {
+                Results[Index] = default;
+            }
+
+            for (int Index = 0; Index < Order.Length; Index++)
+            {
+                Solve(Order[Index]);
+            }
+        }
+
+        private void Solve(int slotIndex)
+        {
+            BasisConstraintSlot slot = Slots[slotIndex];
+            BasisConstraintResult result = default;
+            result.LocalRotation = quaternion.identity;
+
+            int target = slot.TargetIndex;
+            int row = TargetRow[slotIndex];
+            if (slot.Active == 0 || target < 0 || slot.SourceCount <= 0)
+            {
+                return;
+            }
+
+            BasisConstraintTransform local = Local[target];
+            BasisConstraintWorld targetWorld = World[target];
+            BasisConstraintWorld parent = local.ParentIndex >= 0 ? World[local.ParentIndex] : IdentityWorld();
+            float weight = math.saturate(slot.Weight);
+
+            switch (slot.Kind)
+            {
+                case BasisConstraintKind.Position:
+                    SolvePosition(in slot, in local, in parent, weight, false, ref result);
+                    break;
+                case BasisConstraintKind.Rotation:
+                    SolveRotation(in slot, in local, in parent, weight, false, ref result);
+                    break;
+                case BasisConstraintKind.Scale:
+                    SolveScale(in slot, in local, in parent, weight, ref result);
+                    break;
+                case BasisConstraintKind.Parent:
+                    SolvePosition(in slot, in local, in parent, weight, true, ref result);
+                    SolveRotation(in slot, in local, in parent, weight, true, ref result);
+                    break;
+                case BasisConstraintKind.Aim:
+                case BasisConstraintKind.LookAt:
+                    SolveAim(in slot, in local, in parent, in targetWorld, weight, ref result);
+                    break;
+            }
+
+            // Merge per channel: a slot only overwrites what it actually drives, so a position and a
+            // rotation constraint on the same transform compose rather than cancel.
+            BasisConstraintResult merged = Results[row];
+            if (result.WritePosition != 0)
+            {
+                merged.LocalPosition = result.LocalPosition;
+                merged.WritePosition = 1;
+            }
+            if (result.WriteRotation != 0)
+            {
+                merged.LocalRotation = result.LocalRotation;
+                merged.WriteRotation = 1;
+            }
+            if (result.WriteScale != 0)
+            {
+                merged.LocalScale = result.LocalScale;
+                merged.WriteScale = 1;
+            }
+            Results[row] = merged;
+
+            // Only recompose when something was actually written. The sampled world row is exact;
+            // the recomposition is a lossy-scale TRS reconstruction, so refreshing a row nothing
+            // touched would inject decomposition error under a rotated, non-uniformly scaled
+            // ancestor and hand it to every constraint sourcing this transform.
+            if (merged.WritePosition != 0 || merged.WriteRotation != 0 || merged.WriteScale != 0)
+            {
+                RefreshWorld(target, in local, in parent, in merged);
+            }
+        }
+
+        private void SolvePosition(
+            in BasisConstraintSlot slot,
+            in BasisConstraintTransform local,
+            in BasisConstraintWorld parent,
+            float weight,
+            bool applySourceOffsets,
+            ref BasisConstraintResult result)
+        {
+            float3 blended = BasisConstraintMath.BlendPositions(
+                Sources, World, slot.SourceStart, slot.SourceCount, applySourceOffsets, out float totalWeight);
+            if (totalWeight <= BasisConstraintDefaults.WeightEpsilon)
+            {
+                return;
+            }
+
+            float3 driven = BasisConstraintMath.WorldToParentPoint(parent, blended) + slot.TranslationOffset;
+            float3 current = local.LocalPosition;
+            // Masked-out axes fall through as "current" on both sides of the lerp, so the weight
+            // blend cannot drag them toward the rest pose either.
+            float3 masked = BasisConstraintMath.MaskAxis(current, driven, slot.TranslationMask);
+            float3 rest = BasisConstraintMath.MaskAxis(current, slot.TranslationAtRest, slot.TranslationMask);
+
+            result.LocalPosition = math.lerp(rest, masked, weight);
+            result.WritePosition = 1;
+        }
+
+        private void SolveRotation(
+            in BasisConstraintSlot slot,
+            in BasisConstraintTransform local,
+            in BasisConstraintWorld parent,
+            float weight,
+            bool applySourceOffsets,
+            ref BasisConstraintResult result)
+        {
+            quaternion blended = BasisConstraintMath.BlendRotations(
+                Sources, World, slot.SourceStart, slot.SourceCount, applySourceOffsets, out float totalWeight);
+            if (totalWeight <= BasisConstraintDefaults.WeightEpsilon)
+            {
+                return;
+            }
+
+            quaternion driven = math.mul(
+                BasisConstraintMath.WorldToParentRotation(parent, blended), slot.RotationOffset);
+            quaternion current = local.LocalRotation;
+            quaternion masked = BasisConstraintMath.MaskEuler(current, driven, slot.RotationMask);
+            quaternion rest = BasisConstraintMath.MaskEuler(current, slot.RotationAtRest, slot.RotationMask);
+
+            result.LocalRotation = math.slerp(rest, masked, weight);
+            result.WriteRotation = 1;
+        }
+
+        private void SolveScale(
+            in BasisConstraintSlot slot,
+            in BasisConstraintTransform local,
+            in BasisConstraintWorld parent,
+            float weight,
+            ref BasisConstraintResult result)
+        {
+            float3 blended = BasisConstraintMath.BlendScales(
+                Sources, World, slot.SourceStart, slot.SourceCount, out float totalWeight);
+            if (totalWeight <= BasisConstraintDefaults.WeightEpsilon)
+            {
+                return;
+            }
+
+            // Sources blend in world scale, so divide the parent back out to land in local space.
+            float3 driven = blended / BasisConstraintMath.SafeScale(parent.Scale) * slot.ScaleOffset;
+            float3 current = local.LocalScale;
+            float3 masked = BasisConstraintMath.MaskAxis(current, driven, slot.ScaleMask);
+            float3 rest = BasisConstraintMath.MaskAxis(current, slot.ScaleAtRest, slot.ScaleMask);
+
+            result.LocalScale = math.lerp(rest, masked, weight);
+            result.WriteScale = 1;
+        }
+
+        private void SolveAim(
+            in BasisConstraintSlot slot,
+            in BasisConstraintTransform local,
+            in BasisConstraintWorld parent,
+            in BasisConstraintWorld targetWorld,
+            float weight,
+            ref BasisConstraintResult result)
+        {
+            float3 aimPoint = BasisConstraintMath.BlendPositions(
+                Sources, World, slot.SourceStart, slot.SourceCount, false, out float totalWeight);
+            if (totalWeight <= BasisConstraintDefaults.WeightEpsilon)
+            {
+                return;
+            }
+
+            float3 aimDirection = aimPoint - targetWorld.Position;
+            float3 worldUp = BasisConstraintMath.ResolveWorldUp(in slot, in targetWorld, World);
+            quaternion driven = BasisConstraintMath.AimRotation(
+                aimDirection, worldUp, slot.AimVector, slot.UpVector);
+
+            if (math.abs(slot.Roll) > 0f)
+            {
+                float3 rollAxis = math.normalizesafe(slot.AimVector, new float3(0f, 0f, 1f));
+                driven = math.mul(driven, quaternion.AxisAngle(rollAxis, math.radians(slot.Roll)));
+            }
+
+            quaternion localDriven = math.mul(
+                BasisConstraintMath.WorldToParentRotation(parent, driven), slot.RotationOffset);
+            quaternion current = local.LocalRotation;
+            quaternion masked = BasisConstraintMath.MaskEuler(current, localDriven, slot.RotationMask);
+            quaternion rest = BasisConstraintMath.MaskEuler(current, slot.RotationAtRest, slot.RotationMask);
+
+            result.LocalRotation = math.slerp(rest, masked, weight);
+            result.WriteRotation = 1;
+        }
+
+        /// <summary>
+        /// Recompose the solved target's world pose so slots later in depth order read the
+        /// constrained result rather than the stale sample.
+        /// </summary>
+        private void RefreshWorld(
+            int target,
+            in BasisConstraintTransform local,
+            in BasisConstraintWorld parent,
+            in BasisConstraintResult result)
+        {
+            float3 localPosition = result.WritePosition != 0 ? result.LocalPosition : local.LocalPosition;
+            quaternion localRotation = result.WriteRotation != 0 ? result.LocalRotation : local.LocalRotation;
+            float3 localScale = result.WriteScale != 0 ? result.LocalScale : local.LocalScale;
+
+            World[target] = new BasisConstraintWorld
+            {
+                Position = parent.Position + math.mul(parent.Rotation, localPosition * parent.Scale),
+                Rotation = math.mul(parent.Rotation, localRotation),
+                Scale = parent.Scale * localScale,
+            };
+        }
+
+        public static BasisConstraintWorld IdentityWorld()
+        {
+            return new BasisConstraintWorld
+            {
+                Position = float3.zero,
+                Rotation = quaternion.identity,
+                Scale = new float3(1f, 1f, 1f),
+            };
+        }
+    }
+
+    /// <summary>
+    /// Writes the solved local poses back. Runs over the target-only transform array, so a
+    /// transform driven by no constraint is never touched.
+    /// </summary>
+    [BurstCompile]
+    public struct BasisConstraintWriteJob : IJobParallelForTransform
+    {
+        [ReadOnly] public NativeArray<BasisConstraintResult> Results;
+
+        public void Execute(int index, TransformAccess transform)
+        {
+            if (!transform.isValid)
+            {
+                return;
+            }
+
+            BasisConstraintResult result = Results[index];
+
+            if (result.WritePosition != 0 || result.WriteRotation != 0)
+            {
+                // Set both at once: two separate property writes dirty the hierarchy twice.
+                float3 position = result.WritePosition != 0 ? result.LocalPosition : (float3)transform.localPosition;
+                quaternion rotation = result.WriteRotation != 0 ? result.LocalRotation : (quaternion)transform.localRotation;
+                transform.SetLocalPositionAndRotation(position, rotation);
+            }
+
+            if (result.WriteScale != 0)
+            {
+                transform.localScale = result.LocalScale;
+            }
+        }
+    }
+}

--- a/Basis/Packages/com.basis.framework/Constraints/BasisConstraintJobs.cs.meta
+++ b/Basis/Packages/com.basis.framework/Constraints/BasisConstraintJobs.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 84b2463dadb99855b36bb12ee24ee33d

--- a/Basis/Packages/com.basis.framework/Constraints/BasisConstraintMath.cs
+++ b/Basis/Packages/com.basis.framework/Constraints/BasisConstraintMath.cs
@@ -1,0 +1,214 @@
+using Unity.Burst;
+using Unity.Collections;
+using Unity.Mathematics;
+
+namespace Basis.Scripts.Constraints
+{
+    [BurstCompile]
+    public static class BasisConstraintMath
+    {
+        public static float3 MaskAxis(float3 current, float3 value, byte mask)
+        {
+            return new float3(
+                (mask & 1) != 0 ? value.x : current.x,
+                (mask & 2) != 0 ? value.y : current.y,
+                (mask & 4) != 0 ? value.z : current.z);
+        }
+
+        public static quaternion MaskEuler(quaternion current, quaternion value, byte mask)
+        {
+            if (mask == (byte)BasisConstraintAxis.All)
+            {
+                return value;
+            }
+            float3 currentEuler = ToEulerZXY(current);
+            float3 valueEuler = ToEulerZXY(value);
+            return FromEulerZXY(MaskAxis(currentEuler, valueEuler, mask));
+        }
+
+        public static float3 ToEulerZXY(quaternion q)
+        {
+            float4 v = q.value;
+            float sinX = 2f * (v.w * v.x - v.y * v.z);
+            sinX = math.clamp(sinX, -1f, 1f);
+            float x = math.asin(sinX);
+            float y = math.atan2(2f * (v.w * v.y + v.x * v.z), 1f - 2f * (v.x * v.x + v.y * v.y));
+            float z = math.atan2(2f * (v.w * v.z + v.x * v.y), 1f - 2f * (v.x * v.x + v.z * v.z));
+            return new float3(x, y, z);
+        }
+
+        public static quaternion FromEulerZXY(float3 euler)
+        {
+            return quaternion.EulerZXY(euler);
+        }
+
+        public static quaternion BlendRotations(
+            in NativeArray<BasisConstraintSource> sources,
+            in NativeArray<BasisConstraintWorld> world,
+            int start,
+            int count,
+            bool applySourceOffsets,
+            out float totalWeight)
+        {
+            totalWeight = 0f;
+            float4 accumulated = float4.zero;
+            for (int i = 0; i < count; i++)
+            {
+                BasisConstraintSource source = sources[start + i];
+                if (source.Weight <= 0f || source.TransformIndex < 0)
+                {
+                    continue;
+                }
+                quaternion rotation = world[source.TransformIndex].Rotation;
+                if (applySourceOffsets)
+                {
+                    rotation = math.mul(rotation, source.RotationOffset);
+                }
+                float4 candidate = rotation.value;
+                if (totalWeight > 0f && math.dot(math.normalizesafe(accumulated), candidate) < 0f)
+                {
+                    candidate = -candidate;
+                }
+                accumulated += candidate * source.Weight;
+                totalWeight += source.Weight;
+            }
+            if (totalWeight <= BasisConstraintDefaults.WeightEpsilon)
+            {
+                return quaternion.identity;
+            }
+            return math.normalize(new quaternion(accumulated / totalWeight));
+        }
+
+        public static float3 BlendPositions(
+            in NativeArray<BasisConstraintSource> sources,
+            in NativeArray<BasisConstraintWorld> world,
+            int start,
+            int count,
+            bool applySourceOffsets,
+            out float totalWeight)
+        {
+            totalWeight = 0f;
+            float3 accumulated = float3.zero;
+            for (int i = 0; i < count; i++)
+            {
+                BasisConstraintSource source = sources[start + i];
+                if (source.Weight <= 0f || source.TransformIndex < 0)
+                {
+                    continue;
+                }
+                BasisConstraintWorld w = world[source.TransformIndex];
+                float3 position = w.Position;
+                if (applySourceOffsets)
+                {
+                    position += math.mul(w.Rotation, source.PositionOffset);
+                }
+                accumulated += position * source.Weight;
+                totalWeight += source.Weight;
+            }
+            if (totalWeight <= BasisConstraintDefaults.WeightEpsilon)
+            {
+                return float3.zero;
+            }
+            return accumulated / totalWeight;
+        }
+
+        public static float3 BlendScales(
+            in NativeArray<BasisConstraintSource> sources,
+            in NativeArray<BasisConstraintWorld> world,
+            int start,
+            int count,
+            out float totalWeight)
+        {
+            totalWeight = 0f;
+            float3 accumulated = float3.zero;
+            for (int i = 0; i < count; i++)
+            {
+                BasisConstraintSource source = sources[start + i];
+                if (source.Weight <= 0f || source.TransformIndex < 0)
+                {
+                    continue;
+                }
+                accumulated += world[source.TransformIndex].Scale * source.Weight;
+                totalWeight += source.Weight;
+            }
+            if (totalWeight <= BasisConstraintDefaults.WeightEpsilon)
+            {
+                return new float3(1f, 1f, 1f);
+            }
+            return accumulated / totalWeight;
+        }
+
+        public static float3 WorldToParentPoint(in BasisConstraintWorld parent, float3 worldPoint)
+        {
+            float3 delta = worldPoint - parent.Position;
+            float3 rotated = math.mul(math.conjugate(parent.Rotation), delta);
+            return rotated / SafeScale(parent.Scale);
+        }
+
+        public static quaternion WorldToParentRotation(in BasisConstraintWorld parent, quaternion worldRotation)
+        {
+            return math.mul(math.conjugate(parent.Rotation), worldRotation);
+        }
+
+        public static float3 SafeScale(float3 scale)
+        {
+            return new float3(
+                math.abs(scale.x) < 1e-8f ? 1e-8f : scale.x,
+                math.abs(scale.y) < 1e-8f ? 1e-8f : scale.y,
+                math.abs(scale.z) < 1e-8f ? 1e-8f : scale.z);
+        }
+
+        public static quaternion AimRotation(float3 aimDirection, float3 worldUp, float3 localAim, float3 localUp)
+        {
+            float3 forward = math.normalizesafe(aimDirection, new float3(0f, 0f, 1f));
+            float3 up = math.normalizesafe(worldUp, new float3(0f, 1f, 0f));
+            if (math.abs(math.dot(forward, up)) > 0.9999f)
+            {
+                up = math.abs(forward.y) > 0.9999f ? new float3(0f, 0f, 1f) : new float3(0f, 1f, 0f);
+            }
+            float3 right = math.normalizesafe(math.cross(up, forward), new float3(1f, 0f, 0f));
+            float3 orthoUp = math.cross(forward, right);
+            float3x3 targetBasis = new float3x3(right, orthoUp, forward);
+
+            float3 srcForward = math.normalizesafe(localAim, new float3(0f, 0f, 1f));
+            float3 srcUp = math.normalizesafe(localUp, new float3(0f, 1f, 0f));
+            if (math.abs(math.dot(srcForward, srcUp)) > 0.9999f)
+            {
+                srcUp = math.abs(srcForward.y) > 0.9999f ? new float3(0f, 0f, 1f) : new float3(0f, 1f, 0f);
+            }
+            float3 srcRight = math.normalizesafe(math.cross(srcUp, srcForward), new float3(1f, 0f, 0f));
+            float3 srcOrthoUp = math.cross(srcForward, srcRight);
+            float3x3 sourceBasis = new float3x3(srcRight, srcOrthoUp, srcForward);
+
+            return math.mul(new quaternion(targetBasis), math.conjugate(new quaternion(sourceBasis)));
+        }
+
+        public static float3 ResolveWorldUp(
+            in BasisConstraintSlot slot,
+            in BasisConstraintWorld target,
+            in NativeArray<BasisConstraintWorld> world)
+        {
+            switch (slot.WorldUpKind)
+            {
+                case BasisWorldUpKind.SceneUp:
+                    return new float3(0f, 1f, 0f);
+                case BasisWorldUpKind.ObjectUp:
+                    if (slot.WorldUpIndex < 0)
+                    {
+                        return new float3(0f, 1f, 0f);
+                    }
+                    return math.normalizesafe(world[slot.WorldUpIndex].Position - target.Position, new float3(0f, 1f, 0f));
+                case BasisWorldUpKind.ObjectRotationUp:
+                    if (slot.WorldUpIndex < 0)
+                    {
+                        return new float3(0f, 1f, 0f);
+                    }
+                    return math.mul(world[slot.WorldUpIndex].Rotation, math.normalizesafe(slot.WorldUpVector, new float3(0f, 1f, 0f)));
+                case BasisWorldUpKind.Vector:
+                    return math.normalizesafe(slot.WorldUpVector, new float3(0f, 1f, 0f));
+                default:
+                    return float3.zero;
+            }
+        }
+    }
+}

--- a/Basis/Packages/com.basis.framework/Constraints/BasisConstraintMath.cs.meta
+++ b/Basis/Packages/com.basis.framework/Constraints/BasisConstraintMath.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: eab65ccab42275740bfcd4848fa625ed

--- a/Basis/Packages/com.basis.framework/Constraints/BasisConstraintSystem.cs
+++ b/Basis/Packages/com.basis.framework/Constraints/BasisConstraintSystem.cs
@@ -1,0 +1,744 @@
+using System;
+using System.Collections.Generic;
+using Basis.Scripts.BasisSdk.Constraints;
+using Unity.Collections;
+using Unity.Jobs;
+using Unity.Mathematics;
+using UnityEngine;
+using UnityEngine.Jobs;
+
+namespace Basis.Scripts.Constraints
+{
+    /// <summary>
+    /// Batched solver behind the <see cref="BasisConstraintBase"/> components. Every enabled
+    /// constraint in the process — avatar or scene — is flattened into one set of native containers
+    /// and solved by three jobs per frame (sample, solve, write), instead of each component paying
+    /// for its own <c>Update</c> and its own scattered transform reads.
+    ///
+    /// Components announce themselves through the SDK-side static events rather than calling in
+    /// directly, because the SDK assembly cannot reference this one. The subscription is installed
+    /// once at <see cref="RuntimeInitializeLoadType.SubsystemRegistration"/>, before any scene
+    /// loads, so no component can enable ahead of the listener.
+    ///
+    /// Structural changes (a component joining, leaving, or reshaping its source list) set
+    /// <c>sDirty</c> and rebuild the whole table on the next <see cref="Schedule"/>. That is a
+    /// deliberate simplification over the incremental append <c>BasisAuthoredMotionSystem</c> does:
+    /// constraint counts are small and structural churn is rare, whereas the shared source buffer
+    /// makes incremental compaction fiddly to get right. Scalar edits — weight, offsets, masks,
+    /// rest pose, source weights — are re-read every frame and never trigger a rebuild, so
+    /// animating a constraint's weight stays free.
+    ///
+    /// Reparenting a constrained transform at runtime does not invalidate anything on its own;
+    /// call <see cref="BasisConstraintBase.SetDirty"/> after doing so, since the cached parent row
+    /// is resolved at rebuild.
+    /// </summary>
+    public static class BasisConstraintSystem
+    {
+        private sealed class Registration
+        {
+            public BasisConstraintBase Component;
+            public int SlotIndex;
+            public int SourceStart;
+            public int SourceCount;
+
+            /// <summary>
+            /// Flattened source i came from this index of the component's list. Sources with a null
+            /// transform are dropped during flatten, so the two orderings are not interchangeable —
+            /// the parent constraint's per-source offset arrays are indexed through this.
+            /// </summary>
+            public int[] SourceMap = Array.Empty<int>();
+
+            /// <summary>
+            /// The world-up reference this slot's WorldUpIndex was resolved against. Assigning or
+            /// swapping worldUpObject at runtime is a structural change — the index is only
+            /// resolvable while the intern table is being built — so it is diffed every frame.
+            /// </summary>
+            public Transform WorldUpObject;
+        }
+
+        private static readonly List<Registration> sRegistrations = new List<Registration>();
+        private static readonly Dictionary<BasisConstraintBase, Registration> sLookup =
+            new Dictionary<BasisConstraintBase, Registration>();
+
+        /// <summary>Interning table for every transform the solve touches, mapped to its row index.</summary>
+        private static readonly Dictionary<Transform, int> sTransformLookup = new Dictionary<Transform, int>();
+        private static readonly List<Transform> sTrackedScratch = new List<Transform>();
+        private static readonly List<Transform> sTargetScratch = new List<Transform>();
+        /// <summary>Target transform to its row in the results/write arrays; deduplicates stacked constraints.</summary>
+        private static readonly Dictionary<Transform, int> sTargetRowLookup = new Dictionary<Transform, int>();
+        private static readonly List<int> sOrderScratch = new List<int>();
+        private static readonly List<int> sDepthScratch = new List<int>();
+        private static readonly List<int> sSourceMapScratch = new List<int>();
+        /// <summary>Transform row → the slots that drive it, for the dependency sort.</summary>
+        private static readonly Dictionary<int, List<int>> sProducers = new Dictionary<int, List<int>>();
+        private static readonly List<List<int>> sConsumers = new List<List<int>>();
+        private static readonly List<int> sInDegree = new List<int>();
+        private static readonly List<bool> sEmitted = new List<bool>();
+        private static readonly List<BasisConstraintSourceEntry> sSourceScratch =
+            new List<BasisConstraintSourceEntry>();
+
+        private static NativeList<BasisConstraintSlot> sSlots;
+        private static NativeList<BasisConstraintSource> sSources;
+        private static NativeList<BasisConstraintWorld> sWorld;
+        private static NativeList<BasisConstraintTransform> sLocal;
+        private static NativeList<BasisConstraintResult> sResults;
+        private static NativeList<int> sOrder;
+        private static NativeList<int> sTargetRow;
+        private static TransformAccessArray sTracked;
+        private static TransformAccessArray sTargets;
+
+        private static JobHandle sPending;
+        private static bool sInitialized;
+        private static bool sDirty;
+        private static bool sSubscribed;
+
+        /// <summary>Number of constraints currently solved each frame.</summary>
+        public static int SlotCount => sInitialized ? sSlots.Length : 0;
+
+        /// <summary>Distinct transforms sampled each frame (targets, sources, up objects, parents).</summary>
+        public static int TrackedTransformCount => sInitialized ? sTracked.length : 0;
+
+        /// <summary>
+        /// Installs the cross-assembly subscription and clears anything a disabled domain reload
+        /// left behind. Mandatory: with reload disabled, statics survive exiting play mode, and a
+        /// leftover <see cref="NativeList{T}"/> would both leak and be handed to the next session.
+        /// </summary>
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        private static void ResetStatics()
+        {
+            Dispose();
+
+            sRegistrations.Clear();
+            sLookup.Clear();
+            sTransformLookup.Clear();
+            sDirty = false;
+            sPending = default;
+
+            if (!sSubscribed)
+            {
+                BasisConstraintBase.ActiveStateChanged += OnActiveStateChanged;
+                BasisConstraintBase.StructureChanged += OnStructureChanged;
+                sSubscribed = true;
+            }
+        }
+
+        public static void Initialize(int initialCapacity = 0)
+        {
+            if (sInitialized)
+            {
+                return;
+            }
+            sSlots = new NativeList<BasisConstraintSlot>(initialCapacity, Allocator.Persistent);
+            sSources = new NativeList<BasisConstraintSource>(initialCapacity, Allocator.Persistent);
+            sWorld = new NativeList<BasisConstraintWorld>(initialCapacity, Allocator.Persistent);
+            sLocal = new NativeList<BasisConstraintTransform>(initialCapacity, Allocator.Persistent);
+            sResults = new NativeList<BasisConstraintResult>(initialCapacity, Allocator.Persistent);
+            sOrder = new NativeList<int>(initialCapacity, Allocator.Persistent);
+            sTargetRow = new NativeList<int>(initialCapacity, Allocator.Persistent);
+            sTracked = new TransformAccessArray(math.max(1, initialCapacity));
+            sTargets = new TransformAccessArray(math.max(1, initialCapacity));
+            sInitialized = true;
+        }
+
+        public static void Dispose()
+        {
+            if (!sInitialized)
+            {
+                return;
+            }
+            sPending.Complete();
+            sPending = default;
+
+            if (sSlots.IsCreated) sSlots.Dispose();
+            if (sSources.IsCreated) sSources.Dispose();
+            if (sWorld.IsCreated) sWorld.Dispose();
+            if (sLocal.IsCreated) sLocal.Dispose();
+            if (sResults.IsCreated) sResults.Dispose();
+            if (sOrder.IsCreated) sOrder.Dispose();
+            if (sTargetRow.IsCreated) sTargetRow.Dispose();
+            if (sTracked.isCreated) sTracked.Dispose();
+            if (sTargets.isCreated) sTargets.Dispose();
+
+            // Drop the managed side too. Otherwise a component enabling after teardown re-enters
+            // Register, re-Initializes fresh persistent containers that nothing will ever schedule
+            // or dispose, and holds references to destroyed objects until the next domain reset.
+            sRegistrations.Clear();
+            sLookup.Clear();
+            sTransformLookup.Clear();
+            sTargetRowLookup.Clear();
+            sTrackedScratch.Clear();
+            sTargetScratch.Clear();
+            sOrderScratch.Clear();
+            sDepthScratch.Clear();
+            sSourceScratch.Clear();
+            sProducers.Clear();
+            sConsumers.Clear();
+            sDirty = false;
+
+            sInitialized = false;
+        }
+
+        private static void OnActiveStateChanged(BasisConstraintBase component, bool active)
+        {
+            if (active)
+            {
+                Register(component);
+            }
+            else
+            {
+                Unregister(component);
+            }
+        }
+
+        private static void OnStructureChanged(BasisConstraintBase component)
+        {
+            if (component != null && sLookup.ContainsKey(component))
+            {
+                sDirty = true;
+            }
+        }
+
+        public static void Register(BasisConstraintBase component)
+        {
+            if (component == null)
+            {
+                return;
+            }
+            if (!sInitialized)
+            {
+                Initialize();
+            }
+            if (sLookup.ContainsKey(component))
+            {
+                return;
+            }
+
+            Registration registration = new Registration { Component = component };
+            sRegistrations.Add(registration);
+            sLookup[component] = registration;
+            sDirty = true;
+        }
+
+        public static void Unregister(BasisConstraintBase component)
+        {
+            if (component == null || !sLookup.TryGetValue(component, out Registration registration))
+            {
+                return;
+            }
+            sLookup.Remove(component);
+            sRegistrations.Remove(registration);
+            sDirty = true;
+        }
+
+        /// <summary>
+        /// Samples, solves and writes every constraint. Call once per frame after the pose the
+        /// constraints should read is final — after IK and authored motion, before jiggle samples
+        /// the bones — and pair it with <see cref="Complete"/> in the same frame: the returned
+        /// handle owns the transform arrays until then, so touching a constrained transform on the
+        /// main thread in between is a race.
+        /// </summary>
+        public static JobHandle Schedule()
+        {
+            if (!sInitialized)
+            {
+                return default;
+            }
+            // Never mutate the containers under a live job: a frame that early-returns below would
+            // otherwise leave sPending in flight while the next Rebuild clears everything.
+            CompletePending();
+
+            // A pending rebuild is honoured even with no registrations left, so unregistering the
+            // last constraint actually clears the tables instead of stranding stale slots.
+            // A component destroyed without an OnDisable (scene teardown, DestroyImmediate) has to
+            // be caught here too: its transform would otherwise still be in the write array.
+            if (sDirty || HasDestroyedRegistration() || HasDesyncedTransforms())
+            {
+                Rebuild();
+            }
+            if (sSlots.Length == 0)
+            {
+                return default;
+            }
+
+            RefreshDynamicState();
+
+            JobHandle read = new BasisConstraintReadJob
+            {
+                World = sWorld.AsArray(),
+                Local = sLocal.AsArray(),
+            }.Schedule(sTracked);
+
+            JobHandle solve = new BasisConstraintSolveJob
+            {
+                Slots = sSlots.AsArray(),
+                Sources = sSources.AsArray(),
+                Local = sLocal.AsArray(),
+                Order = sOrder.AsArray(),
+                TargetRow = sTargetRow.AsArray(),
+                World = sWorld.AsArray(),
+                Results = sResults.AsArray(),
+            }.Schedule(read);
+
+            sPending = new BasisConstraintWriteJob
+            {
+                Results = sResults.AsArray(),
+            }.Schedule(sTargets, solve);
+
+            return sPending;
+        }
+
+        public static void Complete(JobHandle handle)
+        {
+            handle.Complete();
+            // Only retire the tracked handle if this is it; a caller completing some unrelated
+            // handle must not convince the system that its own solve has landed.
+            if (handle.Equals(sPending))
+            {
+                sPending = default;
+            }
+        }
+
+        /// <summary>
+        /// Cheap per-frame sweep for components destroyed behind the system's back. The Unity
+        /// fake-null check is the whole cost, over a list that is tens of entries in practice.
+        /// </summary>
+        private static bool HasDestroyedRegistration()
+        {
+            for (int Index = 0; Index < sRegistrations.Count; Index++)
+            {
+                if (sRegistrations[Index].Component == null)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// A TransformAccessArray silently drops destroyed transforms and compacts, which desyncs it
+        /// from the parallel native arrays — the read job would then sample shifted rows and the
+        /// write job would push solved poses onto the wrong objects, with no exception to show for
+        /// it. Length disagreement is the tell; rebuilding resyncs.
+        /// </summary>
+        private static bool HasDesyncedTransforms()
+        {
+            return sTracked.length != sWorld.Length || sTargets.length != sResults.Length;
+        }
+
+        /// <summary>Completes any in-flight solve. Safe to call when nothing is scheduled.</summary>
+        public static void CompletePending()
+        {
+            sPending.Complete();
+            sPending = default;
+        }
+
+        /// <summary>
+        /// Rebuilds the flattened tables from the live component set. Prunes destroyed components,
+        /// interns every transform once, and topologically orders the slots so whatever drives a
+        /// constraint resolves before it.
+        /// </summary>
+        private static void Rebuild()
+        {
+            CompletePending();
+
+            sSlots.Clear();
+            sSources.Clear();
+            sWorld.Clear();
+            sLocal.Clear();
+            sOrder.Clear();
+            sTargetRow.Clear();
+            sTransformLookup.Clear();
+            sTrackedScratch.Clear();
+            sTargetScratch.Clear();
+            sTargetRowLookup.Clear();
+            sOrderScratch.Clear();
+            sDepthScratch.Clear();
+
+            for (int Index = sRegistrations.Count - 1; Index >= 0; Index--)
+            {
+                // Destroyed without an OnDisable (scene teardown) leaves a fake-null behind.
+                if (sRegistrations[Index].Component == null)
+                {
+                    sRegistrations.RemoveAt(Index);
+                }
+            }
+
+            for (int Index = 0; Index < sRegistrations.Count; Index++)
+            {
+                Registration registration = sRegistrations[Index];
+                BasisConstraintBase component = registration.Component;
+                Transform target = component.transform;
+
+                int targetIndex = InternTransform(target);
+                int parentIndex = target.parent != null ? InternTransform(target.parent) : -1;
+
+                // ParentIndex rides in the local-pose row; the sample job preserves it.
+                BasisConstraintTransform local = sLocal[targetIndex];
+                local.ParentIndex = parentIndex;
+                sLocal[targetIndex] = local;
+
+                registration.SlotIndex = sSlots.Length;
+                registration.SourceStart = sSources.Length;
+
+                component.GetSources(sSourceScratch);
+                sSourceMapScratch.Clear();
+                for (int SourceIndex = 0; SourceIndex < sSourceScratch.Count; SourceIndex++)
+                {
+                    BasisConstraintSourceEntry entry = sSourceScratch[SourceIndex];
+                    if (entry.sourceTransform == null)
+                    {
+                        continue;
+                    }
+                    sSources.Add(new BasisConstraintSource
+                    {
+                        TransformIndex = InternTransform(entry.sourceTransform),
+                        Weight = math.max(0f, entry.weight),
+                        PositionOffset = float3.zero,
+                        RotationOffset = quaternion.identity,
+                    });
+                    sSourceMapScratch.Add(SourceIndex);
+                }
+                registration.SourceCount = sSourceMapScratch.Count;
+                registration.SourceMap = sSourceMapScratch.ToArray();
+
+                BasisConstraintSlot slot = BasisConstraintDefaults.Identity(ToKind(component.constraintType));
+                slot.TargetIndex = targetIndex;
+                slot.SourceStart = registration.SourceStart;
+                slot.SourceCount = registration.SourceCount;
+                slot.Depth = ToDepth(target);
+                registration.WorldUpObject = GetWorldUpObject(component);
+                slot.WorldUpIndex = registration.WorldUpObject != null
+                    ? InternTransform(registration.WorldUpObject)
+                    : -1;
+                FillScalarState(component, ref slot);
+                sSlots.Add(slot);
+                FillSourceState(component, registration);
+
+                // Several constraints may share one target (position + rotation is routine); they
+                // all write through a single row so the parallel write job never doubles up.
+                if (!sTargetRowLookup.TryGetValue(target, out int targetRow))
+                {
+                    targetRow = sTargetScratch.Count;
+                    sTargetRowLookup[target] = targetRow;
+                    sTargetScratch.Add(target);
+                }
+                sTargetRow.Add(targetRow);
+
+                sOrderScratch.Add(registration.SlotIndex);
+                sDepthScratch.Add(slot.Depth);
+            }
+
+            BuildSolveOrder();
+            for (int Index = 0; Index < sOrderScratch.Count; Index++)
+            {
+                sOrder.Add(sOrderScratch[Index]);
+            }
+
+            sResults.Resize(sTargetScratch.Count, NativeArrayOptions.ClearMemory);
+            sTracked.SetTransforms(sTrackedScratch.ToArray());
+            sTargets.SetTransforms(sTargetScratch.ToArray());
+
+            sDirty = false;
+        }
+
+        /// <summary>
+        /// Orders the solve so a constraint always runs after whatever drives it. Hierarchy depth
+        /// alone is not enough: a root-level prop constrained to a deep, itself-constrained hand
+        /// bone is shallower than its own dependency, and would read a stale pose forever. So this
+        /// is a real topological sort over source→target edges, with depth only as the tie-break
+        /// among slots that are equally ready (which keeps sibling order stable and natural).
+        ///
+        /// A cycle has no valid order; rather than drop those constraints, it is broken at the
+        /// shallowest member, which costs that one slot a frame of lag.
+        /// </summary>
+        private static void BuildSolveOrder()
+        {
+            int count = sSlots.Length;
+
+            // Which slots drive each transform row. Several may drive one row (stacked constraints).
+            sProducers.Clear();
+            for (int Index = 0; Index < count; Index++)
+            {
+                int targetIndex = sSlots[Index].TargetIndex;
+                if (targetIndex < 0)
+                {
+                    continue;
+                }
+                if (!sProducers.TryGetValue(targetIndex, out List<int> producers))
+                {
+                    producers = new List<int>();
+                    sProducers[targetIndex] = producers;
+                }
+                producers.Add(Index);
+            }
+
+            sConsumers.Clear();
+            sInDegree.Clear();
+            sEmitted.Clear();
+            for (int Index = 0; Index < count; Index++)
+            {
+                sConsumers.Add(new List<int>());
+                sInDegree.Add(0);
+                sEmitted.Add(false);
+            }
+
+            for (int Index = 0; Index < count; Index++)
+            {
+                BasisConstraintSlot slot = sSlots[Index];
+                for (int SourceIndex = 0; SourceIndex < slot.SourceCount; SourceIndex++)
+                {
+                    int transformIndex = sSources[slot.SourceStart + SourceIndex].TransformIndex;
+                    if (transformIndex < 0 || !sProducers.TryGetValue(transformIndex, out List<int> producers))
+                    {
+                        continue;
+                    }
+                    for (int ProducerIndex = 0; ProducerIndex < producers.Count; ProducerIndex++)
+                    {
+                        int producer = producers[ProducerIndex];
+                        if (producer == Index)
+                        {
+                            // A constraint sourcing its own target imposes no ordering on itself.
+                            continue;
+                        }
+                        sConsumers[producer].Add(Index);
+                        sInDegree[Index]++;
+                    }
+                }
+            }
+
+            sOrderScratch.Clear();
+            for (int Step = 0; Step < count; Step++)
+            {
+                int chosen = PickShallowest(count, readyOnly: true);
+                if (chosen < 0)
+                {
+                    chosen = PickShallowest(count, readyOnly: false);
+                }
+                if (chosen < 0)
+                {
+                    break;
+                }
+
+                sEmitted[chosen] = true;
+                sOrderScratch.Add(chosen);
+
+                List<int> consumers = sConsumers[chosen];
+                for (int ConsumerIndex = 0; ConsumerIndex < consumers.Count; ConsumerIndex++)
+                {
+                    sInDegree[consumers[ConsumerIndex]]--;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Shallowest un-emitted slot, optionally restricted to those with no unmet dependency.
+        /// In-degree is compared with &gt; 0 rather than != 0 so a cycle broken above, which can push
+        /// a counter negative, still leaves its dependents selectable.
+        /// </summary>
+        private static int PickShallowest(int count, bool readyOnly)
+        {
+            int chosen = -1;
+            for (int Index = 0; Index < count; Index++)
+            {
+                if (sEmitted[Index] || (readyOnly && sInDegree[Index] > 0))
+                {
+                    continue;
+                }
+                if (chosen < 0 || sDepthScratch[Index] < sDepthScratch[chosen])
+                {
+                    chosen = Index;
+                }
+            }
+            return chosen;
+        }
+
+        /// <summary>
+        /// Interns a transform, growing the per-transform world/local rows to match. Returns the
+        /// row index every slot and source refers to.
+        /// </summary>
+        private static int InternTransform(Transform transform)
+        {
+            if (sTransformLookup.TryGetValue(transform, out int existing))
+            {
+                return existing;
+            }
+            int index = sTrackedScratch.Count;
+            sTransformLookup[transform] = index;
+            sTrackedScratch.Add(transform);
+
+            sWorld.Resize(index + 1, NativeArrayOptions.ClearMemory);
+            sLocal.Resize(index + 1, NativeArrayOptions.ClearMemory);
+            sLocal[index] = new BasisConstraintTransform
+            {
+                LocalPosition = float3.zero,
+                LocalRotation = quaternion.identity,
+                LocalScale = new float3(1f, 1f, 1f),
+                ParentIndex = -1,
+            };
+            return index;
+        }
+
+        private static Transform GetWorldUpObject(BasisConstraintBase component)
+        {
+            return component switch
+            {
+                BasisAimConstraint aim => aim.worldUpObject,
+                BasisLookAtConstraint lookAt => lookAt.worldUpObject,
+                _ => null,
+            };
+        }
+
+        /// <summary>
+        /// Re-reads the cheap per-frame state — weights, offsets, masks, rest poses, source weights
+        /// — straight off the components, so inspector and script edits take effect the same frame
+        /// without a rebuild.
+        /// </summary>
+        private static void RefreshDynamicState()
+        {
+            for (int Index = 0; Index < sRegistrations.Count; Index++)
+            {
+                Registration registration = sRegistrations[Index];
+                BasisConstraintBase component = registration.Component;
+                if (component == null)
+                {
+                    sDirty = true;
+                    continue;
+                }
+
+                // Swapping or assigning worldUpObject only takes effect through a rebuild, and
+                // nothing on the components marks it dirty, so diff it here.
+                if (GetWorldUpObject(component) != registration.WorldUpObject)
+                {
+                    sDirty = true;
+                }
+
+                BasisConstraintSlot slot = sSlots[registration.SlotIndex];
+                FillScalarState(component, ref slot);
+                sSlots[registration.SlotIndex] = slot;
+                FillSourceState(component, registration);
+            }
+        }
+
+        /// <summary>
+        /// Copies every non-structural field off the component into its slot. Shared by the rebuild
+        /// and the per-frame refresh so the two can never drift apart.
+        /// </summary>
+        private static void FillScalarState(BasisConstraintBase component, ref BasisConstraintSlot slot)
+        {
+            slot.Weight = Mathf.Clamp01(component.weight);
+            slot.Active = (byte)(component.constraintActive ? 1 : 0);
+            slot.Locked = (byte)(component.locked ? 1 : 0);
+
+            switch (component)
+            {
+                case BasisPositionConstraint position:
+                    slot.TranslationAtRest = position.translationAtRest;
+                    slot.TranslationOffset = position.translationOffset;
+                    slot.TranslationMask = (byte)position.translationAxis;
+                    break;
+
+                case BasisRotationConstraint rotation:
+                    slot.RotationAtRest = ToQuaternion(rotation.rotationAtRest);
+                    slot.RotationOffset = ToQuaternion(rotation.rotationOffset);
+                    slot.RotationMask = (byte)rotation.rotationAxis;
+                    break;
+
+                case BasisScaleConstraint scale:
+                    slot.ScaleAtRest = scale.scaleAtRest;
+                    slot.ScaleOffset = scale.scaleOffset;
+                    slot.ScaleMask = (byte)scale.scalingAxis;
+                    break;
+
+                case BasisParentConstraint parent:
+                    slot.TranslationAtRest = parent.translationAtRest;
+                    slot.RotationAtRest = ToQuaternion(parent.rotationAtRest);
+                    slot.TranslationOffset = float3.zero;
+                    slot.RotationOffset = quaternion.identity;
+                    slot.TranslationMask = (byte)parent.translationAxis;
+                    slot.RotationMask = (byte)parent.rotationAxis;
+                    break;
+
+                case BasisAimConstraint aim:
+                    slot.RotationAtRest = ToQuaternion(aim.rotationAtRest);
+                    slot.RotationOffset = ToQuaternion(aim.rotationOffset);
+                    slot.RotationMask = (byte)aim.rotationAxis;
+                    slot.AimVector = aim.aimVector;
+                    slot.UpVector = aim.upVector;
+                    slot.WorldUpVector = aim.worldUpVector;
+                    slot.WorldUpKind = (BasisWorldUpKind)aim.worldUpType;
+                    slot.UseUpObject = (byte)(aim.worldUpObject != null ? 1 : 0);
+                    slot.Roll = 0f;
+                    break;
+
+                case BasisLookAtConstraint lookAt:
+                    slot.RotationAtRest = ToQuaternion(lookAt.rotationAtRest);
+                    slot.RotationOffset = ToQuaternion(lookAt.rotationOffset);
+                    slot.RotationMask = (byte)BasisConstraintAxis.All;
+                    // Look-at is an aim constraint pinned to Unity's convention: +Z at the target,
+                    // +Y rolled up, with roll layered on top of the resolved basis.
+                    slot.AimVector = new float3(0f, 0f, 1f);
+                    slot.UpVector = new float3(0f, 1f, 0f);
+                    slot.WorldUpVector = new float3(0f, 1f, 0f);
+                    slot.WorldUpKind = lookAt.useUpObject && lookAt.worldUpObject != null
+                        ? BasisWorldUpKind.ObjectUp
+                        : BasisWorldUpKind.SceneUp;
+                    slot.UseUpObject = (byte)(lookAt.useUpObject && lookAt.worldUpObject != null ? 1 : 0);
+                    slot.Roll = lookAt.roll;
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Refreshes the flattened source rows: weights for every kind, plus the per-source pose
+        /// offsets only the parent constraint carries.
+        /// </summary>
+        private static void FillSourceState(BasisConstraintBase component, Registration registration)
+        {
+            if (registration.SourceCount == 0)
+            {
+                return;
+            }
+
+            BasisParentConstraint parent = component as BasisParentConstraint;
+            for (int Index = 0; Index < registration.SourceCount; Index++)
+            {
+                int flattened = registration.SourceStart + Index;
+                int authored = registration.SourceMap[Index];
+
+                BasisConstraintSource source = sSources[flattened];
+                source.Weight = math.max(0f, component.GetSource(authored).weight);
+
+                if (parent != null)
+                {
+                    source.PositionOffset = authored < parent.translationOffsets.Length
+                        ? parent.translationOffsets[authored]
+                        : Vector3.zero;
+                    source.RotationOffset = authored < parent.rotationOffsets.Length
+                        ? ToQuaternion(parent.rotationOffsets[authored])
+                        : quaternion.identity;
+                }
+
+                sSources[flattened] = source;
+            }
+        }
+
+        /// <summary>
+        /// The SDK and framework kind enums are declared in lockstep; the cast is the mapping.
+        /// </summary>
+        private static BasisConstraintKind ToKind(BasisConstraintType type) => (BasisConstraintKind)type;
+
+        private static int ToDepth(Transform transform)
+        {
+            int depth = 0;
+            Transform cursor = transform.parent;
+            while (cursor != null)
+            {
+                depth++;
+                cursor = cursor.parent;
+            }
+            return depth;
+        }
+
+        private static quaternion ToQuaternion(Vector3 eulerDegrees) => Quaternion.Euler(eulerDegrees);
+    }
+}

--- a/Basis/Packages/com.basis.framework/Constraints/BasisConstraintSystem.cs.meta
+++ b/Basis/Packages/com.basis.framework/Constraints/BasisConstraintSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c7b3368bc97d48e85f0a2484d33fdcde

--- a/Basis/Packages/com.basis.framework/Tests/Editor/Constraints.meta
+++ b/Basis/Packages/com.basis.framework/Tests/Editor/Constraints.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 49a55efb89b7802c335ac979aea9b2d1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Basis/Packages/com.basis.framework/Tests/Editor/Constraints/Basis.Framework.Constraints.Tests.asmdef
+++ b/Basis/Packages/com.basis.framework/Tests/Editor/Constraints/Basis.Framework.Constraints.Tests.asmdef
@@ -1,0 +1,27 @@
+{
+    "name": "Basis.Framework.Constraints.Tests",
+    "rootNamespace": "",
+    "references": [
+        "Basis Framework",
+        "BasisSDK",
+        "Unity.Collections",
+        "Unity.Mathematics",
+        "Unity.Burst",
+        "UnityEngine.TestRunner"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Basis/Packages/com.basis.framework/Tests/Editor/Constraints/Basis.Framework.Constraints.Tests.asmdef.meta
+++ b/Basis/Packages/com.basis.framework/Tests/Editor/Constraints/Basis.Framework.Constraints.Tests.asmdef.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f301c208476792c9503c8110685780dc

--- a/Basis/Packages/com.basis.framework/Tests/Editor/Constraints/BasisConstraintSolveTests.cs
+++ b/Basis/Packages/com.basis.framework/Tests/Editor/Constraints/BasisConstraintSolveTests.cs
@@ -1,0 +1,325 @@
+using System.Collections.Generic;
+using Basis.Scripts.BasisSdk.Constraints;
+using Basis.Scripts.Constraints;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Basis.Tests.Constraints
+{
+    /// <summary>
+    /// End-to-end cover for the batched constraint solver: real components, real transforms, the
+    /// real sample/solve/write jobs. Each case asserts against the transform after a full
+    /// <see cref="BasisConstraintSystem.Schedule"/> / <see cref="BasisConstraintSystem.Complete"/>
+    /// pair, so a regression anywhere in the flatten → solve → write chain shows up here rather
+    /// than only in a scene.
+    ///
+    /// Registration is driven explicitly instead of through <c>OnEnable</c>: the system installs its
+    /// cross-assembly subscription from a <c>[RuntimeInitializeOnLoadMethod]</c>, which never runs in
+    /// an EditMode test. <see cref="BasisConstraintSystem.Register"/> is idempotent, so these tests
+    /// behave identically if a prior play session already wired the subscription up.
+    /// </summary>
+    public sealed class BasisConstraintSolveTests
+    {
+        const float Tolerance = 1e-3f;
+
+        readonly List<GameObject> spawned = new List<GameObject>();
+        readonly List<BasisConstraintBase> registered = new List<BasisConstraintBase>();
+
+        [TearDown]
+        public void TearDown()
+        {
+            for (int Index = 0; Index < registered.Count; Index++)
+            {
+                BasisConstraintSystem.Unregister(registered[Index]);
+            }
+            registered.Clear();
+
+            BasisConstraintSystem.Dispose();
+
+            for (int Index = 0; Index < spawned.Count; Index++)
+            {
+                if (spawned[Index] != null)
+                {
+                    Object.DestroyImmediate(spawned[Index]);
+                }
+            }
+            spawned.Clear();
+        }
+
+        Transform NewTransform(string name, Vector3 position, Quaternion rotation, Transform parent = null)
+        {
+            GameObject go = new GameObject(name);
+            spawned.Add(go);
+            go.transform.SetParent(parent, false);
+            go.transform.SetPositionAndRotation(position, rotation);
+            return go.transform;
+        }
+
+        T Constrain<T>(Transform target, params Transform[] sources) where T : BasisConstraintBase
+        {
+            T constraint = target.gameObject.AddComponent<T>();
+            for (int Index = 0; Index < sources.Length; Index++)
+            {
+                constraint.AddSource(new BasisConstraintSourceEntry(sources[Index], 1f));
+            }
+            BasisConstraintSystem.Register(constraint);
+            registered.Add(constraint);
+            return constraint;
+        }
+
+        static void Solve()
+        {
+            BasisConstraintSystem.Complete(BasisConstraintSystem.Schedule());
+        }
+
+        static void AssertVector(Vector3 expected, Vector3 actual, string what)
+        {
+            Assert.AreEqual(expected.x, actual.x, Tolerance, $"{what}.x");
+            Assert.AreEqual(expected.y, actual.y, Tolerance, $"{what}.y");
+            Assert.AreEqual(expected.z, actual.z, Tolerance, $"{what}.z");
+        }
+
+        [Test]
+        public void PositionConstraintLandsOnItsSource()
+        {
+            Transform source = NewTransform("Source", new Vector3(1f, 2f, 3f), Quaternion.identity);
+            Transform target = NewTransform("Target", Vector3.zero, Quaternion.identity);
+            Constrain<BasisPositionConstraint>(target, source);
+
+            Solve();
+
+            AssertVector(new Vector3(1f, 2f, 3f), target.position, "position");
+        }
+
+        [Test]
+        public void PositionConstraintBlendsHalfwayAtHalfWeight()
+        {
+            Transform source = NewTransform("Source", new Vector3(1f, 2f, 3f), Quaternion.identity);
+            Transform target = NewTransform("Target", Vector3.zero, Quaternion.identity);
+            BasisPositionConstraint constraint = Constrain<BasisPositionConstraint>(target, source);
+            constraint.translationAtRest = Vector3.zero;
+            constraint.weight = 0.5f;
+
+            Solve();
+
+            AssertVector(new Vector3(0.5f, 1f, 1.5f), target.position, "position");
+        }
+
+        [Test]
+        public void TwoEqualSourcesBlendToTheirMidpoint()
+        {
+            Transform left = NewTransform("Left", new Vector3(-2f, 0f, 0f), Quaternion.identity);
+            Transform right = NewTransform("Right", new Vector3(4f, 0f, 0f), Quaternion.identity);
+            Transform target = NewTransform("Target", Vector3.zero, Quaternion.identity);
+            Constrain<BasisPositionConstraint>(target, left, right);
+
+            Solve();
+
+            AssertVector(new Vector3(1f, 0f, 0f), target.position, "position");
+        }
+
+        [Test]
+        public void MaskedAxesAreLeftUntouched()
+        {
+            Transform source = NewTransform("Source", new Vector3(1f, 2f, 3f), Quaternion.identity);
+            Transform target = NewTransform("Target", new Vector3(0f, 7f, 9f), Quaternion.identity);
+            BasisPositionConstraint constraint = Constrain<BasisPositionConstraint>(target, source);
+            constraint.translationAxis = BasisConstraintAxes.X;
+
+            Solve();
+
+            // X follows the source; Y and Z keep the pose the transform arrived with, and the weight
+            // blend must not drag them toward translationAtRest either.
+            AssertVector(new Vector3(1f, 7f, 9f), target.position, "position");
+        }
+
+        [Test]
+        public void ZeroWeightedSourcesWriteNothing()
+        {
+            Transform source = NewTransform("Source", new Vector3(1f, 2f, 3f), Quaternion.identity);
+            Transform target = NewTransform("Target", new Vector3(9f, 9f, 9f), Quaternion.identity);
+            BasisPositionConstraint constraint = Constrain<BasisPositionConstraint>(target, source);
+            constraint.SetSource(0, new BasisConstraintSourceEntry(source, 0f));
+
+            Solve();
+
+            // Nothing drives the constraint, so it must leave the transform alone rather than snap
+            // it to the at-rest pose.
+            AssertVector(new Vector3(9f, 9f, 9f), target.position, "position");
+        }
+
+        [Test]
+        public void InactiveConstraintWritesNothing()
+        {
+            Transform source = NewTransform("Source", new Vector3(1f, 2f, 3f), Quaternion.identity);
+            Transform target = NewTransform("Target", new Vector3(5f, 5f, 5f), Quaternion.identity);
+            BasisPositionConstraint constraint = Constrain<BasisPositionConstraint>(target, source);
+            constraint.constraintActive = false;
+
+            Solve();
+
+            AssertVector(new Vector3(5f, 5f, 5f), target.position, "position");
+        }
+
+        [Test]
+        public void RotationConstraintMatchesItsSource()
+        {
+            Quaternion sourceRotation = Quaternion.Euler(0f, 90f, 0f);
+            Transform source = NewTransform("Source", Vector3.zero, sourceRotation);
+            Transform target = NewTransform("Target", Vector3.zero, Quaternion.identity);
+            Constrain<BasisRotationConstraint>(target, source);
+
+            Solve();
+
+            Assert.Less(Quaternion.Angle(sourceRotation, target.rotation), 0.1f, "rotation");
+        }
+
+        [Test]
+        public void ScaleConstraintMatchesItsSource()
+        {
+            Transform source = NewTransform("Source", Vector3.zero, Quaternion.identity);
+            source.localScale = new Vector3(2f, 3f, 4f);
+            Transform target = NewTransform("Target", Vector3.zero, Quaternion.identity);
+            Constrain<BasisScaleConstraint>(target, source);
+
+            Solve();
+
+            AssertVector(new Vector3(2f, 3f, 4f), target.localScale, "localScale");
+        }
+
+        [Test]
+        public void ParentConstraintAppliesItsPerSourceOffset()
+        {
+            Transform source = NewTransform("Source", new Vector3(5f, 0f, 0f), Quaternion.identity);
+            Transform target = NewTransform("Target", Vector3.zero, Quaternion.identity);
+            BasisParentConstraint constraint = Constrain<BasisParentConstraint>(target, source);
+            constraint.translationOffsets[0] = new Vector3(1f, 0f, 0f);
+
+            Solve();
+
+            AssertVector(new Vector3(6f, 0f, 0f), target.position, "position");
+        }
+
+        [Test]
+        public void LookAtConstraintPointsForwardAtItsSource()
+        {
+            Transform source = NewTransform("Source", new Vector3(5f, 0f, 0f), Quaternion.identity);
+            Transform target = NewTransform("Target", Vector3.zero, Quaternion.identity);
+            Constrain<BasisLookAtConstraint>(target, source);
+
+            Solve();
+
+            AssertVector(new Vector3(1f, 0f, 0f), target.forward, "forward");
+        }
+
+        [Test]
+        public void AimConstraintPointsItsChosenAxisAtTheSource()
+        {
+            Transform source = NewTransform("Source", new Vector3(0f, 0f, 5f), Quaternion.identity);
+            Transform target = NewTransform("Target", Vector3.zero, Quaternion.identity);
+            BasisAimConstraint constraint = Constrain<BasisAimConstraint>(target, source);
+            constraint.aimVector = Vector3.right;
+
+            Solve();
+
+            // +X is the aimed axis, so it should end up pointing at the source, not +Z.
+            AssertVector(new Vector3(0f, 0f, 1f), target.right, "right");
+        }
+
+        [Test]
+        public void DeeperConstraintReadsTheShallowerOneSolvedThisFrame()
+        {
+            // A drives B (depth 1); B drives C (depth 2). Depth ordering must solve B first and
+            // refresh its world row, so C lands on A's position in the same frame rather than
+            // trailing by one.
+            Transform root = NewTransform("Root", Vector3.zero, Quaternion.identity);
+            Transform anchor = NewTransform("Anchor", new Vector3(4f, 0f, 0f), Quaternion.identity);
+
+            Transform b = NewTransform("B", Vector3.zero, Quaternion.identity, root);
+            Transform intermediate = NewTransform("Intermediate", Vector3.zero, Quaternion.identity, root);
+            Transform c = NewTransform("C", Vector3.zero, Quaternion.identity, intermediate);
+
+            // Registered deepest-first on purpose: only the depth sort can put them right.
+            Constrain<BasisPositionConstraint>(c, b);
+            Constrain<BasisPositionConstraint>(b, anchor);
+
+            Solve();
+
+            AssertVector(new Vector3(4f, 0f, 0f), b.position, "b.position");
+            AssertVector(new Vector3(4f, 0f, 0f), c.position, "c.position");
+        }
+
+        [Test]
+        public void ConstraintUnderAMovedParentSolvesInLocalSpace()
+        {
+            // The write path is local-space, so a target whose parent is itself offset and rotated
+            // must still land on the source in world space.
+            Transform parent = NewTransform("Parent", new Vector3(10f, 0f, 0f), Quaternion.Euler(0f, 90f, 0f));
+            Transform source = NewTransform("Source", new Vector3(1f, 2f, 3f), Quaternion.identity);
+            Transform target = NewTransform("Target", Vector3.zero, Quaternion.identity, parent);
+            Constrain<BasisPositionConstraint>(target, source);
+
+            Solve();
+
+            AssertVector(new Vector3(1f, 2f, 3f), target.position, "position");
+        }
+
+        [Test]
+        public void ShallowConstraintStillSeesADeepDependencySolvedThisFrame()
+        {
+            // The case hierarchy depth alone gets wrong: a root-level object (depth 0) sourcing a
+            // deep bone (depth 3) that is itself constrained. Sorting by depth would run the shallow
+            // one first and leave it a frame behind forever; the dependency sort has to override it.
+            Transform anchor = NewTransform("Anchor", new Vector3(7f, 0f, 0f), Quaternion.identity);
+
+            Transform a = NewTransform("A", Vector3.zero, Quaternion.identity);
+            Transform b = NewTransform("B", Vector3.zero, Quaternion.identity, a);
+            Transform deepBone = NewTransform("DeepBone", Vector3.zero, Quaternion.identity, b);
+
+            Transform prop = NewTransform("Prop", Vector3.zero, Quaternion.identity);
+
+            Constrain<BasisPositionConstraint>(prop, deepBone);
+            Constrain<BasisPositionConstraint>(deepBone, anchor);
+
+            Solve();
+
+            AssertVector(new Vector3(7f, 0f, 0f), deepBone.position, "deepBone.position");
+            AssertVector(new Vector3(7f, 0f, 0f), prop.position, "prop.position");
+        }
+
+        [Test]
+        public void StackedPositionAndRotationConstraintsBothApply()
+        {
+            // Two constraints on one GameObject is routine in Unity. They share a single row in the
+            // write array and merge per channel — if they each got their own row, the parallel write
+            // job would have two threads racing over the same transform and one would be lost.
+            Quaternion sourceRotation = Quaternion.Euler(0f, 90f, 0f);
+            Transform source = NewTransform("Source", new Vector3(1f, 2f, 3f), sourceRotation);
+            Transform target = NewTransform("Target", Vector3.zero, Quaternion.identity);
+            Constrain<BasisPositionConstraint>(target, source);
+            Constrain<BasisRotationConstraint>(target, source);
+
+            Solve();
+
+            AssertVector(new Vector3(1f, 2f, 3f), target.position, "position");
+            Assert.Less(Quaternion.Angle(sourceRotation, target.rotation), 0.1f, "rotation");
+        }
+
+        [Test]
+        public void RegistrationCountsTrackTheLiveComponents()
+        {
+            Transform source = NewTransform("Source", Vector3.zero, Quaternion.identity);
+            Transform target = NewTransform("Target", Vector3.zero, Quaternion.identity);
+            BasisPositionConstraint constraint = Constrain<BasisPositionConstraint>(target, source);
+
+            Solve();
+            Assert.AreEqual(1, BasisConstraintSystem.SlotCount, "slot count after register");
+
+            BasisConstraintSystem.Unregister(constraint);
+            registered.Remove(constraint);
+
+            Solve();
+            Assert.AreEqual(0, BasisConstraintSystem.SlotCount, "slot count after unregister");
+        }
+    }
+}

--- a/Basis/Packages/com.basis.framework/Tests/Editor/Constraints/BasisConstraintSolveTests.cs.meta
+++ b/Basis/Packages/com.basis.framework/Tests/Editor/Constraints/BasisConstraintSolveTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6fe7807c402890a4456c5d8284812356

--- a/Basis/Packages/com.basis.sdk/Scripts/Constraints.meta
+++ b/Basis/Packages/com.basis.sdk/Scripts/Constraints.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a3c1d17c64a8c8d8c402cc9f4ef602d8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Basis/Packages/com.basis.sdk/Scripts/Constraints/BasisAimConstraint.cs
+++ b/Basis/Packages/com.basis.sdk/Scripts/Constraints/BasisAimConstraint.cs
@@ -1,0 +1,46 @@
+using UnityEngine;
+
+namespace Basis.Scripts.BasisSdk.Constraints
+{
+    /// <summary>
+    /// Rotates a transform so its <see cref="aimVector"/> points at the weighted average of its
+    /// sources' positions, rolled so its <see cref="upVector"/> lines up with the resolved world up.
+    /// The Basis stand-in for <c>UnityEngine.Animations.AimConstraint</c>.
+    ///
+    /// Position is untouched — only rotation is driven. Use <see cref="BasisLookAtConstraint"/> for
+    /// the simpler "point +Z at it" case.
+    /// </summary>
+    public class BasisAimConstraint : BasisConstraintBase
+    {
+        [Tooltip("Local axis aimed at the sources.")]
+        public Vector3 aimVector = Vector3.forward;
+
+        [Tooltip("Local axis rolled toward the resolved world up.")]
+        public Vector3 upVector = Vector3.up;
+
+        [Tooltip("How the world up is resolved.")]
+        public BasisConstraintWorldUp worldUpType = BasisConstraintWorldUp.SceneUp;
+
+        [Tooltip("Reference transform for the Object Up and Object Rotation Up modes.")]
+        public Transform worldUpObject;
+
+        [Tooltip("Up direction for the Vector and Object Rotation Up modes.")]
+        public Vector3 worldUpVector = Vector3.up;
+
+        [Tooltip("Local euler rotation used when Weight is 0.")]
+        public Vector3 rotationAtRest;
+
+        [Tooltip("Local euler offset applied after aiming.")]
+        public Vector3 rotationOffset;
+
+        [Tooltip("Axes this constraint may drive. Excluded axes keep their current value.")]
+        public BasisConstraintAxes rotationAxis = BasisConstraintAxes.All;
+
+        public override BasisConstraintType constraintType => BasisConstraintType.Aim;
+
+        public override void CaptureRest()
+        {
+            rotationAtRest = transform.localRotation.eulerAngles;
+        }
+    }
+}

--- a/Basis/Packages/com.basis.sdk/Scripts/Constraints/BasisAimConstraint.cs.meta
+++ b/Basis/Packages/com.basis.sdk/Scripts/Constraints/BasisAimConstraint.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7bee29f1dacb7a8d823b74b895e0f76a

--- a/Basis/Packages/com.basis.sdk/Scripts/Constraints/BasisConstraintBase.cs
+++ b/Basis/Packages/com.basis.sdk/Scripts/Constraints/BasisConstraintBase.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Basis.Scripts.BasisSdk.Constraints
+{
+    /// <summary>
+    /// Shared authoring surface for the Basis constraint components — the drop-in replacement for
+    /// Unity's built-in <c>UnityEngine.Animations</c> constraints (<c>PositionConstraint</c>,
+    /// <c>RotationConstraint</c>, and friends). The public shape deliberately mirrors Unity's
+    /// <c>IConstraint</c> (<see cref="weight"/>, <see cref="constraintActive"/>, <see cref="locked"/>,
+    /// <c>AddSource</c> / <c>GetSource</c> / <c>SetSource</c> / <c>RemoveSource</c>) so porting a rig
+    /// is a component swap rather than a rewrite.
+    ///
+    /// Data-only, exactly like <see cref="BasisAuthoredMotion"/>: there is no per-instance
+    /// <c>Update</c>. Every enabled component is folded into one batched, Burst-compiled solve in
+    /// the framework-side <c>BasisConstraintSystem</c>, which is why this type lives in the SDK
+    /// assembly and speaks only plain Unity types — the SDK cannot see the framework.
+    ///
+    /// The framework subscribes to <see cref="ActiveStateChanged"/> and <see cref="StructureChanged"/>
+    /// once at startup; components announce themselves across the assembly boundary through those
+    /// statics rather than holding a reference to any system.
+    ///
+    /// Scalar state (weight, offsets, masks, at-rest pose) is re-read from the component every frame,
+    /// so tweaking it live — in the inspector or from script — just works. Changing the *shape* of
+    /// <see cref="sources"/> is a structural edit: go through the source API below, or call
+    /// <see cref="SetDirty"/> if you mutate the serialized list directly.
+    /// </summary>
+    public abstract class BasisConstraintBase : MonoBehaviour
+    {
+        /// <summary>
+        /// Raised when any constraint component is enabled (<c>true</c>) or disabled (<c>false</c>),
+        /// including on destroy. Static because the batched solver lives in an assembly this one
+        /// cannot reference; it subscribes once and never needs a per-frame poll.
+        /// </summary>
+        public static event Action<BasisConstraintBase, bool> ActiveStateChanged;
+
+        /// <summary>
+        /// Raised when a component's source list changes shape, so the solver rebuilds its flattened
+        /// containers. Scalar edits do not need this — they are picked up every frame.
+        /// </summary>
+        public static event Action<BasisConstraintBase> StructureChanged;
+
+        [Tooltip("Evaluate this constraint. Cleared, the transform is left entirely alone.")]
+        public bool constraintActive = true;
+
+        [Tooltip("Blend between the at-rest pose (0) and the fully constrained pose (1).")]
+        [Range(0f, 1f)]
+        public float weight = 1f;
+
+        [Tooltip("Authoring aid only, matching Unity's constraints: unlocked lets you re-pose the " +
+                 "transform in the editor to author offsets. It does not change runtime evaluation.")]
+        public bool locked = true;
+
+        [SerializeField]
+        [Tooltip("Transforms driving this constraint. Weights are relative, not normalized.")]
+        private List<BasisConstraintSourceEntry> sources = new List<BasisConstraintSourceEntry>();
+
+        /// <summary>Guards double-add / double-remove across enable cycles.</summary>
+        [NonSerialized] private bool announced;
+
+        /// <summary>Which solver path this component takes.</summary>
+        public abstract BasisConstraintType constraintType { get; }
+
+        /// <summary>Number of source transforms driving this constraint.</summary>
+        public int sourceCount => sources.Count;
+
+        /// <summary>
+        /// Direct indexed read for the solver's flatten pass. Indexing avoids the enumerator
+        /// allocation a <c>foreach</c> over the interface would cost on every rebuild.
+        /// </summary>
+        public IReadOnlyList<BasisConstraintSourceEntry> Sources => sources;
+
+        protected virtual void OnEnable() => OnInitialize();
+        protected virtual void OnDisable() => OnRemove();
+
+        /// <summary>
+        /// Announce this constraint to the solver. Factored out of <c>OnEnable</c> so a host that
+        /// drives lifecycle manually (avatar calibration, pooling) can register without toggling
+        /// <see cref="Behaviour.enabled"/>. Idempotent.
+        /// </summary>
+        public void OnInitialize()
+        {
+            if (announced)
+            {
+                return;
+            }
+            announced = true;
+            ActiveStateChanged?.Invoke(this, true);
+        }
+
+        /// <summary>Withdraw this constraint from the solver. Idempotent; safe to call unregistered.</summary>
+        public void OnRemove()
+        {
+            if (!announced)
+            {
+                return;
+            }
+            announced = false;
+            ActiveStateChanged?.Invoke(this, false);
+        }
+
+        /// <summary>
+        /// Flag the source list as structurally changed. Only needed when you mutate the serialized
+        /// list behind the source API's back; every method below already calls it.
+        /// </summary>
+        public void SetDirty()
+        {
+            if (announced)
+            {
+                StructureChanged?.Invoke(this);
+            }
+        }
+
+        public BasisConstraintSourceEntry GetSource(int index) => sources[index];
+
+        /// <summary>
+        /// Replace a source. Only a change of <c>sourceTransform</c> forces a rebuild — retargeting
+        /// weight alone rides the per-frame scalar refresh.
+        /// </summary>
+        public void SetSource(int index, BasisConstraintSourceEntry source)
+        {
+            Transform previous = sources[index].sourceTransform;
+            sources[index] = source;
+            if (previous != source.sourceTransform)
+            {
+                SetDirty();
+            }
+        }
+
+        /// <summary>Copy the sources into <paramref name="results"/>, clearing it first (Unity's shape).</summary>
+        public void GetSources(List<BasisConstraintSourceEntry> results)
+        {
+            if (results == null)
+            {
+                return;
+            }
+            results.Clear();
+            results.AddRange(sources);
+        }
+
+        public void SetSources(List<BasisConstraintSourceEntry> newSources)
+        {
+            sources.Clear();
+            if (newSources != null)
+            {
+                sources.AddRange(newSources);
+            }
+            OnSourcesReshaped();
+            SetDirty();
+        }
+
+        /// <summary>Append a source and return its index.</summary>
+        public int AddSource(BasisConstraintSourceEntry source)
+        {
+            sources.Add(source);
+            OnSourcesReshaped();
+            SetDirty();
+            return sources.Count - 1;
+        }
+
+        public void RemoveSource(int index)
+        {
+            sources.RemoveAt(index);
+            OnSourcesReshaped();
+            SetDirty();
+        }
+
+        public void ClearSources()
+        {
+            sources.Clear();
+            OnSourcesReshaped();
+            SetDirty();
+        }
+
+        /// <summary>
+        /// Hook for kinds carrying per-source data alongside the list — <see cref="BasisParentConstraint"/>
+        /// keeps its offset arrays the same length here.
+        /// </summary>
+        protected virtual void OnSourcesReshaped()
+        {
+        }
+
+        /// <summary>
+        /// Capture the transform's current local pose as the at-rest pose — the pose the constraint
+        /// blends back to at weight 0.
+        /// </summary>
+        [ContextMenu("Capture Rest From Current Pose")]
+        public abstract void CaptureRest();
+
+        protected virtual void Reset()
+        {
+            CaptureRest();
+        }
+
+        protected virtual void OnValidate()
+        {
+            weight = Mathf.Clamp01(weight);
+            for (int Index = 0; Index < sources.Count; Index++)
+            {
+                BasisConstraintSourceEntry source = sources[Index];
+                if (source.weight < 0f)
+                {
+                    source.weight = 0f;
+                    sources[Index] = source;
+                }
+            }
+            OnSourcesReshaped();
+        }
+    }
+}

--- a/Basis/Packages/com.basis.sdk/Scripts/Constraints/BasisConstraintBase.cs.meta
+++ b/Basis/Packages/com.basis.sdk/Scripts/Constraints/BasisConstraintBase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a962b32d452172ee470cae904be28182

--- a/Basis/Packages/com.basis.sdk/Scripts/Constraints/BasisConstraintTypes.cs
+++ b/Basis/Packages/com.basis.sdk/Scripts/Constraints/BasisConstraintTypes.cs
@@ -1,0 +1,76 @@
+using System;
+using UnityEngine;
+
+namespace Basis.Scripts.BasisSdk.Constraints
+{
+    /// <summary>
+    /// Which local axes a constraint is allowed to drive. Mirrors <c>UnityEngine.Animations.Axis</c>
+    /// so a rig ported off the built-in constraints keeps identical masking behaviour.
+    /// An axis left out of the mask keeps whatever value the transform already had this frame —
+    /// the constraint's weight does not pull it toward the at-rest pose either.
+    /// </summary>
+    [Flags]
+    public enum BasisConstraintAxes : byte
+    {
+        None = 0,
+        X = 1,
+        Y = 2,
+        Z = 4,
+        All = X | Y | Z,
+    }
+
+    /// <summary>
+    /// How an aim / look-at constraint resolves the world up vector it rolls against.
+    /// Mirrors <c>UnityEngine.Animations.WorldUpType</c>.
+    /// </summary>
+    public enum BasisConstraintWorldUp : byte
+    {
+        /// <summary>Global +Y.</summary>
+        SceneUp = 0,
+        /// <summary>Direction from the constrained transform toward <c>worldUpObject</c>.</summary>
+        ObjectUp = 1,
+        /// <summary><c>worldUpVector</c> rotated into <c>worldUpObject</c>'s space.</summary>
+        ObjectRotationUp = 2,
+        /// <summary><c>worldUpVector</c> taken as a world-space direction.</summary>
+        Vector = 3,
+        /// <summary>
+        /// No up hint. Unlike Unity's <c>WorldUpType.None</c>, which leaves roll unconstrained, the
+        /// batched solver still needs a basis and falls back to scene up — so today this behaves
+        /// the same as <see cref="SceneUp"/>.
+        /// </summary>
+        None = 4,
+    }
+
+    /// <summary>
+    /// Discriminates the concrete constraint components without a per-kind type test in the
+    /// batched solver. Values are kept in step with the framework-side <c>BasisConstraintKind</c>.
+    /// </summary>
+    public enum BasisConstraintType : byte
+    {
+        Position = 0,
+        Rotation = 1,
+        Scale = 2,
+        Parent = 3,
+        Aim = 4,
+        LookAt = 5,
+    }
+
+    /// <summary>
+    /// One weighted driver of a constraint. Mirrors <c>UnityEngine.Animations.ConstraintSource</c>.
+    /// Weights are relative, not normalized — two sources at 1 each blend 50/50, exactly as the
+    /// built-in constraints do.
+    /// </summary>
+    [Serializable]
+    public struct BasisConstraintSourceEntry
+    {
+        public Transform sourceTransform;
+        [Min(0f)]
+        public float weight;
+
+        public BasisConstraintSourceEntry(Transform sourceTransform, float weight = 1f)
+        {
+            this.sourceTransform = sourceTransform;
+            this.weight = weight;
+        }
+    }
+}

--- a/Basis/Packages/com.basis.sdk/Scripts/Constraints/BasisConstraintTypes.cs.meta
+++ b/Basis/Packages/com.basis.sdk/Scripts/Constraints/BasisConstraintTypes.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6ac5d7121fca601c589333053fe13e75

--- a/Basis/Packages/com.basis.sdk/Scripts/Constraints/BasisLookAtConstraint.cs
+++ b/Basis/Packages/com.basis.sdk/Scripts/Constraints/BasisLookAtConstraint.cs
@@ -1,0 +1,35 @@
+using UnityEngine;
+
+namespace Basis.Scripts.BasisSdk.Constraints
+{
+    /// <summary>
+    /// Rotates a transform so its local +Z points at the weighted average of its sources' positions.
+    /// The Basis stand-in for <c>UnityEngine.Animations.LookAtConstraint</c> — an aim constraint with
+    /// the axes fixed to the Unity convention (+Z forward, +Y up) and a roll angle instead of a full
+    /// world-up configuration.
+    /// </summary>
+    public class BasisLookAtConstraint : BasisConstraintBase
+    {
+        [Tooltip("Extra roll about the look axis, in degrees.")]
+        public float roll;
+
+        [Tooltip("Roll toward World Up Object instead of scene up.")]
+        public bool useUpObject;
+
+        [Tooltip("Reference transform used when Use Up Object is set.")]
+        public Transform worldUpObject;
+
+        [Tooltip("Local euler rotation used when Weight is 0.")]
+        public Vector3 rotationAtRest;
+
+        [Tooltip("Local euler offset applied after looking.")]
+        public Vector3 rotationOffset;
+
+        public override BasisConstraintType constraintType => BasisConstraintType.LookAt;
+
+        public override void CaptureRest()
+        {
+            rotationAtRest = transform.localRotation.eulerAngles;
+        }
+    }
+}

--- a/Basis/Packages/com.basis.sdk/Scripts/Constraints/BasisLookAtConstraint.cs.meta
+++ b/Basis/Packages/com.basis.sdk/Scripts/Constraints/BasisLookAtConstraint.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b650dae788a7c9ad7b0fbb012471cfa3

--- a/Basis/Packages/com.basis.sdk/Scripts/Constraints/BasisParentConstraint.cs
+++ b/Basis/Packages/com.basis.sdk/Scripts/Constraints/BasisParentConstraint.cs
@@ -1,0 +1,90 @@
+using System;
+using UnityEngine;
+
+namespace Basis.Scripts.BasisSdk.Constraints
+{
+    /// <summary>
+    /// Drives a transform's local position and rotation together, as if it were parented to the
+    /// weighted average of its sources. The Basis stand-in for
+    /// <c>UnityEngine.Animations.ParentConstraint</c>.
+    ///
+    /// Each source carries its own position/rotation offset, so a single constrained transform can
+    /// sit at a different relative pose per source — that is what makes a two-source parent
+    /// constraint blend smoothly between, say, a hip holster and a hand.
+    ///
+    /// Not to be confused with <c>Basis.Scripts.BasisSdk.Interactions.BasisParentConstraint</c>,
+    /// the serialized helper class the pickup and held-camera interactables evaluate inline. This
+    /// is the scene-authorable component; that one is an internal building block.
+    /// </summary>
+    public class BasisParentConstraint : BasisConstraintBase
+    {
+        [Tooltip("Local position used when Weight is 0.")]
+        public Vector3 translationAtRest;
+
+        [Tooltip("Local euler rotation used when Weight is 0.")]
+        public Vector3 rotationAtRest;
+
+        [Tooltip("Per-source position offset, in that source's space. One entry per source.")]
+        public Vector3[] translationOffsets = Array.Empty<Vector3>();
+
+        [Tooltip("Per-source euler rotation offset, applied after that source's rotation. One entry per source.")]
+        public Vector3[] rotationOffsets = Array.Empty<Vector3>();
+
+        [Tooltip("Position axes this constraint may drive. Excluded axes keep their current value.")]
+        public BasisConstraintAxes translationAxis = BasisConstraintAxes.All;
+
+        [Tooltip("Rotation axes this constraint may drive. Excluded axes keep their current value.")]
+        public BasisConstraintAxes rotationAxis = BasisConstraintAxes.All;
+
+        public override BasisConstraintType constraintType => BasisConstraintType.Parent;
+
+        public override void CaptureRest()
+        {
+            translationAtRest = transform.localPosition;
+            rotationAtRest = transform.localRotation.eulerAngles;
+        }
+
+        /// <summary>
+        /// Set every source's offset to the pose that holds the constrained transform exactly where
+        /// it sits right now — the equivalent of Unity's "activate and preserve offset". Requires the
+        /// sources to be at their current world poses, so call it while the rig is in its bind pose.
+        /// </summary>
+        [ContextMenu("Capture Offsets From Current Pose")]
+        public void CaptureOffsets()
+        {
+            OnSourcesReshaped();
+            for (int Index = 0; Index < sourceCount; Index++)
+            {
+                Transform source = GetSource(Index).sourceTransform;
+                if (source == null)
+                {
+                    continue;
+                }
+                // The offset that reproduces our current world pose from this source's frame.
+                // Rotation-only inverse, deliberately not InverseTransformPoint: the solver applies
+                // the offset as position + rotation * offset, with no scale term, so dividing the
+                // source's lossy scale out here would make a scaled source snap on activation.
+                translationOffsets[Index] = Quaternion.Inverse(source.rotation) * (transform.position - source.position);
+                rotationOffsets[Index] = (Quaternion.Inverse(source.rotation) * transform.rotation).eulerAngles;
+            }
+        }
+
+        /// <summary>
+        /// Keeps the per-source offset arrays the same length as the source list. Growth preserves
+        /// existing entries and leaves new ones at identity, so adding a source never disturbs the
+        /// offsets already authored for the others.
+        /// </summary>
+        protected override void OnSourcesReshaped()
+        {
+            int count = sourceCount;
+            if (translationOffsets == null || translationOffsets.Length != count)
+            {
+                Array.Resize(ref translationOffsets, count);
+            }
+            if (rotationOffsets == null || rotationOffsets.Length != count)
+            {
+                Array.Resize(ref rotationOffsets, count);
+            }
+        }
+    }
+}

--- a/Basis/Packages/com.basis.sdk/Scripts/Constraints/BasisParentConstraint.cs.meta
+++ b/Basis/Packages/com.basis.sdk/Scripts/Constraints/BasisParentConstraint.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1ab6a486112cc0b7cff4b5f1bb065967

--- a/Basis/Packages/com.basis.sdk/Scripts/Constraints/BasisPositionConstraint.cs
+++ b/Basis/Packages/com.basis.sdk/Scripts/Constraints/BasisPositionConstraint.cs
@@ -1,0 +1,29 @@
+using UnityEngine;
+
+namespace Basis.Scripts.BasisSdk.Constraints
+{
+    /// <summary>
+    /// Drives a transform's local position from the weighted average of its sources' world positions.
+    /// The Basis stand-in for <c>UnityEngine.Animations.PositionConstraint</c>, with the same field
+    /// names and semantics; unlike the built-in it costs no per-instance <c>Update</c>, because every
+    /// enabled constraint in the scene is solved in one batched job.
+    /// </summary>
+    public class BasisPositionConstraint : BasisConstraintBase
+    {
+        [Tooltip("Local position used when Weight is 0.")]
+        public Vector3 translationAtRest;
+
+        [Tooltip("Local-space offset added to the blended source position.")]
+        public Vector3 translationOffset;
+
+        [Tooltip("Axes this constraint may drive. Excluded axes keep their current value.")]
+        public BasisConstraintAxes translationAxis = BasisConstraintAxes.All;
+
+        public override BasisConstraintType constraintType => BasisConstraintType.Position;
+
+        public override void CaptureRest()
+        {
+            translationAtRest = transform.localPosition;
+        }
+    }
+}

--- a/Basis/Packages/com.basis.sdk/Scripts/Constraints/BasisPositionConstraint.cs.meta
+++ b/Basis/Packages/com.basis.sdk/Scripts/Constraints/BasisPositionConstraint.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e6159fc53d5da83be8e96b1880cd874f

--- a/Basis/Packages/com.basis.sdk/Scripts/Constraints/BasisRotationConstraint.cs
+++ b/Basis/Packages/com.basis.sdk/Scripts/Constraints/BasisRotationConstraint.cs
@@ -1,0 +1,31 @@
+using UnityEngine;
+
+namespace Basis.Scripts.BasisSdk.Constraints
+{
+    /// <summary>
+    /// Drives a transform's local rotation from the weighted average of its sources' world rotations.
+    /// The Basis stand-in for <c>UnityEngine.Animations.RotationConstraint</c>.
+    ///
+    /// Blending is the hemisphere-corrected quaternion average used throughout Basis, then masked per
+    /// axis in ZXY euler order — the same order Unity's constraint uses, so authored per-axis rigs
+    /// carry over unchanged.
+    /// </summary>
+    public class BasisRotationConstraint : BasisConstraintBase
+    {
+        [Tooltip("Local euler rotation used when Weight is 0.")]
+        public Vector3 rotationAtRest;
+
+        [Tooltip("Local euler offset applied after the blended source rotation.")]
+        public Vector3 rotationOffset;
+
+        [Tooltip("Axes this constraint may drive. Excluded axes keep their current value.")]
+        public BasisConstraintAxes rotationAxis = BasisConstraintAxes.All;
+
+        public override BasisConstraintType constraintType => BasisConstraintType.Rotation;
+
+        public override void CaptureRest()
+        {
+            rotationAtRest = transform.localRotation.eulerAngles;
+        }
+    }
+}

--- a/Basis/Packages/com.basis.sdk/Scripts/Constraints/BasisRotationConstraint.cs.meta
+++ b/Basis/Packages/com.basis.sdk/Scripts/Constraints/BasisRotationConstraint.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2af57714f2fb3967a54288c0ee65e52d

--- a/Basis/Packages/com.basis.sdk/Scripts/Constraints/BasisScaleConstraint.cs
+++ b/Basis/Packages/com.basis.sdk/Scripts/Constraints/BasisScaleConstraint.cs
@@ -1,0 +1,31 @@
+using UnityEngine;
+
+namespace Basis.Scripts.BasisSdk.Constraints
+{
+    /// <summary>
+    /// Drives a transform's local scale from the weighted average of its sources' lossy (world) scales.
+    /// The Basis stand-in for <c>UnityEngine.Animations.ScaleConstraint</c>.
+    ///
+    /// The blend happens in world scale and is divided back through the parent's lossy scale, so a
+    /// constrained child tracks its source's apparent size regardless of where either sits in the
+    /// hierarchy.
+    /// </summary>
+    public class BasisScaleConstraint : BasisConstraintBase
+    {
+        [Tooltip("Local scale used when Weight is 0.")]
+        public Vector3 scaleAtRest = Vector3.one;
+
+        [Tooltip("Multiplied into the blended source scale.")]
+        public Vector3 scaleOffset = Vector3.one;
+
+        [Tooltip("Axes this constraint may drive. Excluded axes keep their current value.")]
+        public BasisConstraintAxes scalingAxis = BasisConstraintAxes.All;
+
+        public override BasisConstraintType constraintType => BasisConstraintType.Scale;
+
+        public override void CaptureRest()
+        {
+            scaleAtRest = transform.localScale;
+        }
+    }
+}

--- a/Basis/Packages/com.basis.sdk/Scripts/Constraints/BasisScaleConstraint.cs.meta
+++ b/Basis/Packages/com.basis.sdk/Scripts/Constraints/BasisScaleConstraint.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d14a86007f1b90ca7d3435a6e94dab80


### PR DESCRIPTION
Adds the authorable half of the constraint work. `Packages/com.basis.framework/Constraints/` had data structs and math but nothing that consumed them and nothing anyone could put on a GameObject; this adds both.

## Components (SDK)

Six drop-in replacements for Unity's built-in `UnityEngine.Animations` constraints, with the same field names and semantics so porting a rig is a component swap:

| Basis | Unity |
|---|---|
| `BasisPositionConstraint` | `PositionConstraint` |
| `BasisRotationConstraint` | `RotationConstraint` |
| `BasisScaleConstraint` | `ScaleConstraint` |
| `BasisParentConstraint` | `ParentConstraint` |
| `BasisAimConstraint` | `AimConstraint` |
| `BasisLookAtConstraint` | `LookAtConstraint` |

They follow `BasisAuthoredMotion`: data-only, no per-instance `Update`, plain Unity types only (the SDK assembly cannot reference the framework), announcing themselves over static events. The `weight` / `constraintActive` / `locked` / `AddSource` / `GetSource` / `SetSource` / `RemoveSource` surface mirrors Unity's `IConstraint`.

## Solver (framework)

`BasisConstraintSystem` flattens every enabled component into the existing `BasisConstraintSlot` / `BasisConstraintSource` containers and runs three jobs per frame:

1. **sample** every tracked transform once (targets, sources, up objects, parents — interned, so a transform referenced by ten constraints is read once)
2. **solve** single-threaded in dependency order, refreshing each solved target's world row so chains resolve in one frame
3. **write** in parallel over deduplicated target transforms

Scalar edits (weight, offsets, masks, rest pose, source weights) are re-read every frame, so animating a weight is free; only source-list changes trigger a rebuild. Scheduled in `BasisEventDriver.LateUpdateBody` after authored motion and before jiggle samples the bones.

## Notes for review

- **Namespaced, not global.** A global `BasisParentConstraint` would shadow `Basis.Scripts.BasisSdk.Interactions.BasisParentConstraint` inside `BasisHandHeldCameraInteractable.cs` — an enclosing namespace beats a `using` directive — silently breaking it. Everything sits in `Basis.Scripts.BasisSdk.Constraints`.
- **This carries in `BasisConstraintData.cs` and `BasisConstraintMath.cs`**, which were untracked local work. They are unmodified; the branch would not compile without them.
- `locked` is authoring-only, matching Unity; it does not affect runtime evaluation.
- `BasisWorldUpKind.None` currently behaves as scene up (the batched solver always needs a basis), documented on the enum.
- A parallel `sTargetRow` array is used rather than adding a field to `BasisConstraintSlot`, to leave that struct untouched — happy to fold it in instead.

## Verification

- All new code **compiles clean** (0 errors, 0 warnings) against Unity 6000.5.4 reference assemblies.
- The **pure-math core was executed** outside Unity: `Quaternion.Euler` and `quaternion.EulerZXY` agree (so the flatten and the axis mask share one convention), `ToEulerZXY` round-trips, the aim/look-at basis is correct, and the parent-space conversion inverts the world recomposition.
- The **dependency sort was executed** standalone: reverse-registered chains order correctly, cycles terminate without dropping slots, stacked drivers precede their consumer.
- **16 EditMode tests** are included (`Basis.Framework.Constraints.Tests`) — position/rotation/scale/parent/aim/look-at behaviour, axis masking, weight blending, stacked constraints, dependency ordering, and registration lifecycle.

⚠️ **The EditMode tests have not been run.** Executing them needs a full Unity import of this worktree, which would write a multi-GB `Library/` inside OneDrive. They are written against hand-derived expectations, and an independent review re-derived all of them, but they want a real run before merge.

An adversarial review of the solver found seven defects, all fixed in this commit: `TransformAccessArray` compaction desyncing the parallel arrays, `worldUpObject` having no invalidation path, `CaptureOffsets` disagreeing with the solver about source scale, hierarchy depth not ordering the dependency graph (now a real topological sort), `Dispose` leaving the system able to resurrect orphaned containers, `Complete` retiring a handle it did not own, and `RefreshWorld` injecting decomposition error into rows nothing had written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)