### PR TITLE
fix(mediaplayer): apply AudioSource volume, mute and filters on the outputs

### DIFF
--- a/Basis/Packages/com.basis.mediaplayer/Editor/BasisMediaPlayerAudioInspector.cs
+++ b/Basis/Packages/com.basis.mediaplayer/Editor/BasisMediaPlayerAudioInspector.cs
@@ -1,5 +1,6 @@
 using UnityEditor;
 using UnityEditor.UIElements;
+using UnityEngine;
 using UnityEngine.UIElements;
 
 [CustomEditor(typeof(BasisMediaPlayerAudio))]
@@ -33,6 +34,11 @@ public class BasisMediaPlayerAudioInspector : Editor
         BindByName("VolumeGainField", "VolumeGain");
         BindByName("MuteField", "Mute");
         _root.Bind(serializedObject);
+
+        _root.Insert(0, new BasisMediaPlayerTapOrdering.Notice(
+            () => (target as BasisMediaPlayerAudio)?.Outputs,
+            names => $"Audio filters on {string.Join(", ", names)} won't be heard: the tap that " +
+                     "generates the stream has to sit above them in the component list."));
 
         return _root;
     }

--- a/Basis/Packages/com.basis.mediaplayer/Editor/BasisMediaPlayerAudioTapInspector.cs
+++ b/Basis/Packages/com.basis.mediaplayer/Editor/BasisMediaPlayerAudioTapInspector.cs
@@ -1,7 +1,10 @@
+using System;
 using UnityEditor;
+using UnityEngine;
 using UnityEngine.UIElements;
 
-// The tap has no serialized fields, so this draws only a note on filter ordering.
+// The tap has no serialized fields, so this draws the filter-ordering note and,
+// when filters have ended up above the tap, the offer to put it back on top.
 // It also has to be a UIElements inspector: Unity's default MonoBehaviour inspector
 // draws a level meter for any script with an OnAudioFilterRead, and that IMGUI path
 // dereferences GUIView.current without a null check, which throws whenever the
@@ -15,10 +18,24 @@ public class BasisMediaPlayerAudioTapInspector : Editor
         "Chorus filter must sit BELOW this component to hear the stream. Anything " +
         "above it is fed silence.";
 
+    private const string Warning =
+        "The filters above this component are being fed silence. Raise the tap above " +
+        "them so they process the stream.";
+
     public override VisualElement CreateInspectorGUI()
     {
         var root = new VisualElement();
         root.Add(new HelpBox(Note, HelpBoxMessageType.Info));
+        root.Add(new BasisMediaPlayerTapOrdering.Notice(Source, _ => Warning));
         return root;
+    }
+
+    // Resolved per call, never held: the AudioSource can be replaced on this object
+    // while the notice is up.
+    private AudioSource[] Source()
+    {
+        var tap = target as BasisMediaPlayerAudioTap;
+        AudioSource src = tap != null ? tap.GetComponent<AudioSource>() : null;
+        return src != null ? new[] { src } : Array.Empty<AudioSource>();
     }
 }

--- a/Basis/Packages/com.basis.mediaplayer/Editor/BasisMediaPlayerAudioTapInspector.cs
+++ b/Basis/Packages/com.basis.mediaplayer/Editor/BasisMediaPlayerAudioTapInspector.cs
@@ -1,0 +1,24 @@
+using UnityEditor;
+using UnityEngine.UIElements;
+
+// The tap has no serialized fields, so this draws only a note on filter ordering.
+// It also has to be a UIElements inspector: Unity's default MonoBehaviour inspector
+// draws a level meter for any script with an OnAudioFilterRead, and that IMGUI path
+// dereferences GUIView.current without a null check, which throws whenever the
+// inspector redraws outside a GUIView repaint (adding a component, for instance).
+[CustomEditor(typeof(BasisMediaPlayerAudioTap))]
+public class BasisMediaPlayerAudioTapInspector : Editor
+{
+    private const string Note =
+        "Generates this AudioSource's audio from the media player's decoded stream. " +
+        "Unity applies audio filters in component order, so a Low Pass / Reverb / " +
+        "Chorus filter must sit BELOW this component to hear the stream. Anything " +
+        "above it is fed silence.";
+
+    public override VisualElement CreateInspectorGUI()
+    {
+        var root = new VisualElement();
+        root.Add(new HelpBox(Note, HelpBoxMessageType.Info));
+        return root;
+    }
+}

--- a/Basis/Packages/com.basis.mediaplayer/Editor/BasisMediaPlayerAudioTapInspector.cs.meta
+++ b/Basis/Packages/com.basis.mediaplayer/Editor/BasisMediaPlayerAudioTapInspector.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 638dc75ddf1c40bf955410f70b23d614

--- a/Basis/Packages/com.basis.mediaplayer/Editor/BasisMediaPlayerTapOrdering.cs
+++ b/Basis/Packages/com.basis.mediaplayer/Editor/BasisMediaPlayerTapOrdering.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEditorInternal;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+// An output plays through a BasisMediaPlayerAudioTap, which generates the stream into
+// the AudioSource's DSP block. Unity runs filters in component order, so a tap below
+// them — or missing, and added at runtime, which appends — leaves every filter above
+// it processing silence. Shared by the audio and tap inspectors, which both offer to
+// put the tap back on top.
+internal static class BasisMediaPlayerTapOrdering
+{
+    public static bool NeedsRaise(AudioSource src) =>
+        BasisMediaPlayerAudioTap.FirstBypassedFilter(src) != null;
+
+    // Adds the tap if absent and gets it above the filters, by raising the tap or,
+    // failing that, lowering the filters past it. Returns false when neither move is
+    // allowed.
+    public static bool Fix(AudioSource src)
+    {
+        if (src == null) return false;
+
+        // ComponentUtility's reorder calls are native, and whether they register undo
+        // of their own isn't something the caller can see. Record the object up front
+        // and collapse everything into one group, so a single undo takes back the
+        // whole fix however many steps it took, including a run that gave up part-way.
+        Undo.IncrementCurrentGroup();
+        int group = Undo.GetCurrentGroup();
+        Undo.SetCurrentGroupName("Fix audio filter order");
+        Undo.RegisterCompleteObjectUndo(src.gameObject, "Fix audio filter order");
+
+        if (!src.TryGetComponent(out BasisMediaPlayerAudioTap tap))
+        {
+            tap = Undo.AddComponent<BasisMediaPlayerAudioTap>(src.gameObject);
+        }
+
+        bool fixedOrder = RaiseTap(src, tap) || LowerFilters(src);
+        EditorUtility.SetDirty(src.gameObject);
+        Undo.CollapseUndoOperations(group);
+        return fixedOrder;
+    }
+
+    // One move, and it leaves the filters in the order they were written in.
+    private static bool RaiseTap(AudioSource src, BasisMediaPlayerAudioTap tap)
+    {
+        while (NeedsRaise(src))
+        {
+            if (!ComponentUtility.MoveComponentUp(tap)) return false;
+        }
+        return true;
+    }
+
+    // A prefab instance refuses to move a component that came from the asset, but the
+    // filters added on the instance still move. Lowest offender first: taking the top
+    // one down would drop it past its neighbours and reverse the chain they run in.
+    private static bool LowerFilters(AudioSource src)
+    {
+        for (int guard = 0; guard < 256 && NeedsRaise(src); guard++)
+        {
+            Component filter = LowestFilterAboveTap(src);
+            if (filter == null || !ComponentUtility.MoveComponentDown(filter)) return false;
+        }
+        return !NeedsRaise(src);
+    }
+
+    private static Component LowestFilterAboveTap(AudioSource src)
+    {
+        Component[] comps = src.GetComponents<Component>();
+        int tap = -1;
+        for (int i = 0; i < comps.Length; i++)
+        {
+            if (comps[i] is BasisMediaPlayerAudioTap) { tap = i; break; }
+        }
+        for (int i = tap - 1; i >= 0; i--)
+        {
+            if (comps[i] != null && BasisMediaPlayerAudioTap.IsAudioFilter(comps[i])) return comps[i];
+        }
+        return null;
+    }
+
+    public const string ReorderRefused =
+        "Unity wouldn't reorder these components: neither the tap nor the filters would move. " +
+        "Open the prefab and put the tap above the filters there, or unpack the instance.";
+
+    // The warning and its fix button, shared by the audio and tap inspectors so a
+    // change to either lands on both. `resolve` is called fresh on every poll and on
+    // every click: the offending sources are never held between the two, since a
+    // source swapped for a same-named one leaves the message identical and so the
+    // notice can outlive what it named.
+    internal sealed class Notice : VisualElement
+    {
+        private readonly Func<AudioSource[]> resolve;
+        private readonly Func<List<string>, string> describe;
+        private string signature;
+        private bool blocked;
+
+        public Notice(Func<AudioSource[]> resolveSources, Func<List<string>, string> describeOffenders)
+        {
+            resolve = resolveSources;
+            describe = describeOffenders;
+            Refresh();
+            // The edit lands on components, not on a serialized property either
+            // inspector could track, so poll. The scheduler stops on its own once
+            // this element leaves the panel.
+            schedule.Execute(Refresh).Every(500);
+        }
+
+        private List<AudioSource> Offenders()
+        {
+            var pending = new List<AudioSource>();
+            AudioSource[] sources = resolve();
+            if (sources == null) return pending;
+            foreach (AudioSource src in sources)
+            {
+                if (NeedsRaise(src)) pending.Add(src);
+            }
+            return pending;
+        }
+
+        private void Refresh()
+        {
+            List<AudioSource> pending = Offenders();
+            if (pending.Count == 0)
+            {
+                if (signature != null) { Clear(); signature = null; blocked = false; }
+                return;
+            }
+
+            var names = new List<string>(pending.Count);
+            foreach (AudioSource src in pending) names.Add(src.name);
+            string message = describe(names);
+
+            // Redraw only when what the notice says changes, so the poll can't
+            // rebuild the button out from under a click.
+            string want = blocked ? message + " [blocked]" : message;
+            if (signature == want) return;
+            signature = want;
+
+            Clear();
+            Add(new HelpBox(message, HelpBoxMessageType.Warning));
+            Add(new Button(Apply) { text = "Fix audio filter order" });
+            if (blocked) Add(new HelpBox(ReorderRefused, HelpBoxMessageType.Info));
+        }
+
+        private void Apply()
+        {
+            blocked = false;
+            foreach (AudioSource src in Offenders())
+            {
+                if (!Fix(src)) blocked = true;
+            }
+            Refresh();
+        }
+    }
+}

--- a/Basis/Packages/com.basis.mediaplayer/Editor/BasisMediaPlayerTapOrdering.cs.meta
+++ b/Basis/Packages/com.basis.mediaplayer/Editor/BasisMediaPlayerTapOrdering.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7dd2b21b3e674093b65f313703521134

--- a/Basis/Packages/com.basis.mediaplayer/Prefabs/MediaPlayerMultiChannelStreaming.prefab
+++ b/Basis/Packages/com.basis.mediaplayer/Prefabs/MediaPlayerMultiChannelStreaming.prefab
@@ -871,6 +871,7 @@ GameObject:
   m_Component:
   - component: {fileID: 284369164929462608}
   - component: {fileID: 8492380507994031485}
+  - component: {fileID: 4700000000000000001}
   - component: {fileID: 5029848432392392423}
   m_Layer: 0
   m_Name: Channel 6 - Back Right
@@ -913,7 +914,7 @@ AudioSource:
   Loop: 0
   Mute: 0
   Spatialize: 1
-  SpatializePostEffects: 0
+  SpatializePostEffects: 1
   Priority: 128
   DopplerLevel: 1
   MinDistance: 1
@@ -1015,6 +1016,7 @@ GameObject:
   m_Component:
   - component: {fileID: 6394943730414216791}
   - component: {fileID: 1169068719169778331}
+  - component: {fileID: 4700000000000000002}
   - component: {fileID: 9188990892457773809}
   m_Layer: 0
   m_Name: Channel 2 - Front Right
@@ -1057,7 +1059,7 @@ AudioSource:
   Loop: 0
   Mute: 0
   Spatialize: 1
-  SpatializePostEffects: 0
+  SpatializePostEffects: 1
   Priority: 128
   DopplerLevel: 1
   MinDistance: 1
@@ -1367,6 +1369,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2174438926814300381}
   - component: {fileID: 6734675154905328036}
+  - component: {fileID: 4700000000000000003}
   - component: {fileID: 7699144265348857292}
   m_Layer: 0
   m_Name: Channel 5 - Back Left
@@ -1409,7 +1412,7 @@ AudioSource:
   Loop: 0
   Mute: 0
   Spatialize: 1
-  SpatializePostEffects: 0
+  SpatializePostEffects: 1
   Priority: 128
   DopplerLevel: 1
   MinDistance: 1
@@ -1601,6 +1604,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4148955688040547278}
   - component: {fileID: 5253027019616493262}
+  - component: {fileID: 4700000000000000004}
   - component: {fileID: 153497546933995149}
   m_Layer: 0
   m_Name: Channel 7 - Side Left
@@ -1643,7 +1647,7 @@ AudioSource:
   Loop: 0
   Mute: 0
   Spatialize: 1
-  SpatializePostEffects: 0
+  SpatializePostEffects: 1
   Priority: 128
   DopplerLevel: 1
   MinDistance: 1
@@ -1835,6 +1839,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7025231822000820434}
   - component: {fileID: 4708977768835521612}
+  - component: {fileID: 4700000000000000005}
   - component: {fileID: 5356243225140337869}
   m_Layer: 0
   m_Name: Channel 8 - Side Right
@@ -1877,7 +1882,7 @@ AudioSource:
   Loop: 0
   Mute: 0
   Spatialize: 1
-  SpatializePostEffects: 0
+  SpatializePostEffects: 1
   Priority: 128
   DopplerLevel: 1
   MinDistance: 1
@@ -2019,6 +2024,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5137532306463264051}
   - component: {fileID: 8225461348031970565}
+  - component: {fileID: 4700000000000000006}
   - component: {fileID: 2684115064595991151}
   m_Layer: 0
   m_Name: Channel 3 - Front Centre
@@ -2060,7 +2066,7 @@ AudioSource:
   Loop: 0
   Mute: 0
   Spatialize: 1
-  SpatializePostEffects: 0
+  SpatializePostEffects: 1
   Priority: 128
   DopplerLevel: 1
   MinDistance: 1
@@ -2162,6 +2168,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3681285666842893386}
   - component: {fileID: 5816047855775780060}
+  - component: {fileID: 4700000000000000007}
   - component: {fileID: 5750983338186741599}
   m_Layer: 0
   m_Name: Channel 1 - Front Left
@@ -2204,7 +2211,7 @@ AudioSource:
   Loop: 0
   Mute: 0
   Spatialize: 1
-  SpatializePostEffects: 0
+  SpatializePostEffects: 1
   Priority: 128
   DopplerLevel: 1
   MinDistance: 1
@@ -2306,6 +2313,7 @@ GameObject:
   m_Component:
   - component: {fileID: 754076941067710568}
   - component: {fileID: 2687526597242759347}
+  - component: {fileID: 4700000000000000008}
   - component: {fileID: 5436737240109758080}
   m_Layer: 0
   m_Name: Channel 4 - LFE
@@ -2347,7 +2355,7 @@ AudioSource:
   Loop: 0
   Mute: 0
   Spatialize: 1
-  SpatializePostEffects: 0
+  SpatializePostEffects: 1
   Priority: 128
   DopplerLevel: 1
   MinDistance: 1
@@ -2696,3 +2704,99 @@ MonoBehaviour:
   player: {fileID: 8757368325675487334}
   label: {fileID: 6815530408632593247}
   background: {fileID: 6625954625511748195}
+--- !u!114 &4700000000000000001
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1006988167474170037}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bd4d9af99b4353142af4b7bdd5c2b853, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: BasisMediaPlayer::BasisMediaPlayerAudioTap
+--- !u!114 &4700000000000000002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2565437961886034552}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bd4d9af99b4353142af4b7bdd5c2b853, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: BasisMediaPlayer::BasisMediaPlayerAudioTap
+--- !u!114 &4700000000000000003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4067286564769727513}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bd4d9af99b4353142af4b7bdd5c2b853, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: BasisMediaPlayer::BasisMediaPlayerAudioTap
+--- !u!114 &4700000000000000004
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6086984266641354651}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bd4d9af99b4353142af4b7bdd5c2b853, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: BasisMediaPlayer::BasisMediaPlayerAudioTap
+--- !u!114 &4700000000000000005
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6556824477466809312}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bd4d9af99b4353142af4b7bdd5c2b853, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: BasisMediaPlayer::BasisMediaPlayerAudioTap
+--- !u!114 &4700000000000000006
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6895909008755713970}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bd4d9af99b4353142af4b7bdd5c2b853, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: BasisMediaPlayer::BasisMediaPlayerAudioTap
+--- !u!114 &4700000000000000007
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7106499004218466471}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bd4d9af99b4353142af4b7bdd5c2b853, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: BasisMediaPlayer::BasisMediaPlayerAudioTap
+--- !u!114 &4700000000000000008
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7370652399459993111}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bd4d9af99b4353142af4b7bdd5c2b853, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: BasisMediaPlayer::BasisMediaPlayerAudioTap

--- a/Basis/Packages/com.basis.mediaplayer/Prefabs/MediaPlayerStreaming.prefab
+++ b/Basis/Packages/com.basis.mediaplayer/Prefabs/MediaPlayerStreaming.prefab
@@ -363,6 +363,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2265814159907839490}
   - component: {fileID: 136030129054553920}
+  - component: {fileID: 4700000000000000001}
   - component: {fileID: 4300968560286109803}
   - component: {fileID: 1325980082505240854}
   m_Layer: 8
@@ -405,7 +406,7 @@ AudioSource:
   Loop: 0
   Mute: 0
   Spatialize: 1
-  SpatializePostEffects: 0
+  SpatializePostEffects: 1
   Priority: 128
   DopplerLevel: 1
   MinDistance: 1
@@ -1099,3 +1100,15 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 14.463681, y: 8.13582, z: 0.1}
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &4700000000000000001
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6715880030743322348}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bd4d9af99b4353142af4b7bdd5c2b853, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: BasisMediaPlayer::BasisMediaPlayerAudioTap

--- a/Basis/Packages/com.basis.mediaplayer/Prefabs/MediaPlayerStreaming.prefab
+++ b/Basis/Packages/com.basis.mediaplayer/Prefabs/MediaPlayerStreaming.prefab
@@ -364,7 +364,6 @@ GameObject:
   - component: {fileID: 2265814159907839490}
   - component: {fileID: 136030129054553920}
   - component: {fileID: 4700000000000000001}
-  - component: {fileID: 4300968560286109803}
   - component: {fileID: 1325980082505240854}
   m_Layer: 8
   m_Name: Stereo Downmix
@@ -397,7 +396,7 @@ AudioSource:
   m_GameObject: {fileID: 6715880030743322348}
   m_Enabled: 1
   serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
+  OutputAudioMixerGroup: {fileID: 6216228358845890117, guid: 1ff7d045b2e32054aad6c5815495d8b8, type: 2}
   m_audioClip: {fileID: 0}
   m_Resource: {fileID: 0}
   m_PlayOnAwake: 1
@@ -485,7 +484,7 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
---- !u!114 &4300968560286109803
+--- !u!114 &4700000000000000001
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -494,83 +493,9 @@ MonoBehaviour:
   m_GameObject: {fileID: 6715880030743322348}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 59c3684b22f00604a97bb68037fcf4cd, type: 3}
+  m_Script: {fileID: 11500000, guid: bd4d9af99b4353142af4b7bdd5c2b853, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: SteamAudioUnity::SteamAudio.SteamAudioSource
-  directBinaural: 1
-  interpolation: 0
-  perspectiveCorrection: 0
-  distanceAttenuation: 1
-  distanceAttenuationInput: 1
-  distanceAttenuationValue: 1
-  airAbsorption: 1
-  airAbsorptionInput: 0
-  airAbsorptionLow: 1
-  airAbsorptionMid: 1
-  airAbsorptionHigh: 1
-  directivity: 0
-  directivityInput: 0
-  dipoleWeight: 0
-  dipolePower: 0
-  directivityValue: 1
-  occlusion: 1
-  occlusionInput: 0
-  occlusionType: 0
-  occlusionRadius: 1
-  occlusionSamples: 16
-  occlusionValue: 1
-  transmission: 1
-  transmissionType: 0
-  transmissionInput: 0
-  transmissionLow: 1
-  transmissionMid: 1
-  transmissionHigh: 1
-  maxTransmissionSurfaces: 1
-  directMixLevel: 1
-  reflections: 0
-  reflectionsType: 0
-  useDistanceCurveForReflections: 0
-  currentBakedSource: {fileID: 0}
-  reverbTimeLow: 0
-  reverbTimeMid: 0
-  reverbTimeHigh: 0
-  hybridReverbEQLow: 1
-  hybridReverbEQMid: 1
-  hybridReverbEQHigh: 1
-  hybridReverbDelay: 0
-  applyHRTFToReflections: 0
-  reflectionsMixLevel: 1
-  pathing: 0
-  pathingProbeBatch: {fileID: 0}
-  pathValidation: 1
-  findAlternatePaths: 1
-  pathingEQ:
-  - 1
-  - 1
-  - 1
-  pathingSH:
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  - 0
-  applyHRTFToPathing: 0
-  pathingMixLevel: 1
-  mAudioSource: {fileID: 0}
-  Transform: {fileID: 0}
-  IsUnityEngineUsed: 0
-  AllowsUpdateParameters: 0
+  m_EditorClassIdentifier: BasisMediaPlayer::BasisMediaPlayerAudioTap
 --- !u!114 &1325980082505240854
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -622,7 +547,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
+  m_LocalScale: {x: 0.25, y: 0.25, z: 0.25}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2265814159907839490}
@@ -1100,15 +1025,3 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 14.463681, y: 8.13582, z: 0.1}
   m_Center: {x: 0, y: 0, z: 0}
---- !u!114 &4700000000000000001
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6715880030743322348}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: bd4d9af99b4353142af4b7bdd5c2b853, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: BasisMediaPlayer::BasisMediaPlayerAudioTap

--- a/Basis/Packages/com.basis.mediaplayer/README.md
+++ b/Basis/Packages/com.basis.mediaplayer/README.md
@@ -283,6 +283,32 @@ prefab); for surround, one `Output` per channel so a 5.1 / 7.1 mix (up to 8
 channels) can be positioned speaker-by-speaker in the world (the
 `Prefabs/MediaPlayerMultiChannelStreaming` prefab).
 
+Each output `AudioSource` carries a `BasisMediaPlayerAudioTap`, which writes the
+decoded stream straight into that source's DSP block. Unity applies audio filters in
+component order, so a Low Pass / High Pass / Reverb filter has to sit **below** the
+tap on the same GameObject; anything above it is handed silence.
+
+An output carrying filters with no tap above them is flagged in the inspector, on the
+owning `BasisMediaPlayerAudio` and on the tap itself where there is one, with a button
+that fixes the order by raising the tap, or by lowering the filters past it where the
+tap can't move. An output with no filters isn't flagged: it gets its tap at runtime and
+there's no ordering to get wrong. Component order is fixed once play starts, so an
+output assembled in code that already carries filters can't be put right, and logs a
+warning naming the filter instead.
+
+Each source's own `Volume` and `Mute` are folded into that tap's gain, so they behave
+as they would for a clip and stay per-output — on a surround setup you can trim one
+speaker without touching the rest. `BasisMediaPlayerAudio`'s `VolumeGain` / `Mute` are
+the player-wide pair, and the client's main volume scales the lot; all three multiply.
+
+Two of the AudioSource's own controls behave differently from a clip. `Pitch` does
+nothing, since it belongs to clip playback, and pitching the stream would pull the
+audio off the video in any case. Spatialisation needs the spatialiser to run *after*
+the tap, so `Spatialize Post Effects` stays ticked and `Bypass Effects` unticked (both
+prefabs ship that way): with either the wrong way round, the spatialiser processes the
+silent keepalive clip and the tap overwrites the result, which sounds the same as
+dropping `Spatial Blend` to 2D.
+
 Channel ceiling depends on the source: **LPCM** — Blu-ray-style over MPEG-TS, or a
 **WAV** file — carries a full 7.1 (8 channels); **AAC on Windows** decodes up to 5.1
 (the Media Foundation decoder's limit — wider or PCE-signalled AAC layouts play muted

--- a/Basis/Packages/com.basis.mediaplayer/Runtime/Audio/BasisMediaPlayerAudio.cs
+++ b/Basis/Packages/com.basis.mediaplayer/Runtime/Audio/BasisMediaPlayerAudio.cs
@@ -251,6 +251,16 @@ public sealed class BasisMediaPlayerAudio : MonoBehaviour, IBasisMediaClockSourc
             src.spatializePostEffects = true;
             if (!src.TryGetComponent(out BasisMediaPlayerAudioTap tap)) tap = src.gameObject.AddComponent<BasisMediaPlayerAudioTap>();
             b.FilterTap = tap;
+            // A tap added here appends, so it lands below anything already on the
+            // object. Component order is fixed at runtime, so this is a warning
+            // rather than something we can put right; the editor offers the reorder.
+            Component bypassed = BasisMediaPlayerAudioTap.FirstBypassedFilter(src);
+            if (bypassed != null)
+            {
+                BasisDebug.LogWarning(
+                    $"BasisMediaPlayerAudio: '{src.name}' has a {bypassed.GetType().Name} above its BasisMediaPlayerAudioTap, so that filter never hears the stream. Move it below the tap.",
+                    BasisDebug.LogTag.Video);
+            }
             bool primary = b.Primary;
             // Source frames per output frame: the tap renders straight into DSP
             // blocks, so rate conversion happens in the splitter read (Quest runs

--- a/Basis/Packages/com.basis.mediaplayer/Runtime/Audio/BasisMediaPlayerAudioTap.cs
+++ b/Basis/Packages/com.basis.mediaplayer/Runtime/Audio/BasisMediaPlayerAudioTap.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using UnityEngine;
 
 // Feeds one BasisMediaPlayer output AudioSource by mixing its channel(s) from the
@@ -18,6 +19,7 @@ using UnityEngine;
 // this output's channel taps, and a gain provider; the primary tap also reports the
 // mixed block back for the diagnostics metrics (consumed samples / peak / RMS).
 [RequireComponent(typeof(AudioSource))]
+[DisallowMultipleComponent]
 public sealed class BasisMediaPlayerAudioTap : MonoBehaviour
 {
     private AudioSource source;
@@ -70,6 +72,46 @@ public sealed class BasisMediaPlayerAudioTap : MonoBehaviour
     {
         if (source == null && !TryGetComponent(out source)) return;
         sourceVolume = source.mute ? 0f : Mathf.Max(0f, source.volume);
+    }
+
+    // Unity runs a source's filters in component order, and this tap generates the
+    // audio rather than processing it, so a filter above it is handed the silent
+    // keepalive clip and then overwritten. Returns the topmost filter that has ended
+    // up there, for callers to warn about or offer to reorder. Component order can't
+    // be changed at runtime, so a rig assembled in code can only be warned about.
+    public static Component FirstBypassedFilter(AudioSource source)
+    {
+        if (source == null) return null;
+
+        Component[] comps = source.GetComponents<Component>();
+        int limit = comps.Length;
+        for (int i = 0; i < comps.Length; i++)
+        {
+            if (comps[i] is BasisMediaPlayerAudioTap) { limit = i; break; }
+        }
+        for (int i = 0; i < limit; i++)
+        {
+            if (comps[i] != null && IsAudioFilter(comps[i])) return comps[i];
+        }
+        return null;
+    }
+
+    public static bool IsAudioFilter(Component c)
+    {
+        if (c is AudioLowPassFilter || c is AudioHighPassFilter || c is AudioReverbFilter ||
+            c is AudioChorusFilter || c is AudioDistortionFilter || c is AudioEchoFilter)
+        {
+            return true;
+        }
+        if (c is not MonoBehaviour) return false;
+
+        // Script filters are DSP stages too. Match Unity's callback exactly, so a
+        // same-named method of another shape isn't mistaken for one (and so an
+        // overload can't make the lookup ambiguous).
+        MethodInfo m = c.GetType().GetMethod("OnAudioFilterRead",
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null, types: new[] { typeof(float[]), typeof(int) }, modifiers: null);
+        return m != null && m.ReturnType == typeof(void);
     }
 
     public void Unbind()

--- a/Basis/Packages/com.basis.mediaplayer/Runtime/Audio/BasisMediaPlayerAudioTap.cs
+++ b/Basis/Packages/com.basis.mediaplayer/Runtime/Audio/BasisMediaPlayerAudioTap.cs
@@ -20,6 +20,7 @@ using UnityEngine;
 [RequireComponent(typeof(AudioSource))]
 public sealed class BasisMediaPlayerAudioTap : MonoBehaviour
 {
+    private AudioSource source;
     private BasisMultiChannelPcmSplitter splitter;
     private BasisMultiChannelPcmSplitter.Reader reader;
     private BasisMultiChannelPcmSplitter.Tap[] taps;
@@ -27,6 +28,7 @@ public sealed class BasisMediaPlayerAudioTap : MonoBehaviour
     private Action<float[], int> onMixedBlock;   // null unless this is the primary output
     private bool spreadMono;                      // replicate ch0 across the DSP width (positioned mono sources)
     private double sourceStep = 1.0;              // source frames per output frame (source rate / DSP rate)
+    private volatile float sourceVolume = 1f;     // this AudioSource's own volume/mute, pushed from the main thread
     private volatile bool active;
     private volatile int observedChannels;        // DSP width seen on the audio thread; read on the main thread
 
@@ -51,6 +53,23 @@ public sealed class BasisMediaPlayerAudioTap : MonoBehaviour
         sourceStep = sourceFramesPerOutputFrame > 0 ? sourceFramesPerOutputFrame : 1.0;
         observedChannels = 0;
         active = s != null && t != null && reader != null;
+        PollSourceVolume();
+    }
+
+    // Unity applies AudioSource.volume and .mute to the clip this block overwrites,
+    // so neither reaches the mix unless it's folded into the tap's gain. Polled
+    // because neither raises a change notification, and here rather than on the
+    // owning BasisMediaPlayerAudio so it keeps tracking while that component is
+    // disabled with StopOnDisable off, which leaves this tap generating audio.
+    private void Update()
+    {
+        if (active) PollSourceVolume();
+    }
+
+    private void PollSourceVolume()
+    {
+        if (source == null && !TryGetComponent(out source)) return;
+        sourceVolume = source.mute ? 0f : Mathf.Max(0f, source.volume);
     }
 
     public void Unbind()
@@ -78,7 +97,7 @@ public sealed class BasisMediaPlayerAudioTap : MonoBehaviour
 
         observedChannels = channels;
         int frames = data.Length / channels;
-        float gain = gainProvider != null ? gainProvider() : 1f;
+        float gain = (gainProvider != null ? gainProvider() : 1f) * sourceVolume;
         Array.Clear(data, 0, data.Length);
         s.ReadMixed(r, data, frames, channels, t, gain, sourceStep);
 

--- a/Basis/Packages/com.basis.mediaplayer/TESTING.md
+++ b/Basis/Packages/com.basis.mediaplayer/TESTING.md
@@ -295,6 +295,30 @@ and that a late joiner receives it too. Worth a pass on a peer with
 `AutoPlayOnSourceAssigned` unticked, which is the case that relies on the owner's advertised
 state rather than local autoplay.
 
+**Audio source controls and filters** — `AudioSource.volume` and `.mute` are per output, not
+per player: with a stream playing, drag one output's `Volume` to zero and back and only that
+source's level moves, and `Mute` silences that source alone. The player-wide controls are
+`BasisMediaPlayerAudio`'s `VolumeGain` / `Mute` (what the panel slider drives), and the three
+multiply. The multichannel prefab is the row that matters here — set each of the eight outputs
+to a different level and confirm the balance holds, rather than one slider dragging the rest
+with it. Then add an `Audio Low Pass Filter` (or Reverb / Chorus) to one of the output
+GameObjects and confirm it colours that output. Unity applies filters in component order and
+the `BasisMediaPlayerAudioTap` is what generates the audio, so a filter moved **above** the tap
+is expected to do nothing; the check is that one added normally, below it, is heard. Drag a
+filter above the tap and both the tap's own inspector and the owning `BasisMediaPlayerAudio`
+should say so and offer to fix it, without either needing a reselect to notice. On a prefab
+instance the tap itself can't move, so the fix lowers the filters below it instead — with two
+filters stacked, check they keep their order relative to each other, since swapping them
+changes the chain. Only when neither move is allowed should the notice say to open the prefab.
+That notice is also what a hand-built output rig relies on, so add a bare AudioSource with a
+filter on it to `Outputs` and confirm it's flagged. A rig assembled in code can't be reordered
+at all once play starts, so build one that way (AudioSource plus a filter, added to `Outputs`
+from a script) and confirm the player logs a warning naming the filter rather than failing
+quietly. Two AudioSource controls are expected to
+misbehave and shouldn't be reported as regressions: `Pitch` does nothing, and ticking `Bypass
+Effects` or unticking `Spatialize Post Effects` drops spatialisation to flat 2D, because the
+spatialiser then runs ahead of the tap and its output is overwritten.
+
 **Panel UI** ("Media Players" panel, `Runtime/UI/BasisMediaPlayerPanelProvider.cs`) — URL
 load, transport buttons, seek slider (VOD only), volume, bitrate dropdown (HLS multi-variant),
 audio-track dropdown (multi-audio content), captions toggle + opacity sliders, subtitles


### PR DESCRIPTION
## Summary
Three fixes to media player audio, all reported by @uruno-fuyune

1. **`AudioSource.volume` and `.mute` did nothing.** The tap generates each output's audio in `OnAudioFilterRead`, clearing the DSP block and writing the decoded mix over it. Unity applies volume and mute to clip playback, upstream of that, so neither reached the stream. They're now folded into the tap's gain, per output, so a surround rig can still trim one speaker.
2. **Audio filters on an output did nothing.** Unity runs filters in component order and the tap is a generator, so anything above it gets silence and is then overwritten. The tap was only added at runtime, and `AddComponent` appends, so it always landed below filters added in the editor. It's now authored into both prefabs, the inspector flags and fixes an output whose filters ended up above it, and `Rebuild` warns when a rig built in code can't be fixed.
3. **Selecting an output threw a `NullReferenceException`.** Unity's default MonoBehaviour inspector draws a level meter for any script with an `OnAudioFilterRead`, through an IMGUI path that dereferences `GUIView.current` unguarded. The tap now has a UIElements inspector, so that path never runs.

Also ticks `Spatialize Post Effects` on the output prefabs, which `Rebuild` was already setting at runtime, and aligns the stereo prefab's audio setup with the multichannel one.

## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [x] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [ ] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — `BasisEventDriver` runs the single per-frame tick that drives the whole framework (network apply, local player sim, blendshapes, JigglePhysics, nameplates, and more) as one sequential chain. An unhandled exception anywhere in that chain aborts the rest of the tick, so every step after the throwing one is silently skipped for that frame. New work added to the driver must either be guaranteed not to throw, or be wrapped in a `try`/`catch` that contains the failure and surfaces it through `BasisDebug` — logged once / rate-limited, never every frame (see the existing `HVRBasisBuiltInAddresses.Simulate()` guard for the pattern). Expect this to be scrutinized closely in review.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [x] Windows
- [ ] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [ ] Tested in VR (note headset under **Notes**)
- [ ] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [x] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [x] N/A — change does not touch any of the above

## Notes
- **Per-frame check unticked.** The tap polls its own `AudioSource` from an `Update` rather than through `BasisEventDriver`. Volume and mute raise no change notification, and the outputs keep playing when `BasisMediaPlayerAudio` is disabled with `StopOnDisable` off, so the poll has to be independent of that component. One callback per bound output, guarded so an unbound tap does nothing. If @dooly123 would prefer this moved to the driver I can do so.
- **Tested** in the editor on Windows against `rtsp://stream.vrcdn.live/live/vrcdn`: the outputs behave as expected, and the volume slider was confirmed dead on the same setup before the fix. The inspector notice and its prefab-instance path were exercised too. Not yet run on a device, and not yet in a built player.
- `FirstBypassedFilter` calls `GetComponents<Component>()` and, for script filters, `GetMethod` on `OnAudioFilterRead`. Both run once per output inside `Rebuild`, never per frame. The reflection is new on the runtime path, so it's worth an eye on IL2CPP; a false negative there costs a missing warning, not audio.
- `TESTING.md` gains a row for all of this, including the controls that stay inert by design: `Pitch` does nothing, and `Bypass Effects` or an unticked `Spatialize Post Effects` drops spatialisation, because the spatialiser then runs ahead of the tap.

