### PR TITLE
fix(mediaplayer): let each client reach its own end of stream

### DIFF
--- a/Basis/Packages/com.basis.mediaplayer/Runtime/BasisMediaPlayerNetworking.cs
+++ b/Basis/Packages/com.basis.mediaplayer/Runtime/BasisMediaPlayerNetworking.cs
@@ -804,8 +804,11 @@ public sealed class BasisMediaPlayerNetworking : BasisNetworkBehaviour
         mediaPlayer.OnReady += HandleLocalReady;
         mediaPlayer.OnStarted += HandleLocalStarted;
         mediaPlayer.OnPaused += HandleLocalPaused;
-        mediaPlayer.OnEnded += HandleLocalEnded;
         mediaPlayer.OnSeekCompleted += HandleLocalSeekCompleted;
+        // OnEnded is deliberately not hooked: end-of-stream is per-client. Every peer plays
+        // the same source and reaches its own end; broadcasting a stop on the owner's EOS
+        // would cut off any client still behind its playhead (a late joiner, by its join
+        // latency). Deliberate stops broadcast from Stop() directly.
         eventsHooked = true;
     }
 
@@ -819,7 +822,6 @@ public sealed class BasisMediaPlayerNetworking : BasisNetworkBehaviour
         mediaPlayer.OnReady -= HandleLocalReady;
         mediaPlayer.OnStarted -= HandleLocalStarted;
         mediaPlayer.OnPaused -= HandleLocalPaused;
-        mediaPlayer.OnEnded -= HandleLocalEnded;
         mediaPlayer.OnSeekCompleted -= HandleLocalSeekCompleted;
         eventsHooked = false;
     }
@@ -891,21 +893,6 @@ public sealed class BasisMediaPlayerNetworking : BasisNetworkBehaviour
         }
 
         SendOwnerSimple(MessageId.Pause);
-    }
-
-    private void HandleLocalEnded()
-    {
-        if (applyingRemoteCommand)
-        {
-            return;
-        }
-
-        if (!IsOwnedLocallyOnClient)
-        {
-            return;
-        }
-
-        SendOwnerSimple(MessageId.Stop);
     }
 
     private void HandleLocalSeekCompleted(TimeSpan position)

--- a/Basis/Packages/com.basis.mediaplayer/TESTING.md
+++ b/Basis/Packages/com.basis.mediaplayer/TESTING.md
@@ -267,7 +267,10 @@ header reports no duration and shows no seek bar.
 **Networking** — two clients minimum: owner loads URL → both play; non-owner requests control
 → ownership transfers; owner pause/stop propagates; late joiner receives current state; each
 client resolves the URL independently (per-client CDN/bitrate differences are fine, state
-divergence is not).
+divergence is not). End-of-stream is per-client: a late joiner runs behind the owner by its
+join latency and must play through to its own end of the content — the owner finishing first
+must not cut it off. Clients therefore finish at slightly different wall-clock times; a peer
+stopping short of the end is the failure, synchronised finishes are not expected.
 
 **Networked audio-only** — the same two-client setup with an audio-only URL (`.wav`, `.mp3`,
 `.m4a`, `.opus`). These carry no video track, so anything that waits on a video frame or an


### PR DESCRIPTION
## Summary
Fixes the tail truncation reported off the 2026-07-20 test night: a late joiner starts at the owner's playhead correctly but stops short of the end of the content, losing roughly its join latency off the tail (measured ~4s on a 1:40 clip, cutting out moments after the owner finished).

The owner was broadcasting a Stop from its own end-of-stream handler, and remote clients applied it wherever their playhead happened to be. Any client behind the owner lost the difference, and a late joiner is always behind. This affects every content type, video included; it just surfaces most readily on late joins.

The fix is a deletion: end-of-stream no longer broadcasts anything. Every peer plays the same source, so each reaches its own end independently; the owner has no way of knowing a peer's drift, so it isn't in a position to decide when that peer has finished. The accepted trade-off is that clients now finish at slightly different wall-clock times rather than together, which beats silently cutting content off. Deliberate stops (the user pressing stop) broadcast from `Stop()` directly and are unaffected.

`TESTING.md`'s networking scenario now spells out the expected end-of-stream behaviour.
## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [x] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — `BasisEventDriver` runs the single per-frame tick that drives the whole framework (network apply, local player sim, blendshapes, JigglePhysics, nameplates, and more) as one sequential chain. An unhandled exception anywhere in that chain aborts the rest of the tick, so every step after the throwing one is silently skipped for that frame. New work added to the driver must either be guaranteed not to throw, or be wrapped in a `try`/`catch` that contains the failure and surfaces it through `BasisDebug` — logged once / rate-limited, never every frame (see the existing `HVRBasisBuiltInAddresses.Simulate()` guard for the pattern). Expect this to be scrutinized closely in review.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [x] Windows
- [ ] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [ ] Tested in VR (note headset under **Notes**)
- [ ] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [x] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [x] N/A — change does not touch any of the above

## Notes
- The change is C#-only and purely a deletion (the end-of-stream broadcast path); the required checks other than Tested are ticked as N/A on that basis: there are no new components, per-frame work, logging, allocations or asset loads.
- `OnEnded` itself stays: the playlist and the rendering placeholder-restore components still subscribe to it. Only the networking subscription is gone, with a comment at the hook site so the absence reads as deliberate.
- One behaviour that quietly disappears: a remote that stalls and never reaches its own end-of-stream no longer gets force-stopped when the owner finishes. That was never the broadcast's purpose, but flagging it for review.
- Verification plan before marking Tested: two clients, owner plays https://mr.town/vod/tos_opus.webm (1:40 audio-only), second client joins around halfway, listen through to the end on the late joiner, which should reach the actual end of the clip. A video lane pass on the same shape covers the general case.
