### PR TITLE
fix(mediaplayer): let audio analysers read an output's stream

### DIFF
--- a/Basis/Packages/com.basis.mediaplayer/Editor/BasisMediaAudioChannelInspector.cs
+++ b/Basis/Packages/com.basis.mediaplayer/Editor/BasisMediaAudioChannelInspector.cs
@@ -25,9 +25,23 @@ public class BasisMediaAudioChannelInspector : Editor
         if (sheet != null) _root.styleSheets.Add(sheet);
 
         BindByName("ChannelField", "Channel");
+        BindByName("AnalysisFeedField", "AnalysisFeed");
+        BindByName("AnalysisFeedLatencyField", "AnalysisFeedLatency");
         _root.Bind(serializedObject);
 
+        // The buffer length and the note only mean anything once the feed is on.
+        var toggle = _root.Q<PropertyField>("AnalysisFeedField");
+        toggle?.RegisterValueChangeCallback(evt => ShowAnalysisFeedDetail(evt.changedProperty.boolValue));
+        ShowAnalysisFeedDetail(serializedObject.FindProperty("AnalysisFeed").boolValue);
+
         return _root;
+    }
+
+    private void ShowAnalysisFeedDetail(bool on)
+    {
+        DisplayStyle style = on ? DisplayStyle.Flex : DisplayStyle.None;
+        if (_root.Q<VisualElement>("AnalysisFeedLatencyField") is VisualElement latency) latency.style.display = style;
+        if (_root.Q<VisualElement>("AnalysisFeedHelp") is VisualElement help) help.style.display = style;
     }
 
     private void BindByName(string name, string property)

--- a/Basis/Packages/com.basis.mediaplayer/Editor/BasisMediaPlayerTapOrdering.cs
+++ b/Basis/Packages/com.basis.mediaplayer/Editor/BasisMediaPlayerTapOrdering.cs
@@ -12,7 +12,11 @@ using UnityEngine.UIElements;
 // put the tap back on top.
 internal static class BasisMediaPlayerTapOrdering
 {
+    // An analysis output plays a written clip rather than generating into the DSP
+    // block, so its filters run in the normal order and there is nothing to raise.
     public static bool NeedsRaise(AudioSource src) =>
+        src != null &&
+        !(src.TryGetComponent(out BasisMediaAudioChannel channel) && channel.AnalysisFeed) &&
         BasisMediaPlayerAudioTap.FirstBypassedFilter(src) != null;
 
     // Adds the tap if absent and gets it above the filters, by raising the tap or,

--- a/Basis/Packages/com.basis.mediaplayer/Editor/StyleSheets/MediaPlayerChannelSDK.uxml
+++ b/Basis/Packages/com.basis.mediaplayer/Editor/StyleSheets/MediaPlayerChannelSDK.uxml
@@ -8,5 +8,11 @@
         <engine:VisualElement class="bvp-card">
             <editor:PropertyField name="ChannelField" label="Channel" tooltip="Mono picks one decoded channel; Stereo plays a stereo downmix of the whole stream."/>
         </engine:VisualElement>
+
+        <engine:VisualElement class="bvp-card">
+            <editor:PropertyField name="AnalysisFeedField" label="Analysis Feed" tooltip="Play this output from a written AudioClip so AudioSource.GetOutputData can read it back. Needed by AudioLink and other per-source analysers."/>
+            <editor:PropertyField name="AnalysisFeedLatencyField" label="Feed Delay (s)" tooltip="How far behind the other outputs this one runs. Lower is tighter; too low breaks up when the frame rate dips."/>
+            <engine:HelpBox name="AnalysisFeedHelp" message-type="Info" text="This output plays a clip the player writes instead of the DSP tap, so audio analysers can sample it. It runs slightly behind the other outputs, so point it at the analyser's own AudioSource rather than a speaker you listen to."/>
+        </engine:VisualElement>
     </engine:VisualElement>
 </engine:UXML>

--- a/Basis/Packages/com.basis.mediaplayer/Materials/MediaPlayer.mat
+++ b/Basis/Packages/com.basis.mediaplayer/Materials/MediaPlayer.mat
@@ -19,8 +19,7 @@ Material:
   m_CustomRenderQueue: -1
   stringTagMap:
     RenderType: Opaque
-  disabledShaderPasses:
-  - MOTIONVECTORS
+  disabledShaderPasses: []
   m_LockedProperties: 
   m_SavedProperties:
     serializedVersion: 3

--- a/Basis/Packages/com.basis.mediaplayer/Runtime/Audio/BasisMediaAudioChannel.cs
+++ b/Basis/Packages/com.basis.mediaplayer/Runtime/Audio/BasisMediaAudioChannel.cs
@@ -30,6 +30,15 @@ public sealed class BasisMediaAudioChannel : MonoBehaviour
     [Tooltip("Which decoded channel(s) this AudioSource plays. Channel N picks one decoded channel; Stereo plays a stereo downmix of the whole stream.")]
     public Selection Channel = Selection.Channel1;
 
+    [Tooltip("Play this output from a written AudioClip instead of the DSP tap, so AudioSource.GetOutputData can read it back. Needed by AudioLink and other per-source audio analysers, which cannot see audio a script generates. Costs this output a small delay behind the others, so use it for the analyser's own AudioSource rather than a speaker you listen to.")]
+    public bool AnalysisFeed = false;
+
+    public const float MinAnalysisFeedLatency = 0.02f;
+    public const float MaxAnalysisFeedLatency = 0.5f;
+
+    [Tooltip("How far behind the tap-driven outputs this one runs. Lower is tighter; too low and the feed breaks up when the frame rate dips, since it is written once a frame.")]
+    [Range(MinAnalysisFeedLatency, MaxAnalysisFeedLatency)] public float AnalysisFeedLatency = 0.05f;
+
     public bool IsStereo => Channel == Selection.Stereo;
 
     // Decoded-stream channel index a mono selection draws from (0-based).

--- a/Basis/Packages/com.basis.mediaplayer/Runtime/Audio/BasisMediaPlayerAudio.cs
+++ b/Basis/Packages/com.basis.mediaplayer/Runtime/Audio/BasisMediaPlayerAudio.cs
@@ -108,6 +108,98 @@ public sealed class BasisMediaPlayerAudio : MonoBehaviour, IBasisMediaClockSourc
         public int OutChannels;
         public bool Primary;
         public BasisMediaPlayerAudioTap FilterTap;   // per-output OnAudioFilterRead tap
+        public AnalysisFeed Feed;                    // set instead of FilterTap on an analysis output
+    }
+
+    // Feeds an analysis output by writing the splitter's audio into a looping
+    // AudioClip a little ahead of that AudioSource's own playhead, topped up from
+    // Update.
+    //
+    // A streaming clip (AudioClip.Create with a PCM callback) is the obvious way to
+    // do this and is the wrong one: Unity keeps its own buffer between the callback
+    // and the speaker, it runs about a second whatever length the clip is declared,
+    // and it isn't reachable from the callback. That puts an analyser a second behind
+    // the audio everyone can hear. Writing the clip's samples directly puts the delay
+    // back under our control -- it becomes the lead we write at, plus the output
+    // buffer.
+    //
+    // Chunks are a fixed size and the clip an exact multiple of it, so a write never
+    // straddles the loop point and never needs to allocate.
+    private sealed class AnalysisFeed
+    {
+        private const int ChunkFrames = 1024;
+
+        private readonly AudioSource source;
+        private readonly BasisMultiChannelPcmSplitter splitter;
+        private readonly BasisMultiChannelPcmSplitter.Reader reader;
+        private readonly BasisMultiChannelPcmSplitter.Tap[] taps;
+        private readonly int channels;
+        private readonly int lengthFrames;
+        private readonly int leadFrames;
+        private readonly float[] scratch;
+        private readonly Func<float> gainProvider;
+        private int writeCursor;
+        private bool active;
+
+        public readonly AudioClip Clip;
+
+        public AnalysisFeed(AudioSource src, BasisMultiChannelPcmSplitter s, BasisMultiChannelPcmSplitter.Tap[] t,
+                            int outChannels, int rate, float leadSeconds, string clipName, Func<float> gain)
+        {
+            source = src;
+            splitter = s;
+            reader = s?.CreateReader();
+            taps = t;
+            channels = Mathf.Max(1, outChannels);
+            gainProvider = gain;
+
+            // The lead is the delay. Floored at two chunks so a frame hitch doesn't
+            // let the playhead overtake the writer, and kept to a quarter of the clip
+            // so the overtake check below can tell a large gap from a wrapped one.
+            int wanted = Mathf.Max(Mathf.RoundToInt(rate * leadSeconds), ChunkFrames * 2);
+            int chunks = Mathf.Max(4, Mathf.CeilToInt(wanted / (float)ChunkFrames) * 4);
+            lengthFrames = chunks * ChunkFrames;
+            leadFrames = Mathf.Min(wanted, lengthFrames / 4);
+
+            scratch = new float[ChunkFrames * channels];
+            Clip = AudioClip.Create(clipName, lengthFrames, channels, rate, false);
+            active = s != null && t != null && reader != null && src != null;
+        }
+
+        public void Release() => active = false;
+
+        // Main thread, once a frame. Tops the clip back up to `leadFrames` ahead of
+        // the playhead, which is what holds the delay steady.
+        public void Pump()
+        {
+            if (!active || source == null || Clip == null || !source.isPlaying) return;
+
+            int play = source.timeSamples;
+            int gap = writeCursor - play;
+            if (gap < 0) gap += lengthFrames;
+
+            // A gap past halfway means the playhead has overtaken the writer (a hitch,
+            // or playback restarting), not that we are miles ahead. Drop back into
+            // position rather than waiting for it to lap us.
+            if (gap > lengthFrames / 2)
+            {
+                // Kept on a chunk boundary, so a write still can't straddle the loop.
+                int target = (play + leadFrames) % lengthFrames;
+                writeCursor = target - (target % ChunkFrames);
+                gap = writeCursor - play;
+                if (gap < 0) gap += lengthFrames;
+            }
+
+            for (int guard = 0; gap < leadFrames && guard < lengthFrames / ChunkFrames; guard++)
+            {
+                Array.Clear(scratch, 0, scratch.Length);
+                splitter.ReadMixed(reader, scratch, ChunkFrames, channels, taps,
+                                   gainProvider != null ? gainProvider() : 1f);
+                Clip.SetData(scratch, writeCursor);
+                writeCursor = (writeCursor + ChunkFrames) % lengthFrames;
+                gap += ChunkFrames;
+            }
+        }
     }
 
     private BasisMultiChannelPcmSplitter splitter;
@@ -169,6 +261,13 @@ public sealed class BasisMediaPlayerAudio : MonoBehaviour, IBasisMediaClockSourc
             rebuildRequested = false;
             Rebuild();
         }
+
+        // Analysis outputs are written from here rather than an audio callback, so
+        // they have to be topped up every frame to stay ahead of their playhead.
+        if (bindings != null)
+        {
+            foreach (var b in bindings) b.Feed?.Pump();
+        }
     }
 
     private void OnDestroy()
@@ -201,6 +300,7 @@ public sealed class BasisMediaPlayerAudio : MonoBehaviour, IBasisMediaClockSourc
         lastPcmRms = 0f;
 
         var built = new List<Binding>(outputs.Length);
+        bool primaryAssigned = false;
         for (int i = 0; i < outputs.Length; i++)
         {
             AudioSource src = outputs[i];
@@ -239,7 +339,49 @@ public sealed class BasisMediaPlayerAudio : MonoBehaviour, IBasisMediaClockSourc
             }
 
             var b = new Binding { Source = src, Splitter = splitter, OutChannels = outChannels, Taps = taps };
-            b.Primary = built.Count == 0;
+            bool analysis = sel != null && sel.AnalysisFeed;
+            // The metrics are documented as audio-thread figures from the primary
+            // output, and an analysis feed is written from Update, ahead of its own
+            // playhead, so it can't stand in for one -- it would report bursts of
+            // audio that hasn't played yet. A set with nothing but analysis outputs
+            // reports no metrics, which is the honest answer: nothing is consuming
+            // on the audio thread.
+            b.Primary = !primaryAssigned && !analysis;
+            if (b.Primary) primaryAssigned = true;
+            bool primary = b.Primary;
+            src.loop = true;
+            src.spatializePostEffects = true;
+
+            if (analysis)
+            {
+                // Unity's per-source readback (AudioSource.GetOutputData, and the
+                // spectrum calls behind it) only reflects clip playback: audio a
+                // script writes in OnAudioFilterRead reaches the listener but never
+                // enters the buffer those read. Analysers that sample an AudioSource
+                // -- AudioLink among them -- therefore see silence from the tap. An
+                // output flagged for analysis plays a clip this component writes
+                // instead, which Unity does read back. It runs its configured delay
+                // behind the tap-driven outputs, which is why it isn't the default.
+                //
+                // Unlike the tap, Unity applies this AudioSource's volume and mute to
+                // clip playback itself, so neither is folded into the gain here or it
+                // would land twice.
+                var feed = new AnalysisFeed(src, splitter, taps, outChannels, rate,
+                                            Mathf.Clamp(sel.AnalysisFeedLatency,
+                                                        BasisMediaAudioChannel.MinAnalysisFeedLatency,
+                                                        BasisMediaAudioChannel.MaxAnalysisFeedLatency),
+                                            $"BasisMediaPlayerAudio_{i}_analysis",
+                                            () => EffectiveVolumeGain);
+                b.Feed = feed;
+                b.Clip = feed.Clip;
+                src.clip = b.Clip;
+                // A tap left over from a previous build (or authored on the prefab)
+                // would clear the block and overwrite the clip, so drop its binding.
+                if (src.TryGetComponent(out BasisMediaPlayerAudioTap stale)) stale.Unbind();
+                built.Add(b);
+                continue;
+            }
+
             // A short silent looping clip keeps the source's DSP chain active; the tap
             // overwrites each block from the splitter each DSP block (~tens of ms of
             // latency vs a streaming clip's ~half-second buffer). SpatializePostEffects
@@ -247,8 +389,6 @@ public sealed class BasisMediaPlayerAudio : MonoBehaviour, IBasisMediaClockSourc
             // audio is spatialised / occluded / transmitted normally.
             b.Clip = AudioClip.Create($"BasisMediaPlayerAudio_{i}_keepalive", Mathf.Max(256, rate / 10), 1, rate, false);
             src.clip = b.Clip;
-            src.loop = true;
-            src.spatializePostEffects = true;
             if (!src.TryGetComponent(out BasisMediaPlayerAudioTap tap)) tap = src.gameObject.AddComponent<BasisMediaPlayerAudioTap>();
             b.FilterTap = tap;
             // A tap added here appends, so it lands below anything already on the
@@ -261,7 +401,6 @@ public sealed class BasisMediaPlayerAudio : MonoBehaviour, IBasisMediaClockSourc
                     $"BasisMediaPlayerAudio: '{src.name}' has a {bypassed.GetType().Name} above its BasisMediaPlayerAudioTap, so that filter never hears the stream. Move it below the tap.",
                     BasisDebug.LogTag.Video);
             }
-            bool primary = b.Primary;
             // Source frames per output frame: the tap renders straight into DSP
             // blocks, so rate conversion happens in the splitter read (Quest runs
             // the DSP at 24kHz against 48kHz sources; desktop is typically 1:1).
@@ -346,6 +485,7 @@ public sealed class BasisMediaPlayerAudio : MonoBehaviour, IBasisMediaClockSourc
             foreach (var b in bindings)
             {
                 if (b.FilterTap != null) b.FilterTap.Unbind();
+                if (b.Feed != null) b.Feed.Release();
                 if (b.Source != null && b.Source.clip == b.Clip) { b.Source.Stop(); b.Source.clip = null; }
                 if (b.Clip != null) Destroy(b.Clip);
             }

--- a/Basis/Packages/com.basis.mediaplayer/TESTING.md
+++ b/Basis/Packages/com.basis.mediaplayer/TESTING.md
@@ -319,6 +319,26 @@ misbehave and shouldn't be reported as regressions: `Pitch` does nothing, and ti
 Effects` or unticking `Spatialize Post Effects` drops spatialisation to flat 2D, because the
 spatialiser then runs ahead of the tap and its output is overwritten.
 
+**Audio analysis feed** — Unity's per-source readback (`AudioSource.GetOutputData` and the
+spectrum calls behind it) only reflects clip playback, so an output the tap drives reads back as
+silence and anything sampling that AudioSource — AudioLink, VU meters, spectrum-driven world
+scripts — sees nothing. `Analysis Feed` on that output's `BasisMediaAudioChannel` swaps it to a clip the
+player writes, which Unity does read back. The row to run is AudioLink: add its `AudioLinkInput`
+AudioSource to `Outputs` with a `BasisMediaAudioChannel` set to `Stereo (downmix)` and
+`Analysis Feed` ticked, point AudioLink's `audioSource` at it, and confirm the AudioLink texture
+tracks the stream. Untick it and reactivity should stop, which is the control for the whole
+mechanism. Only that output changes: the speakers stay on the tap, so check A/V sync on them is
+no different with the feed on. The feed runs `Feed Delay` behind the tap-driven outputs, so
+reactivity trails the sound by that much — check it looks in time at the default and lower it
+until it breaks up to find the floor on the platform under test. It's written once a frame, so
+the floor moves with the frame rate; a rig that holds at 0.02s on desktop may need more on a
+headset. The filter-order notices don't apply to
+an analysis output, since it isn't generating into the DSP block, so confirm a filter added there
+is heard and isn't flagged. The analyser still won't hear that filter: the readback is taken from
+clip playback, upstream of the filter chain, so a low pass on an analysis output colours what you
+hear and nothing of what AudioLink sees. Worth one pass on Quest, where the DSP runs at a different rate to
+the stream and the clip path leans on Unity's own resampling rather than the tap's.
+
 **Panel UI** ("Media Players" panel, `Runtime/UI/BasisMediaPlayerPanelProvider.cs`) — URL
 load, transport buttons, seek slider (VOD only), volume, bitrate dropdown (HLS multi-variant),
 audio-track dropdown (multi-audio content), captions toggle + opacity sliders, subtitles


### PR DESCRIPTION
## Summary
AudioLink doesn't react to anything the media player plays, and neither does any other per-source audio analyser. Closes #989.

`BasisMediaPlayerAudioTap` generates each output's audio in `OnAudioFilterRead`, and Unity's per-source readback -- `AudioSource.GetOutputData` and the spectrum calls behind it -- samples clip playback upstream of the source's DSP filter chain, so it never sees the tap. AudioLink ingests through exactly that call, so it reads silence from every output. VU meters and spectrum-driven world scripts are in the same boat.

Reduced to three plain AudioSources with no Basis code involved: a clip with no filter reads back at 0.01768; the same clip with a filter that zeroes the block reads **the same** 0.01768 while being audibly silent; a silent clip with a filter generating a tone reads 0.00000 while audibly playing. Identical to five decimals on 6000.0.80f1, 6000.3.21f1 and 6000.5.5f1, in empty projects as well as this one, so it isn't a regression and may be long-standing behaviour.

`Analysis Feed` on `BasisMediaAudioChannel` drives one output from an `AudioClip` this component writes rather than from the tap. Unity reads that back normally. It's filled from `Update` a set distance ahead of that source's own playhead, in fixed chunks against a clip length that's an exact multiple of them, so a write never straddles the loop point and never allocates. If a frame hitch lets the playhead overtake the writer, it drops back into position rather than playing a lap of stale audio.

A streaming clip is the obvious way to do this and is unusable: Unity's buffer between the PCM callback and the speaker runs about a second whatever length the clip declares, and isn't reachable from the callback, which left AudioLink a second behind the audio everyone could hear. Writing the clip puts the delay under our control -- `Feed Delay`, 0.02-0.5s, default 0.05.

Unlike the tap, the feed does **not** fold `AudioSource.volume` into its gain. Unity applies volume to clip playback itself and AudioLink divides it back out, so folding it would apply it twice.

It's per output, so the speakers keep the tap and their A/V sync, and analysis outputs are excluded from the diagnostics' primary-metrics slot -- those are documented as audio-thread figures, and a feed written from `Update` ahead of its playhead can't stand in for one.

## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [x] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — `BasisEventDriver` runs the single per-frame tick that drives the whole framework (network apply, local player sim, blendshapes, JigglePhysics, nameplates, and more) as one sequential chain. An unhandled exception anywhere in that chain aborts the rest of the tick, so every step after the throwing one is silently skipped for that frame. New work added to the driver must either be guaranteed not to throw, or be wrapped in a `try`/`catch` that contains the failure and surfaces it through `BasisDebug` — logged once / rate-limited, never every frame (see the existing `HVRBasisBuiltInAddresses.Simulate()` guard for the pattern). Expect this to be scrutinized closely in review.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [x] Windows
- [ ] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [ ] Tested in VR (note headset under **Notes**)
- [ ] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [x] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [x] N/A — change does not touch any of the above

## Notes
**Verification so far is editor-only, on Windows.** With `Analysis Feed` ticked on AudioLink's `AudioLinkInput`, the AudioLink texture tracks the stream; unticked, it goes flat again on the same stream, which is the control for the whole mechanism. An Android/Quest pass is still outstanding and is the one I'd most like before merge: the DSP rate differs from the stream there, so the clip path leans on Unity's own resampling where the tap does its own. TESTING.md carries the row.

**Per-frame work** — no new `Update` was added. `BasisMediaPlayerAudio` already had one for the rebuild request, and the feed's top-up rides it. Nothing was added to `BasisEventDriver`, so that box is N/A. The top-up allocates nothing: the scratch buffer and the clip are created once per rebuild, and `Array.Clear` / `ReadMixed` / `SetData` are allocation-free. Work per second is fixed by sample rate rather than frame rate — roughly 47 chunks/sec at 48kHz, about 375KB/s of copying.

**Jobification** — considered, not possible. `AudioClip.SetData` is a main-thread Unity API, and the splitter read shares a lock with the audio thread.

**GetComponent** — the two new lookups are `TryGetComponent`, one in `Rebuild` (runs on format change, not per frame) and one in editor inspector code.

**Hot-path collections** — the feed's top-up iterates `bindings` with `foreach` over an array, matching the three existing loops in the same file rather than introducing a different idiom for one call site.