### PR TITLE
feat(trackerobjects): bind spare VR trackers to spawned props

### DIFF
--- a/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/en.json
+++ b/Basis/Packages/com.basis.framework/BasisUI/Localization/Languages/en.json
@@ -8617,6 +8617,30 @@
     {
       "key": "settings.bodyTracking.headSwing.backward.tooltip",
       "value": "How far the camera pulls back when you look UP, as a fraction of the look-down carry. Looking up is not the mirror of looking down - your upper back takes most of it, so your skull does not slide backward nearly as far. 1.0 would treat them the same."
+    },
+    {
+      "key": "library.instantiated.assignTracker.tooltip",
+      "value": "Bind this item to a spare tracker"
+    },
+    {
+      "key": "library.instantiated.unbindTracker.tooltip",
+      "value": "Release this item from its tracker"
+    },
+    {
+      "key": "library.trackerPicker.title",
+      "value": "Choose Tracker"
+    },
+    {
+      "key": "library.trackerPicker.empty",
+      "value": "No spare trackers are currently connected."
+    },
+    {
+      "key": "library.trackerPicker.outOfRange",
+      "value": "No spare trackers are within reach of this item. Bring a tracker to the item to bind it."
+    },
+    {
+      "key": "library.trackerPicker.cancel",
+      "value": "Cancel"
     }
   ]
 }

--- a/Basis/Packages/com.basis.framework/BasisUI/Menus/Library/LibraryProvider.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Menus/Library/LibraryProvider.cs
@@ -88,6 +88,14 @@ namespace Basis.BasisUI
         private static protected bool IsProtected = false; // we use this to determine if the user is admin for admin related queries on the library provider
         public static BasisMenuPanel panel;
 
+        /// <summary>
+        /// Fires per instantiated-object row right after the Select button is built,
+        /// before Teleport/Static/Remove. Does not fire for embedded rows — those carry
+        /// no action buttons at all. Subscribers can append buttons to the supplied
+        /// row container — they land between Select and Teleport.
+        /// </summary>
+        public static event Action<RectTransform, BasisRuntimeSpawnRegistry.SpawnInstance> OnInstanceRowCreated;
+
         // The library panel can be released mid-refresh (user closes the menu) while we await
         // key/metadata loads; its controls are destroyed with it, so bail before touching them.
         private static bool PanelAlive => panel != null && !panel.IsReleased;
@@ -2499,6 +2507,23 @@ namespace Basis.BasisUI
                     }
                 },
             });
+
+            if (OnInstanceRowCreated != null)
+            {
+                // Subscribers are external integrations; one throwing must not leave the
+                // row half-built or abort the rest of the tab rebuild.
+                foreach (Action<RectTransform, BasisRuntimeSpawnRegistry.SpawnInstance> subscriber in OnInstanceRowCreated.GetInvocationList())
+                {
+                    try
+                    {
+                        subscriber(itemListPanel.TabButtonParent, itemKey);
+                    }
+                    catch (Exception e)
+                    {
+                        BasisDebug.LogError($"OnInstanceRowCreated subscriber {subscriber.Method.DeclaringType?.FullName}.{subscriber.Method.Name} threw: {e}");
+                    }
+                }
+            }
 
             BuildEntryActionButton(itemListPanel.TabButtonParent, new EntryActionButton
             {

--- a/Basis/Packages/com.basis.integration.trackerobjects/LICENSE.md
+++ b/Basis/Packages/com.basis.integration.trackerobjects/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 BasisVR
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Basis/Packages/com.basis.integration.trackerobjects/LICENSE.md.meta
+++ b/Basis/Packages/com.basis.integration.trackerobjects/LICENSE.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 12563aaadbb712e49a94036afb0c2d06
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Basis/Packages/com.basis.integration.trackerobjects/README.md
+++ b/Basis/Packages/com.basis.integration.trackerobjects/README.md
@@ -10,6 +10,7 @@ Bridges `com.basis.trackerobjects` into the Basis library menu. When a prop has 
 
 - A `[RuntimeInitializeOnLoadMethod(SubsystemRegistration)]` subscriber on `LibraryProvider.OnInstanceRowCreated`. For every instantiated-object row that `LibraryProvider` builds, this appends a `StandardButton` between the existing Select and Teleport buttons.
 - The button only appears on `SpawnMode.GameObject` (prop) rows — scenes and avatars are skipped, as are `SpawnMethod.Embedded` and static-locked items. Static rows rebuild on the server's Modified broadcast, so the button reappears when the lock clears.
+- The button also hides when no spare bindable tracker is connected, and reappears live when one turns up (the hook watches `AllInputDevices` and the binding events). A bound prop's row always keeps its button so Unlink stays reachable. Eligibility changes that don't touch the device list (e.g. calibrating a tracker to a body bone) are picked up on the next device or binding change, or menu rebuild.
 - Clicking the Link icon opens a `DialogBox<BasisInput>` modal listing the currently-connected trackers eligible for prop binding. Confirming a row calls `BasisTrackerObjectManager.TryCreateBindingAsync` with the spawn instance's `LoadedNetID` and `GameObject` transform; the manager takes network ownership of the prop before the binding is created. The picker excludes:
   - `BasisVirtualMidpointInput` instances (the virtual half of an active pair).
   - Trackers with `BasisInput.IsLinked == true` (one half of an active pair).

--- a/Basis/Packages/com.basis.integration.trackerobjects/README.md
+++ b/Basis/Packages/com.basis.integration.trackerobjects/README.md
@@ -19,6 +19,7 @@ Bridges `com.basis.trackerobjects` into the Basis library menu. When a prop has 
   - Trackers already bound to another prop (`BasisTrackerObjectManager.IsTrackerBound`). One tracker drives at most one prop; unbind it there first.
   - Trackers out of interaction range of the prop (`BasisTrackerObjectManager.IsWithinBindRange` — the same reach rule as grabbing it). If spare trackers exist but none are in reach, the dialog says so rather than showing the generic empty message.
 - Clicking the Unlink icon calls `BasisTrackerObjectManager.TryRemoveBinding` directly — no confirmation dialog. Unbinding isn't destructive; the binding just lifts.
+- The row icon follows `OnBindingCreated`/`OnBindingRemoved`, so it stays correct while the menu is open even when a binding dissolves externally (ownership steal, static lock, tracker loss).
 
 ## Compile guards
 

--- a/Basis/Packages/com.basis.integration.trackerobjects/README.md
+++ b/Basis/Packages/com.basis.integration.trackerobjects/README.md
@@ -1,0 +1,36 @@
+# Basis Tracker Objects Integration
+
+Bridges `com.basis.trackerobjects` into the Basis library menu. When a prop has been instantiated and shows up in the library's instantiated-items tab, this package adds an icon-only Assign/Unbind Tracker button to the row (Link/Unlink icons with tooltips, no title text). Clicking the Link icon opens a tracker picker; confirming a tracker binds the prop's GameObject to that tracker via `BasisTrackerObjectManager`. Clicking the Unlink icon removes the binding.
+
+## Why a separate package
+
+`com.basis.trackerobjects` references `Basis Framework` for the types it needs to drive a transform (`BasisInput`, `BasisLocalPlayer`, `BasisRuntimeSpawnRegistry`, `BasisPickupSyncNetworking`). That means `Basis Framework` can't reference `com.basis.trackerobjects` back — the asmdef graph would cycle. This integration package references both and is the only place that can wire a library-menu button into a `BasisTrackerObjectManager.TryCreateBindingAsync` call. Same pattern as `com.basis.integration.audiolink`.
+
+## What it adds
+
+- A `[RuntimeInitializeOnLoadMethod(SubsystemRegistration)]` subscriber on `LibraryProvider.OnInstanceRowCreated`. For every instantiated-object row that `LibraryProvider` builds, this appends a `StandardButton` between the existing Select and Teleport buttons.
+- The button only appears on `SpawnMode.GameObject` (prop) rows — scenes and avatars are skipped, as are `SpawnMethod.Embedded` and static-locked items. Static rows rebuild on the server's Modified broadcast, so the button reappears when the lock clears.
+- Clicking the Link icon opens a `DialogBox<BasisInput>` modal listing the currently-connected trackers eligible for prop binding. Confirming a row calls `BasisTrackerObjectManager.TryCreateBindingAsync` with the spawn instance's `LoadedNetID` and `GameObject` transform; the manager takes network ownership of the prop before the binding is created. The picker excludes:
+  - `BasisVirtualMidpointInput` instances (the virtual half of an active pair).
+  - Trackers with `BasisInput.IsLinked == true` (one half of an active pair).
+  - Trackers whose `UniqueDeviceIdentifier` has a `BasisTrackerRoleOverride.TryGetOverride` hit.
+  - Devices the input matcher has pinned to a fixed role (HMD, named controllers, etc.).
+  - Trackers currently driving an avatar bone via calibration. Decalibrate first if you want to reuse a calibrated tracker for a prop.
+  - Trackers already bound to another prop (`BasisTrackerObjectManager.IsTrackerBound`). One tracker drives at most one prop; unbind it there first.
+  - Trackers out of interaction range of the prop (`BasisTrackerObjectManager.IsWithinBindRange` — the same reach rule as grabbing it). If spare trackers exist but none are in reach, the dialog says so rather than showing the generic empty message.
+- Clicking the Unlink icon calls `BasisTrackerObjectManager.TryRemoveBinding` directly — no confirmation dialog. Unbinding isn't destructive; the binding just lifts.
+
+## Compile guards
+
+The assembly defines two version constraints:
+
+- `com.basis.framework` → `BASIS_FRAMEWORK_EXISTS`
+- `com.basis.trackerobjects` → `BASIS_TRACKEROBJECTS_EXISTS`
+
+Both must be present for this package to compile. If either is removed from the project, this assembly drops out silently.
+
+## See also
+
+- `BasisTrackerObjectManager` in `com.basis.trackerobjects` — the binding manager: pose drive, ownership, pickup veto, and registry-cleanup handling.
+- `LibraryProvider.OnInstanceRowCreated` — the event this package subscribes to. Lives in `com.basis.framework`.
+- `com.basis.integration.audiolink` — sibling integration package that follows the same bridge pattern.

--- a/Basis/Packages/com.basis.integration.trackerobjects/README.md.meta
+++ b/Basis/Packages/com.basis.integration.trackerobjects/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: af43d869252215f42a6e073975019f90
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Basis/Packages/com.basis.integration.trackerobjects/Runtime.meta
+++ b/Basis/Packages/com.basis.integration.trackerobjects/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d3f6f5a03cdabb849a41d489b099507e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Basis/Packages/com.basis.integration.trackerobjects/Runtime/Basis.Integration.TrackerObjects.asmdef
+++ b/Basis/Packages/com.basis.integration.trackerobjects/Runtime/Basis.Integration.TrackerObjects.asmdef
@@ -1,0 +1,34 @@
+{
+    "name": "Basis.Integration.TrackerObjects",
+    "rootNamespace": "Basis.Integration.TrackerObjects",
+    "references": [
+        "Basis Framework",
+        "BasisSDK",
+        "BasisDebug",
+        "BasisTrackerObjects",
+        "Unity.TextMeshPro"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [
+        "BASIS_FRAMEWORK_EXISTS",
+        "BASIS_TRACKEROBJECTS_EXISTS"
+    ],
+    "versionDefines": [
+        {
+            "name": "com.basis.framework",
+            "expression": "0.0.0",
+            "define": "BASIS_FRAMEWORK_EXISTS"
+        },
+        {
+            "name": "com.basis.trackerobjects",
+            "expression": "0.0.0",
+            "define": "BASIS_TRACKEROBJECTS_EXISTS"
+        }
+    ],
+    "noEngineReferences": false
+}

--- a/Basis/Packages/com.basis.integration.trackerobjects/Runtime/Basis.Integration.TrackerObjects.asmdef.meta
+++ b/Basis/Packages/com.basis.integration.trackerobjects/Runtime/Basis.Integration.TrackerObjects.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 14e7fa5f04af2d848a51f1e909da387f
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Basis/Packages/com.basis.integration.trackerobjects/Runtime/BasisTrackerObjectsLibraryHook.cs
+++ b/Basis/Packages/com.basis.integration.trackerobjects/Runtime/BasisTrackerObjectsLibraryHook.cs
@@ -1,0 +1,164 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Basis.BasisUI;
+using Basis.Scripts.Avatar;
+using Basis.Scripts.BasisSdk.Interactions;
+using Basis.Scripts.Device_Management;
+using Basis.Scripts.Device_Management.Devices;
+using Basis.Scripts.Device_Management.Devices.Pairing;
+using Basis.Scripts.TransformBinders.BoneControl;
+using Basis.TrackerObjects;
+using UnityEngine;
+
+namespace Basis.Integration.TrackerObjects
+{
+    internal static class BasisTrackerObjectsLibraryHook
+    {
+        private static readonly Vector2 PickerSize = new Vector2(900, 720);
+        private static readonly Vector2 RowSize = new Vector2(80, 80);
+        private static readonly Vector2 PickerRowSize = new Vector2(700, 60);
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        private static void Subscribe()
+        {
+            LibraryProvider.OnInstanceRowCreated -= OnRowCreated;
+            LibraryProvider.OnInstanceRowCreated += OnRowCreated;
+        }
+
+        private static void OnRowCreated(RectTransform parent, BasisRuntimeSpawnRegistry.SpawnInstance instance)
+        {
+            if (instance == null) return;
+            string netID = instance.LoadedNetID;
+            if (string.IsNullOrEmpty(netID)) return;
+
+            // Only GameObject-mode (prop) instances can host a tracker binding — scenes
+            // and avatars have no pickup/rigid surface to drive, and embedded items
+            // aren't user-owned spawns. Skip adding the button at all rather than
+            // disabling it — a dead extra button just pushes the row over.
+            if (instance.SpawnMode != BasisRuntimeSpawnRegistry.SpawnMode.GameObject) return;
+            if (instance.SpawnMethod == BasisRuntimeSpawnRegistry.SpawnMethod.Embedded) return;
+            // Static-locked props are frozen server-side; the row rebuilds on the
+            // Modified broadcast, so the button reappears when the lock clears.
+            if (instance.Static) return;
+
+            bool hasBinding = BasisTrackerObjectManager.TryGetBindingByLoadedNetID(netID, out _);
+            PanelButton button = PanelButton.CreateNew(PanelButton.ButtonStyles.StandardButton, parent);
+            button.Descriptor.SetTitle(string.Empty);
+            button.SetIcon(hasBinding ? AddressableAssets.Sprites.Unlink : AddressableAssets.Sprites.Link);
+            button.SetSize(RowSize);
+            // Inset the icon so its strokes stay clear of the bevel — matches the row's
+            // other action buttons.
+            button.Descriptor.IconImage.rectTransform.sizeDelta = new Vector2(-30, -30);
+            button.Descriptor.SetTooltip(BasisLocalization.Get(hasBinding
+                ? "library.instantiated.unbindTracker.tooltip"
+                : "library.instantiated.assignTracker.tooltip"));
+
+            button.OnClicked += async () =>
+            {
+                if (BasisTrackerObjectManager.TryGetBindingByLoadedNetID(netID, out BasisTrackerBinding existing))
+                {
+                    BasisTrackerObjectManager.TryRemoveBinding(existing.Id);
+                    button.SetIcon(AddressableAssets.Sprites.Link);
+                    button.Descriptor.SetTooltip(BasisLocalization.Get("library.instantiated.assignTracker.tooltip"));
+                    return;
+                }
+
+                if (!BasisRuntimeSpawnRegistry.SpawnedGameobjects.TryGetValue(netID, out GameObject go) || go == null)
+                {
+                    BasisDebug.LogWarning($"AssignTracker: spawn instance {netID} has no resolved GameObject", BasisDebug.LogTag.TrackerObjects);
+                    return;
+                }
+
+                BasisInput chosen = await OpenPickerAsync(go.transform);
+                if (chosen == null) return;
+
+                // The spawn can be removed or swapped while the picker is open, so
+                // re-resolve rather than binding through the stale capture. Static and
+                // duplicate-binding races are re-checked inside the manager.
+                if (!BasisRuntimeSpawnRegistry.SpawnedGameobjects.TryGetValue(netID, out go) || go == null) return;
+
+                BasisTrackerBinding created = await BasisTrackerObjectManager.TryCreateBindingAsync(chosen, go.transform, netID);
+                if (created != null && button != null)
+                {
+                    button.SetIcon(AddressableAssets.Sprites.Unlink);
+                    button.Descriptor.SetTooltip(BasisLocalization.Get("library.instantiated.unbindTracker.tooltip"));
+                }
+            };
+        }
+
+        private static async Task<BasisInput> OpenPickerAsync(Transform target)
+        {
+            DialogBox<BasisInput> picker = DialogBox<BasisInput>.Create(
+                LibraryProvider.panel,
+                PickerSize,
+                BasisLocalization.Get("library.trackerPicker.title"),
+                description: null,
+                icon: AddressableAssets.Sprites.Information);
+
+            PanelButton cancel = PanelButton.CreateNew(PanelButton.ButtonStyles.ExitButton, picker.Descriptor.Header);
+            cancel.Descriptor.SetTitle(BasisLocalization.Get("library.trackerPicker.cancel"));
+            cancel.rectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, 125);
+            cancel.rectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, 50);
+            cancel.OnClicked += () => picker.Cancel(null);
+
+            List<BasisInput> candidates = CollectBindableTrackers();
+            // Same reach rule as grabbing the prop, so the picker never offers a
+            // tracker the bind gate would refuse. The distances are a snapshot at
+            // open; the manager re-checks range when the choice lands.
+            BasisPickupInteractable pickup = BasisTrackerObjectManager.ResolvePickup(target);
+            int eligible = candidates.Count;
+            candidates.RemoveAll(t => !BasisTrackerObjectManager.IsWithinBindRange(t.transform.position, target, pickup));
+            if (candidates.Count == 0)
+            {
+                PanelTextField empty = PanelTextField.CreateNew(PanelTextField.TextFieldStyles.Entry, picker.Descriptor.ContentParent);
+                empty._inputField.gameObject.SetActive(false);
+                empty.Descriptor.SetTitle(BasisLocalization.Get(eligible > 0
+                    ? "library.trackerPicker.outOfRange"
+                    : "library.trackerPicker.empty"));
+            }
+            else
+            {
+                for (int index = 0; index < candidates.Count; index++)
+                {
+                    BasisInput tracker = candidates[index];
+                    string roleLabel = tracker.TryGetRole(out BasisBoneTrackedRole role)
+                        ? role.ToString()
+                        : "Tracker";
+                    PanelButton row = PanelButton.CreateNew(PanelButton.ButtonStyles.StandardButton, picker.Descriptor.ContentParent);
+                    row.Descriptor.SetTitle($"{roleLabel} — {tracker.UniqueDeviceIdentifier}");
+                    row.SetSize(PickerRowSize);
+                    row.OnClicked += () => picker.CloseWithResult(tracker);
+                }
+            }
+
+            return await picker.WaitAsync();
+        }
+
+        private static List<BasisInput> CollectBindableTrackers()
+        {
+            List<BasisInput> result = new List<BasisInput>();
+            BasisObservableList<BasisInput> devices = BasisDeviceManagement.Instance?.AllInputDevices;
+            if (devices == null) return result;
+
+            for (int i = 0; i < devices.Count; i++)
+            {
+                BasisInput input = devices[i];
+                if (input == null) continue;
+                if (string.IsNullOrEmpty(input.UniqueDeviceIdentifier)) continue;
+                if (input is BasisVirtualMidpointInput) continue;
+                if (input.IsLinked) continue;
+                if (BasisTrackerRoleOverride.TryGetOverride(input.UniqueDeviceIdentifier, out _)) continue;
+                if (input.DeviceMatchSettings != null && input.DeviceMatchSettings.HasTrackedRole) continue;
+                // A tracker already driving a body bone (post-calibration) is excluded so
+                // calibration and prop binding can't fight over the same device. To reuse
+                // a calibrated tracker, decalibrate first.
+                if (input.TryGetRole(out _)) continue;
+                // One tracker drives at most one prop; unbind it there first.
+                if (BasisTrackerObjectManager.IsTrackerBound(input)) continue;
+
+                result.Add(input);
+            }
+            return result;
+        }
+    }
+}

--- a/Basis/Packages/com.basis.integration.trackerobjects/Runtime/BasisTrackerObjectsLibraryHook.cs
+++ b/Basis/Packages/com.basis.integration.trackerobjects/Runtime/BasisTrackerObjectsLibraryHook.cs
@@ -23,9 +23,26 @@ namespace Basis.Integration.TrackerObjects
         // transient; entries go stale when the tab rebuilds and are pruned on use.
         private static readonly Dictionary<string, PanelButton> _rowButtons = new Dictionary<string, PanelButton>();
 
+        // The device list this hook is watching for spare-tracker availability.
+        // Subscribed lazily from OnRowCreated because BasisDeviceManagement.Instance
+        // doesn't exist yet at SubsystemRegistration, and re-checked there in case
+        // the singleton was reassigned.
+        private static BasisObservableList<BasisInput> _watchedDevices;
+        private static readonly List<string> _staleRowKeys = new List<string>();
+
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         private static void Subscribe()
         {
+            // Statics survive Play sessions when domain reload is disabled; drop the
+            // dead session's device watch and row cache before re-registering.
+            if (_watchedDevices != null)
+            {
+                _watchedDevices.OnListChanged -= RefreshAllButtonVisibility;
+                _watchedDevices = null;
+            }
+            _rowButtons.Clear();
+            _staleRowKeys.Clear();
+
             LibraryProvider.OnInstanceRowCreated -= OnRowCreated;
             LibraryProvider.OnInstanceRowCreated += OnRowCreated;
             BasisTrackerObjectManager.OnBindingCreated -= OnBindingCreated;
@@ -34,9 +51,19 @@ namespace Basis.Integration.TrackerObjects
             BasisTrackerObjectManager.OnBindingRemoved += OnBindingRemoved;
         }
 
-        private static void OnBindingCreated(BasisTrackerBinding binding) => RefreshRowButton(binding.LoadedNetID, bound: true);
+        private static void OnBindingCreated(BasisTrackerBinding binding)
+        {
+            RefreshRowButton(binding.LoadedNetID, bound: true);
+            // Binding a tracker can consume the last spare; unbound rows lose their button.
+            RefreshAllButtonVisibility();
+        }
 
-        private static void OnBindingRemoved(BasisTrackerBinding binding) => RefreshRowButton(binding.LoadedNetID, bound: false);
+        private static void OnBindingRemoved(BasisTrackerBinding binding)
+        {
+            RefreshRowButton(binding.LoadedNetID, bound: false);
+            // Unbinding frees a tracker back into the spare pool; hidden buttons return.
+            RefreshAllButtonVisibility();
+        }
 
         private static void RefreshRowButton(string netID, bool bound)
         {
@@ -52,6 +79,47 @@ namespace Basis.Integration.TrackerObjects
             button.Descriptor.SetTooltip(BasisLocalization.Get(bound
                 ? "library.instantiated.unbindTracker.tooltip"
                 : "library.instantiated.assignTracker.tooltip"));
+        }
+
+        private static void WatchDeviceList()
+        {
+            BasisObservableList<BasisInput> devices = BasisDeviceManagement.Instance?.AllInputDevices;
+            if (devices == null || ReferenceEquals(devices, _watchedDevices)) return;
+            if (_watchedDevices != null)
+            {
+                _watchedDevices.OnListChanged -= RefreshAllButtonVisibility;
+            }
+            devices.OnListChanged += RefreshAllButtonVisibility;
+            _watchedDevices = devices;
+        }
+
+        /// <summary>
+        /// A row's button shows when a spare bindable tracker exists, or when its prop
+        /// is already bound (the Unlink action must stay reachable regardless).
+        /// </summary>
+        private static bool ShouldShowButton(string netID, bool anySpare)
+        {
+            return anySpare || BasisTrackerObjectManager.TryGetBindingByLoadedNetID(netID, out _);
+        }
+
+        private static void RefreshAllButtonVisibility()
+        {
+            bool anySpare = HasSpareTracker();
+            _staleRowKeys.Clear();
+            foreach (KeyValuePair<string, PanelButton> pair in _rowButtons)
+            {
+                if (pair.Value == null)
+                {
+                    _staleRowKeys.Add(pair.Key);
+                    continue;
+                }
+                pair.Value.Descriptor.SetActive(ShouldShowButton(pair.Key, anySpare));
+            }
+            int staleCount = _staleRowKeys.Count;
+            for (int index = 0; index < staleCount; index++)
+            {
+                _rowButtons.Remove(_staleRowKeys[index]);
+            }
         }
 
         private static void OnRowCreated(RectTransform parent, BasisRuntimeSpawnRegistry.SpawnInstance instance)
@@ -70,6 +138,8 @@ namespace Basis.Integration.TrackerObjects
             // Modified broadcast, so the button reappears when the lock clears.
             if (instance.Static) return;
 
+            WatchDeviceList();
+
             bool hasBinding = BasisTrackerObjectManager.TryGetBindingByLoadedNetID(netID, out _);
             PanelButton button = PanelButton.CreateNew(PanelButton.ButtonStyles.StandardButton, parent);
             button.Descriptor.SetTitle(string.Empty);
@@ -82,6 +152,12 @@ namespace Basis.Integration.TrackerObjects
                 ? "library.instantiated.unbindTracker.tooltip"
                 : "library.instantiated.assignTracker.tooltip"));
             _rowButtons[netID] = button;
+            // Built hidden when no spare tracker exists (and this prop isn't bound);
+            // the device-list and binding subscriptions bring it back live.
+            if (!hasBinding && !HasSpareTracker())
+            {
+                button.Descriptor.SetActive(false);
+            }
 
             // Icon and tooltip updates flow from OnBindingCreated/OnBindingRemoved
             // (via RefreshRowButton), so the click handler only drives the manager.
@@ -159,29 +235,49 @@ namespace Basis.Integration.TrackerObjects
             return await picker.WaitAsync();
         }
 
+        private static bool IsBindableSpareTracker(BasisInput input)
+        {
+            if (input == null) return false;
+            if (string.IsNullOrEmpty(input.UniqueDeviceIdentifier)) return false;
+            if (input is BasisVirtualMidpointInput) return false;
+            if (input.IsLinked) return false;
+            if (BasisTrackerRoleOverride.TryGetOverride(input.UniqueDeviceIdentifier, out _)) return false;
+            if (input.DeviceMatchSettings != null && input.DeviceMatchSettings.HasTrackedRole) return false;
+            // A tracker already driving a body bone (post-calibration) is excluded so
+            // calibration and prop binding can't fight over the same device. To reuse
+            // a calibrated tracker, decalibrate first.
+            if (input.TryGetRole(out _)) return false;
+            // One tracker drives at most one prop; unbind it there first.
+            if (BasisTrackerObjectManager.IsTrackerBound(input)) return false;
+            return true;
+        }
+
+        private static bool HasSpareTracker()
+        {
+            BasisObservableList<BasisInput> devices = BasisDeviceManagement.Instance?.AllInputDevices;
+            if (devices == null) return false;
+            int count = devices.Count;
+            for (int i = 0; i < count; i++)
+            {
+                if (IsBindableSpareTracker(devices[i])) return true;
+            }
+            return false;
+        }
+
         private static List<BasisInput> CollectBindableTrackers()
         {
             List<BasisInput> result = new List<BasisInput>();
             BasisObservableList<BasisInput> devices = BasisDeviceManagement.Instance?.AllInputDevices;
             if (devices == null) return result;
 
-            for (int i = 0; i < devices.Count; i++)
+            int count = devices.Count;
+            for (int i = 0; i < count; i++)
             {
                 BasisInput input = devices[i];
-                if (input == null) continue;
-                if (string.IsNullOrEmpty(input.UniqueDeviceIdentifier)) continue;
-                if (input is BasisVirtualMidpointInput) continue;
-                if (input.IsLinked) continue;
-                if (BasisTrackerRoleOverride.TryGetOverride(input.UniqueDeviceIdentifier, out _)) continue;
-                if (input.DeviceMatchSettings != null && input.DeviceMatchSettings.HasTrackedRole) continue;
-                // A tracker already driving a body bone (post-calibration) is excluded so
-                // calibration and prop binding can't fight over the same device. To reuse
-                // a calibrated tracker, decalibrate first.
-                if (input.TryGetRole(out _)) continue;
-                // One tracker drives at most one prop; unbind it there first.
-                if (BasisTrackerObjectManager.IsTrackerBound(input)) continue;
-
-                result.Add(input);
+                if (IsBindableSpareTracker(input))
+                {
+                    result.Add(input);
+                }
             }
             return result;
         }

--- a/Basis/Packages/com.basis.integration.trackerobjects/Runtime/BasisTrackerObjectsLibraryHook.cs
+++ b/Basis/Packages/com.basis.integration.trackerobjects/Runtime/BasisTrackerObjectsLibraryHook.cs
@@ -18,11 +18,40 @@ namespace Basis.Integration.TrackerObjects
         private static readonly Vector2 RowSize = new Vector2(80, 80);
         private static readonly Vector2 PickerRowSize = new Vector2(700, 60);
 
+        // Latest row button per netID, so a binding dissolving externally (steal,
+        // static lock, tracker loss) can update the open menu's icon. Rows are
+        // transient; entries go stale when the tab rebuilds and are pruned on use.
+        private static readonly Dictionary<string, PanelButton> _rowButtons = new Dictionary<string, PanelButton>();
+
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         private static void Subscribe()
         {
             LibraryProvider.OnInstanceRowCreated -= OnRowCreated;
             LibraryProvider.OnInstanceRowCreated += OnRowCreated;
+            BasisTrackerObjectManager.OnBindingCreated -= OnBindingCreated;
+            BasisTrackerObjectManager.OnBindingCreated += OnBindingCreated;
+            BasisTrackerObjectManager.OnBindingRemoved -= OnBindingRemoved;
+            BasisTrackerObjectManager.OnBindingRemoved += OnBindingRemoved;
+        }
+
+        private static void OnBindingCreated(BasisTrackerBinding binding) => RefreshRowButton(binding.LoadedNetID, bound: true);
+
+        private static void OnBindingRemoved(BasisTrackerBinding binding) => RefreshRowButton(binding.LoadedNetID, bound: false);
+
+        private static void RefreshRowButton(string netID, bool bound)
+        {
+            if (string.IsNullOrEmpty(netID)) return;
+            if (!_rowButtons.TryGetValue(netID, out PanelButton button)) return;
+            if (button == null)
+            {
+                // The menu closed or the tab rebuilt since this row was recorded.
+                _rowButtons.Remove(netID);
+                return;
+            }
+            button.SetIcon(bound ? AddressableAssets.Sprites.Unlink : AddressableAssets.Sprites.Link);
+            button.Descriptor.SetTooltip(BasisLocalization.Get(bound
+                ? "library.instantiated.unbindTracker.tooltip"
+                : "library.instantiated.assignTracker.tooltip"));
         }
 
         private static void OnRowCreated(RectTransform parent, BasisRuntimeSpawnRegistry.SpawnInstance instance)
@@ -52,14 +81,15 @@ namespace Basis.Integration.TrackerObjects
             button.Descriptor.SetTooltip(BasisLocalization.Get(hasBinding
                 ? "library.instantiated.unbindTracker.tooltip"
                 : "library.instantiated.assignTracker.tooltip"));
+            _rowButtons[netID] = button;
 
+            // Icon and tooltip updates flow from OnBindingCreated/OnBindingRemoved
+            // (via RefreshRowButton), so the click handler only drives the manager.
             button.OnClicked += async () =>
             {
                 if (BasisTrackerObjectManager.TryGetBindingByLoadedNetID(netID, out BasisTrackerBinding existing))
                 {
                     BasisTrackerObjectManager.TryRemoveBinding(existing.Id);
-                    button.SetIcon(AddressableAssets.Sprites.Link);
-                    button.Descriptor.SetTooltip(BasisLocalization.Get("library.instantiated.assignTracker.tooltip"));
                     return;
                 }
 
@@ -77,12 +107,7 @@ namespace Basis.Integration.TrackerObjects
                 // duplicate-binding races are re-checked inside the manager.
                 if (!BasisRuntimeSpawnRegistry.SpawnedGameobjects.TryGetValue(netID, out go) || go == null) return;
 
-                BasisTrackerBinding created = await BasisTrackerObjectManager.TryCreateBindingAsync(chosen, go.transform, netID);
-                if (created != null && button != null)
-                {
-                    button.SetIcon(AddressableAssets.Sprites.Unlink);
-                    button.Descriptor.SetTooltip(BasisLocalization.Get("library.instantiated.unbindTracker.tooltip"));
-                }
+                await BasisTrackerObjectManager.TryCreateBindingAsync(chosen, go.transform, netID);
             };
         }
 

--- a/Basis/Packages/com.basis.integration.trackerobjects/Runtime/BasisTrackerObjectsLibraryHook.cs.meta
+++ b/Basis/Packages/com.basis.integration.trackerobjects/Runtime/BasisTrackerObjectsLibraryHook.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a9316928431e2d34baf18718780b977c

--- a/Basis/Packages/com.basis.integration.trackerobjects/package.json
+++ b/Basis/Packages/com.basis.integration.trackerobjects/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "com.basis.integration.trackerobjects",
+  "displayName": "Basis Tracker Objects Integration",
+  "version": "0.0.1",
+  "description": "Wires com.basis.trackerobjects into the Basis library menu. Adds the Assign/Unbind Tracker button and the tracker-picker dialog. Compiles only when both com.basis.framework and com.basis.trackerobjects are present.",
+  "author": {
+    "name": "BasisVR",
+    "url": "https://github.com/BasisVR"
+  },
+  "dependencies": {
+    "com.unity.ugui": "2.0.0"
+  },
+  "vpmDependencies": {
+    "com.basis.framework": "0.0.1",
+    "com.basis.sdk": "0.0.1",
+    "com.basis.trackerobjects": "0.0.1"
+  }
+}

--- a/Basis/Packages/com.basis.integration.trackerobjects/package.json.meta
+++ b/Basis/Packages/com.basis.integration.trackerobjects/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b2cab1f2262ce9e45a4f029194039de9
+PackageManifestImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Basis/Packages/com.basis.sdk/Scripts/Basis Logger/BasisDebug.cs
+++ b/Basis/Packages/com.basis.sdk/Scripts/Basis Logger/BasisDebug.cs
@@ -223,6 +223,7 @@ public static class BasisDebug
             LogTag.LocalNetwork => "#ff0055",
             LogTag.AuthoredMotion => "#BA55D3", // Medium Orchid
             LogTag.Rendering => "#ADFF2F",    // Green Yellow
+            LogTag.TrackerObjects => "#F4A460", // Sandy Brown
             _ => "#FFFFFF"                    // Default White
         };
     }
@@ -274,6 +275,7 @@ public static class BasisDebug
         LocalNetwork,
         AuthoredMotion,
         Rendering,
+        TrackerObjects,
     }
 
     public enum MessageType

--- a/Basis/Packages/com.basis.trackerobjects/LICENSE.md
+++ b/Basis/Packages/com.basis.trackerobjects/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 BasisVR
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Basis/Packages/com.basis.trackerobjects/LICENSE.md.meta
+++ b/Basis/Packages/com.basis.trackerobjects/LICENSE.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8f674a0ab242d304db0a81442e8b4c2c
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Basis/Packages/com.basis.trackerobjects/Runtime.meta
+++ b/Basis/Packages/com.basis.trackerobjects/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b44537b3dcedc2645bd3156ecf9c6db3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Basis/Packages/com.basis.trackerobjects/Runtime/BasisTrackerBinding.cs
+++ b/Basis/Packages/com.basis.trackerobjects/Runtime/BasisTrackerBinding.cs
@@ -1,0 +1,29 @@
+using Basis.Scripts.BasisSdk.Interactions;
+using Basis.Scripts.Device_Management.Devices;
+using UnityEngine;
+
+namespace Basis.TrackerObjects
+{
+    public class BasisTrackerBinding
+    {
+        public int Id;
+        public BasisInput Tracker;
+        public Transform Target;
+        public string UniqueDeviceIdentifier;
+        public string LoadedNetID;
+        // Read every frame by the render drive, so external code can adjust a grip
+        // offset on a live binding.
+        public Vector3 LocalPositionOffset;
+        public Quaternion LocalRotationOffset;
+
+        // Capture/restore state for a clean unbind; internal so outside code can't
+        // desync it from the bind/unbind lifecycle.
+        internal BasisPickupInteractable PickupRef;
+        internal Rigidbody RigidRef;
+        internal bool PreBindKinematic;
+        internal bool HasKinematicCaptured;
+
+        internal BasisPickupSyncNetworking SyncRef;
+        internal bool PreBindDistanceReduction;
+    }
+}

--- a/Basis/Packages/com.basis.trackerobjects/Runtime/BasisTrackerBinding.cs.meta
+++ b/Basis/Packages/com.basis.trackerobjects/Runtime/BasisTrackerBinding.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 967b93cccbc1a3846a11dcec83ef1d7d

--- a/Basis/Packages/com.basis.trackerobjects/Runtime/BasisTrackerObjectManager.cs
+++ b/Basis/Packages/com.basis.trackerobjects/Runtime/BasisTrackerObjectManager.cs
@@ -1,0 +1,420 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Basis.Scripts.BasisSdk.Interactions;
+using Basis.Scripts.BasisSdk.Players;
+using Basis.Scripts.Device_Management.Devices;
+using Basis.Scripts.Networking;
+using UnityEngine;
+
+namespace Basis.TrackerObjects
+{
+    public static class BasisTrackerObjectManager
+    {
+        public const int RenderPriority = 99;
+
+        // Reach for props without a pickup surface (no colliders to measure against);
+        // matches the BasisInteractableObject.InteractRange default.
+        public const float FallbackBindRange = 1f;
+
+        // Read-only outside: adding or removing entries directly would skip the
+        // bind/unbind lifecycle (deny predicates, kinematic restore, DistanceReduction,
+        // the events below). Go through TryCreateBindingAsync / TryRemoveBinding.
+        private static readonly List<BasisTrackerBinding> _bindings = new List<BasisTrackerBinding>();
+        public static IReadOnlyList<BasisTrackerBinding> Bindings => _bindings;
+
+        public static event Action<BasisTrackerBinding> OnBindingCreated;
+        public static event Action<BasisTrackerBinding> OnBindingRemoved;
+
+        private static int _nextID = 1;
+        private static bool _subscribed;
+
+        // Single shared deny predicates — each binding lives on a distinct
+        // BasisPickupInteractable (enforced by the LoadedNetID dedup), so the same
+        // delegate instance is added once per pickup list and removed once on unbind.
+        private static readonly Func<BasisInput, bool> _denyHover = static _ => false;
+        private static readonly Func<BasisInput, bool> _denyInteract = static _ => false;
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        private static void Initialize()
+        {
+            if (_subscribed)
+            {
+                return;
+            }
+            BasisLocalPlayer.AfterSimulateOnRender.AddAction(RenderPriority, OnAfterSimulateOnRender);
+            BasisRuntimeSpawnRegistry.OnRegistryChanged += OnRegistryChanged;
+            _subscribed = true;
+            BasisDebug.Log("BasisTrackerObjectManager subscribed", BasisDebug.LogTag.TrackerObjects);
+        }
+
+        public static async Task<BasisTrackerBinding> TryCreateBindingAsync(BasisInput tracker, Transform target, string loadedNetID)
+        {
+            if (tracker == null || target == null)
+            {
+                BasisDebug.LogError("TryCreateBindingAsync: tracker or target was null", BasisDebug.LogTag.TrackerObjects);
+                return null;
+            }
+            if (string.IsNullOrEmpty(loadedNetID))
+            {
+                BasisDebug.LogError("TryCreateBindingAsync: loadedNetID was null/empty", BasisDebug.LogTag.TrackerObjects);
+                return null;
+            }
+            if (TryGetBindingByLoadedNetID(loadedNetID, out _))
+            {
+                BasisDebug.LogWarning($"TryCreateBindingAsync: a binding for LoadedNetID {loadedNetID} already exists", BasisDebug.LogTag.TrackerObjects);
+                return null;
+            }
+            if (IsTrackerBound(tracker))
+            {
+                BasisDebug.LogWarning($"TryCreateBindingAsync: tracker {tracker.UniqueDeviceIdentifier} is already driving another binding", BasisDebug.LogTag.TrackerObjects);
+                return null;
+            }
+
+            BasisPickupInteractable pickup = ResolvePickup(target);
+            if (!IsWithinBindRange(tracker.transform.position, target, pickup))
+            {
+                BasisDebug.LogWarning($"TryCreateBindingAsync: tracker {tracker.UniqueDeviceIdentifier} is out of interaction range of {target.name}, refusing to bind", BasisDebug.LogTag.TrackerObjects);
+                return null;
+            }
+
+            target.TryGetComponent(out BasisPickupSyncNetworking sync);
+            if (sync == null)
+            {
+                BasisDebug.LogWarning($"TryCreateBindingAsync: target {target.name} has no BasisPickupSyncNetworking — local-only motion, remote players will not see the binding move", BasisDebug.LogTag.TrackerObjects);
+            }
+            else
+            {
+                if (sync.IsStatic)
+                {
+                    BasisDebug.LogWarning($"TryCreateBindingAsync: {target.name} is static/locked, refusing to bind", BasisDebug.LogTag.TrackerObjects);
+                    return null;
+                }
+                if (!sync.CanNetworkSteal && !sync.IsOwnedLocallyOnClient && BasisNetworkConnection.LocalPlayerIsConnected)
+                {
+                    // Binding claims ownership, which is a steal when someone else owns
+                    // the prop — respect the pickup's no-steal rule.
+                    BasisDebug.LogWarning($"TryCreateBindingAsync: {target.name} is owned elsewhere and does not allow network steal", BasisDebug.LogTag.TrackerObjects);
+                    return null;
+                }
+                if (BasisNetworkConnection.LocalPlayerIsConnected)
+                {
+                    // Only the owner's transform writes go on the wire, so claim ownership
+                    // up front instead of driving a prop nobody streams. The name is
+                    // captured because the ownership round-trip yields and the logs below
+                    // must not dereference a since-destroyed target.
+                    string targetName = target.name;
+                    BasisOwnershipResult result;
+                    try
+                    {
+                        result = await sync.TakeOwnershipAsync();
+                    }
+                    catch (Exception e)
+                    {
+                        // Keep the method's failure contract: every failed bind returns
+                        // null instead of faulting the task up into a UI click handler.
+                        BasisDebug.LogError($"TryCreateBindingAsync: TakeOwnershipAsync threw for {targetName}: {e}", BasisDebug.LogTag.TrackerObjects);
+                        return null;
+                    }
+                    if (tracker == null || target == null || sync == null)
+                    {
+                        BasisDebug.LogWarning($"TryCreateBindingAsync: binding objects for {targetName} were destroyed while taking ownership", BasisDebug.LogTag.TrackerObjects);
+                        return null;
+                    }
+                    if (!result.Success)
+                    {
+                        BasisDebug.LogWarning($"TryCreateBindingAsync: could not take ownership of {targetName}", BasisDebug.LogTag.TrackerObjects);
+                        return null;
+                    }
+                    if (TryGetBindingByLoadedNetID(loadedNetID, out _) || IsTrackerBound(tracker))
+                    {
+                        // a second bind raced the ownership round-trip
+                        return null;
+                    }
+                    if (!IsWithinBindRange(tracker.transform.position, target, pickup))
+                    {
+                        BasisDebug.LogWarning($"TryCreateBindingAsync: tracker {tracker.UniqueDeviceIdentifier} moved out of range of {targetName} during the ownership round-trip, refusing to bind", BasisDebug.LogTag.TrackerObjects);
+                        return null;
+                    }
+                }
+            }
+
+            tracker.transform.GetPositionAndRotation(out Vector3 trackerPos, out Quaternion trackerRot);
+            target.GetPositionAndRotation(out Vector3 targetPos, out Quaternion targetRot);
+            Quaternion invRot = Quaternion.Inverse(trackerRot);
+
+            BasisTrackerBinding binding = new BasisTrackerBinding
+            {
+                Id = _nextID++,
+                Tracker = tracker,
+                Target = target,
+                UniqueDeviceIdentifier = tracker.UniqueDeviceIdentifier,
+                LoadedNetID = loadedNetID,
+                LocalPositionOffset = invRot * (targetPos - trackerPos),
+                LocalRotationOffset = invRot * targetRot,
+                SyncRef = sync,
+            };
+
+            if (pickup != null)
+            {
+                binding.PickupRef = pickup;
+                // The deny predicates only block future grabs; a hold that's already in
+                // progress keeps driving the transform, so end it before the tracker
+                // takes over.
+                pickup.Drop();
+                pickup.CanHoverInjected.Add(_denyHover);
+                pickup.CanInteractInjected.Add(_denyInteract);
+            }
+
+            // Pickup-less props can still carry a Rigidbody; freeze it too or physics
+            // fights the render-time pose writes.
+            Rigidbody rigid = pickup != null ? pickup.RigidRef : null;
+            if (rigid == null)
+            {
+                target.TryGetComponent(out rigid);
+            }
+            if (rigid != null)
+            {
+                binding.RigidRef = rigid;
+                binding.PreBindKinematic = rigid.isKinematic;
+                binding.HasKinematicCaptured = true;
+                rigid.isKinematic = true;
+            }
+
+            if (sync != null)
+            {
+                // A tracker-driven prop is being actively manipulated and watched like a
+                // held one, so keep its send rate full instead of letting viewer distance
+                // throttle it (same rationale as FullRateWhileHeld on the pickup sync).
+                binding.PreBindDistanceReduction = sync.DistanceReduction;
+                sync.DistanceReduction = false;
+            }
+
+            _bindings.Add(binding);
+            BasisDebug.Log($"Created tracker binding {binding.Id} for {tracker.UniqueDeviceIdentifier} -> {target.name} (netID {loadedNetID})", BasisDebug.LogTag.TrackerObjects);
+            InvokeSafely(OnBindingCreated, binding);
+            return binding;
+        }
+
+        // Bind/unbind frequency only, never per-frame: RemoveAt runs inside loops
+        // (render tick, ClearedAll), so a throwing subscriber must not abort the
+        // remaining bindings' cleanup — and GetInvocationList's allocation is fine
+        // at this rate.
+        private static void InvokeSafely(Action<BasisTrackerBinding> handlers, BasisTrackerBinding binding)
+        {
+            if (handlers == null)
+            {
+                return;
+            }
+            foreach (Action<BasisTrackerBinding> handler in handlers.GetInvocationList())
+            {
+                try
+                {
+                    handler(binding);
+                }
+                catch (Exception e)
+                {
+                    BasisDebug.LogError($"Tracker binding subscriber {handler.Method.DeclaringType?.FullName}.{handler.Method.Name} threw: {e}", BasisDebug.LogTag.TrackerObjects);
+                }
+            }
+        }
+
+        /// <summary>
+        /// The prop's pickup surface: the sync component's cached reference when there is
+        /// one (it discovers pickups on children too), else a pickup on the root.
+        /// </summary>
+        public static BasisPickupInteractable ResolvePickup(Transform target)
+        {
+            if (target == null)
+            {
+                return null;
+            }
+            if (target.TryGetComponent(out BasisPickupSyncNetworking sync) && sync.BasisPickupInteractable != null)
+            {
+                return sync.BasisPickupInteractable;
+            }
+            target.TryGetComponent(out BasisPickupInteractable pickup);
+            return pickup;
+        }
+
+        /// <summary>
+        /// Same reach rule as grabbing: within the pickup's interact range of its
+        /// colliders, or within <see cref="FallbackBindRange"/> of the transform when
+        /// the prop has no pickup surface. Gates both the bind itself and which
+        /// trackers a picker should offer.
+        /// </summary>
+        public static bool IsWithinBindRange(Vector3 sourcePosition, Transform target, BasisPickupInteractable pickup)
+        {
+            if (pickup != null)
+            {
+                return pickup.IsWithinRange(sourcePosition, pickup.InteractRange);
+            }
+            return target != null && Vector3.Distance(target.position, sourcePosition) <= FallbackBindRange;
+        }
+
+        public static bool TryRemoveBinding(int id)
+        {
+            int count = _bindings.Count;
+            for (int index = 0; index < count; index++)
+            {
+                if (_bindings[index].Id == id)
+                {
+                    RemoveAt(index);
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>One tracker drives at most one prop; true if this one is taken.</summary>
+        public static bool IsTrackerBound(BasisInput tracker)
+        {
+            if (tracker == null)
+            {
+                return false;
+            }
+            int count = _bindings.Count;
+            for (int index = 0; index < count; index++)
+            {
+                if (_bindings[index].Tracker == tracker)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public static bool TryGetBindingByLoadedNetID(string loadedNetID, out BasisTrackerBinding binding)
+        {
+            binding = null;
+            if (string.IsNullOrEmpty(loadedNetID))
+            {
+                return false;
+            }
+            int count = _bindings.Count;
+            for (int index = 0; index < count; index++)
+            {
+                BasisTrackerBinding b = _bindings[index];
+                if (b.LoadedNetID == loadedNetID)
+                {
+                    binding = b;
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private static void RemoveAt(int index)
+        {
+            BasisTrackerBinding binding = _bindings[index];
+            if (binding.PickupRef != null)
+            {
+                binding.PickupRef.CanHoverInjected.Remove(_denyHover);
+                binding.PickupRef.CanInteractInjected.Remove(_denyInteract);
+            }
+            // Restore the captured kinematic state first; for a rigidbody the sync
+            // actually manages, ControlState below overrides it with the state derived
+            // from current ownership/static. The order matters because ControlState
+            // no-ops when the sync has no pickup rigidbody (SetIsKinematicOnPickup),
+            // and the capture is then the only restore path.
+            if (binding.HasKinematicCaptured && binding.RigidRef != null)
+            {
+                binding.RigidRef.isKinematic = binding.PreBindKinematic;
+            }
+            if (binding.SyncRef != null)
+            {
+                binding.SyncRef.DistanceReduction = binding.PreBindDistanceReduction;
+                binding.SyncRef.ControlState();
+            }
+            _bindings.RemoveAt(index);
+            BasisDebug.Log($"Removed tracker binding {binding.Id}", BasisDebug.LogTag.TrackerObjects);
+            InvokeSafely(OnBindingRemoved, binding);
+        }
+
+        private static void OnAfterSimulateOnRender()
+        {
+            // AfterSimulateOnRender runs the framework's post-sim subscribers as one
+            // sequential chain; contain any failure here so the rest still tick.
+            try
+            {
+                for (int index = _bindings.Count - 1; index >= 0; index--)
+                {
+                    if (index >= _bindings.Count)
+                    {
+                        // An OnBindingRemoved subscriber removed entries during this pass;
+                        // fall through until the index is valid again.
+                        continue;
+                    }
+                    BasisTrackerBinding binding = _bindings[index];
+                    if (binding.Tracker == null || binding.Target == null)
+                    {
+                        // Tracker disconnected or prop destroyed out from under us — release
+                        // the binding so the deny predicates lift and the netID can rebind.
+                        RemoveAt(index);
+                        continue;
+                    }
+                    if (binding.SyncRef != null && !binding.SyncRef.IsOwnedLocallyOnClient)
+                    {
+                        // Another client took ownership (steal is evaluated on the stealing
+                        // client, so it can't be locked out from here). Their stream drives
+                        // the prop now; dissolve the binding rather than fight it.
+                        RemoveAt(index);
+                        continue;
+                    }
+                    // BasisPickupSyncNetworking.ControlState flips isKinematic = false on
+                    // locally-owned props and re-fires on ownership events long after bind.
+                    // Re-asserting kinematic each frame is cheap and keeps physics from
+                    // advancing the prop between our writes.
+                    if (binding.HasKinematicCaptured && binding.RigidRef != null)
+                    {
+                        binding.RigidRef.isKinematic = true;
+                    }
+                    binding.Tracker.transform.GetPositionAndRotation(out Vector3 trackerPos, out Quaternion trackerRot);
+                    binding.Target.SetPositionAndRotation(
+                        trackerPos + trackerRot * binding.LocalPositionOffset,
+                        trackerRot * binding.LocalRotationOffset);
+                }
+            }
+            catch (Exception e)
+            {
+                BasisDebug.LogErrorOnce($"Tracker binding drive failed: {e}", BasisDebug.LogTag.TrackerObjects);
+            }
+        }
+
+        private static void OnRegistryChanged(BasisRuntimeSpawnRegistry.RegistryChangeType type, BasisRuntimeSpawnRegistry.SpawnInstance instance)
+        {
+            switch (type)
+            {
+                case BasisRuntimeSpawnRegistry.RegistryChangeType.Removed:
+                case BasisRuntimeSpawnRegistry.RegistryChangeType.ClearedUrl:
+                    if (instance != null && TryGetBindingByLoadedNetID(instance.LoadedNetID, out BasisTrackerBinding binding))
+                    {
+                        TryRemoveBinding(binding.Id);
+                    }
+                    break;
+                case BasisRuntimeSpawnRegistry.RegistryChangeType.Modified:
+                    // The server-authoritative static lock freezes the prop for everyone;
+                    // release the tracker when it lands on a bound prop.
+                    if (instance != null && instance.Static && TryGetBindingByLoadedNetID(instance.LoadedNetID, out BasisTrackerBinding lockedBinding))
+                    {
+                        TryRemoveBinding(lockedBinding.Id);
+                    }
+                    break;
+                case BasisRuntimeSpawnRegistry.RegistryChangeType.ClearedAll:
+                    for (int index = _bindings.Count - 1; index >= 0; index--)
+                    {
+                        // An OnBindingRemoved subscriber may mutate the list reentrantly;
+                        // skip stale indices instead of throwing. A countdown (not a
+                        // while-drain) so a subscriber re-binding mid-clear can't spin
+                        // this forever.
+                        if (index >= _bindings.Count)
+                        {
+                            continue;
+                        }
+                        RemoveAt(index);
+                    }
+                    break;
+            }
+        }
+    }
+}

--- a/Basis/Packages/com.basis.trackerobjects/Runtime/BasisTrackerObjectManager.cs
+++ b/Basis/Packages/com.basis.trackerobjects/Runtime/BasisTrackerObjectManager.cs
@@ -38,6 +38,21 @@ namespace Basis.TrackerObjects
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         private static void Initialize()
         {
+            // Statics survive Play sessions when domain reload is disabled, and scene
+            // reload can be disabled independently, so a carried-over binding's objects
+            // may or may not still exist. Run the normal unbind path for each: its
+            // Unity-null checks no-op on destroyed objects, and any survivor gets its
+            // pickup predicates, kinematic state and send rate restored. Snapshot and
+            // remove by ID so a subscriber mutating the list reentrantly can't get a
+            // freshly created binding swept up by a stale index.
+            if (_bindings.Count > 0)
+            {
+                BasisTrackerBinding[] carriedOver = _bindings.ToArray();
+                for (int index = 0; index < carriedOver.Length; index++)
+                {
+                    TryRemoveBinding(carriedOver[index].Id);
+                }
+            }
             if (_subscribed)
             {
                 return;
@@ -206,8 +221,9 @@ namespace Basis.TrackerObjects
             {
                 return;
             }
-            foreach (Action<BasisTrackerBinding> handler in handlers.GetInvocationList())
+            foreach (Delegate subscriber in handlers.GetInvocationList())
             {
+                Action<BasisTrackerBinding> handler = (Action<BasisTrackerBinding>)subscriber;
                 try
                 {
                     handler(binding);
@@ -401,19 +417,17 @@ namespace Basis.TrackerObjects
                     }
                     break;
                 case BasisRuntimeSpawnRegistry.RegistryChangeType.ClearedAll:
-                    for (int index = _bindings.Count - 1; index >= 0; index--)
+                {
+                    // Snapshot and remove by ID: OnBindingRemoved subscribers can mutate
+                    // the list reentrantly, and index-based removal could sweep up a
+                    // binding created mid-clear. Rare event, so the allocation is fine.
+                    BasisTrackerBinding[] cleared = _bindings.ToArray();
+                    for (int index = 0; index < cleared.Length; index++)
                     {
-                        // An OnBindingRemoved subscriber may mutate the list reentrantly;
-                        // skip stale indices instead of throwing. A countdown (not a
-                        // while-drain) so a subscriber re-binding mid-clear can't spin
-                        // this forever.
-                        if (index >= _bindings.Count)
-                        {
-                            continue;
-                        }
-                        RemoveAt(index);
+                        TryRemoveBinding(cleared[index].Id);
                     }
                     break;
+                }
             }
         }
     }

--- a/Basis/Packages/com.basis.trackerobjects/Runtime/BasisTrackerObjectManager.cs.meta
+++ b/Basis/Packages/com.basis.trackerobjects/Runtime/BasisTrackerObjectManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9e1b6649bd24ed042bd5ca4b44a671cf

--- a/Basis/Packages/com.basis.trackerobjects/Runtime/BasisTrackerObjects.asmdef
+++ b/Basis/Packages/com.basis.trackerobjects/Runtime/BasisTrackerObjects.asmdef
@@ -1,0 +1,19 @@
+{
+    "name": "BasisTrackerObjects",
+    "rootNamespace": "Basis.TrackerObjects",
+    "references": [
+        "Basis Framework",
+        "BasisSDK",
+        "BasisCommon",
+        "BasisDebug"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Basis/Packages/com.basis.trackerobjects/Runtime/BasisTrackerObjects.asmdef.meta
+++ b/Basis/Packages/com.basis.trackerobjects/Runtime/BasisTrackerObjects.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2be0cf59cd21f8b4bb8bdcf097744459
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Basis/Packages/com.basis.trackerobjects/package.json
+++ b/Basis/Packages/com.basis.trackerobjects/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "com.basis.trackerobjects",
+  "displayName": "Basis Tracker Objects",
+  "version": "0.0.1",
+  "description": "Bind a SteamVR/OpenXR tracker to a spawned prop so its pose drives the transform every frame. Takes network ownership of the prop's BasisPickupSyncNetworking so the motion streams to remote players.",
+  "unity": "6000.0",
+  "author": {
+    "name": "BasisVR",
+    "url": "https://github.com/BasisVR"
+  },
+  "vpmDependencies": {
+    "com.basis.common": "0.0.1",
+    "com.basis.framework": "0.0.1",
+    "com.basis.sdk": "0.0.1"
+  },
+  "license": "MIT"
+}

--- a/Basis/Packages/com.basis.trackerobjects/package.json.meta
+++ b/Basis/Packages/com.basis.trackerobjects/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a45415a816141ff4096977b85f13038c
+PackageManifestImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Basis/Packages/packages-lock.json
+++ b/Basis/Packages/packages-lock.json
@@ -136,6 +136,14 @@
       "source": "embedded",
       "dependencies": {}
     },
+    "com.basis.integration.trackerobjects": {
+      "version": "file:com.basis.integration.trackerobjects",
+      "depth": 0,
+      "source": "embedded",
+      "dependencies": {
+        "com.unity.ugui": "2.0.0"
+      }
+    },
     "com.basis.integration.ytdlp": {
       "version": "file:com.basis.integration.ytdlp",
       "depth": 0,

--- a/Basis/Packages/packages-lock.json
+++ b/Basis/Packages/packages-lock.json
@@ -276,6 +276,12 @@
       "source": "embedded",
       "dependencies": {}
     },
+    "com.basis.trackerobjects": {
+      "version": "file:com.basis.trackerobjects",
+      "depth": 0,
+      "source": "embedded",
+      "dependencies": {}
+    },
     "com.basis.vehicles": {
       "version": "file:com.basis.vehicles",
       "depth": 0,


### PR DESCRIPTION
## Summary

Lets you bind a spare VR tracker to a spawned prop so the prop follows the tracker. Strap a tracker to a real chair, bind it to the matching prop in the library menu, and the virtual chair moves with the real one for everyone in the instance.

Two new embedded packages, plus small framework hooks:

- `com.basis.trackerobjects` — the binding manager. It captures the tracker-to-prop offset at bind time and drives the prop's transform every frame after IK has settled (`BasisLocalPlayer.AfterSimulateOnRender`, priority 99).
- `com.basis.integration.trackerobjects` — library menu integration. Prop rows on the Instantiated tab get an icon button that opens a picker of eligible spare trackers. Same bridge-package pattern as `com.basis.integration.audiolink`.
- Framework changes: a `LibraryProvider.OnInstanceRowCreated` event so integration packages can append row buttons (the row builder is private, and the framework can't reference the integration package back without an asmdef cycle), a `TrackerObjects` log tag, and the en.json strings.

No new sync surface. Binding takes network ownership of the prop's existing `BasisPickupSyncNetworking`, so the driven pose streams to remote players through the normal transform sync. Distance-based send-rate throttling is turned off while bound, for the same reason `FullRateWhileHeld` does it for held props. The binding releases itself when it loses the prop: someone steals ownership, the static lock lands on it, the prop is removed, or the tracker disconnects. On release the prop's kinematic state is handed back through `ControlState()`.

Rules:

- Binding needs the tracker within the prop's interact range, the same reach rule as grabbing it (1 m fallback for props with no pickup). The picker only lists in-range trackers, so you can't drive a prop from across the scene.
- One tracker drives at most one prop.
- Prop rows only (`SpawnMode.GameObject`); scenes, avatars, embedded and static-locked items don't get the button.
- While bound, the prop can't be grabbed locally (deny predicates on the pickup), and trackers doing body tracking are never offered for binding.

Trackers are local devices, so remote players can never see or bind yours. Two players binding the same prop resolves through the normal ownership/steal rules.

## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [x] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — `BasisEventDriver` runs the single per-frame tick that drives the whole framework (network apply, local player sim, blendshapes, JigglePhysics, nameplates, and more) as one sequential chain. An unhandled exception anywhere in that chain aborts the rest of the tick, so every step after the throwing one is silently skipped for that frame. New work added to the driver must either be guaranteed not to throw, or be wrapped in a `try`/`catch` that contains the failure and surfaces it through `BasisDebug` — logged once / rate-limited, never every frame (see the existing `HVRBasisBuiltInAddresses.Simulate()` guard for the pattern). Expect this to be scrutinized closely in review.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [x] Windows
- [ ] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [ ] Tested in VR (note headset under **Notes**)
- [x] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [ ] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [ ] N/A — change does not touch any of the above

## Notes

- Per-frame work rides `BasisLocalPlayer.AfterSimulateOnRender` (the framework's ordered post-sim delegate) rather than a MonoBehaviour `Update`. The callback body is wrapped in try/catch with a log-once error so a failure can't abort the rest of the chain.
- Jobification: not jobified. Steady-state work is one combined transform read and one combined write per binding, and realistic binding counts are single digits (bounded by physical trackers), so `TransformAccessArray` batching would cost more in setup than it saves. Can revisit if binding counts ever grow.
- Camera box: N/A — nothing here touches the camera.
- Access lockdowns box: `Bindings` is exposed as `IReadOnlyList` and the binding's capture/restore fields are `internal`, because outside writes to those desync the unbind cleanup (kinematic restore, deny-predicate removal, send-rate restore). Identity fields and the grip offsets stay public plain fields; the offsets are read live every frame, so adjusting them on an existing binding is supported.
- The drive loop re-reads `_bindings.Count` inside a guard on purpose: binding-event subscribers may remove entries reentrantly, and the stale-index check needs the live count.
- The bind/unbind events invoke per-subscriber via `GetInvocationList`, which allocates; that happens at bind/unbind frequency only, never per frame.
- Localisation strings are en.json only for now; other locales fall back.
- Tested: editor plus a Windows x64 standalone build, two clients networked, with virtual Tracker Pucks created through the Editor. Covered: bind/unbind, range gating (picker filtering and bind refusal), remote clients seeing tracker-driven motion, a cross-client ownership steal dissolving the binding on the original client, and tracker power-off cleaning up the binding. 
