### PR TITLE
fix(bundlemanagement): only delete library items on positive corruption

### DIFF
--- a/Basis/Packages/com.basis.bundlemanagement/BasisBeeManagement.cs
+++ b/Basis/Packages/com.basis.bundlemanagement/BasisBeeManagement.cs
@@ -5,30 +5,76 @@ using System.Threading.Tasks;
 using UnityEngine;
 
 /// <summary>
-/// Result of a meta-only load attempt. Distinguishes transient network failures
-/// (caller should keep cached state intact and retry later) from genuine corruption
-/// or missing data (caller may safely evict the item).
+/// Result of a meta-only load attempt.
+///
+/// <para><see cref="IsCorrupt"/> is the ONLY field that may authorize destroying the user's cached
+/// bee or their library entry, and it is set only when a reader positively identified unusable
+/// bytes (<see cref="BasisLoadFailureKind.Corrupt"/>). Failing to obtain the connector — because a
+/// host was refused, DNS did not resolve, a disk was full, or a token was cancelled — is not
+/// evidence the content is bad, and must leave the item alone.</para>
+///
+/// <para><see cref="IsTransient"/> is a softer, non-destructive signal: "is retrying worth it?".
+/// It drives retry budgets only. Being wrong about it costs one request.</para>
 /// </summary>
 public readonly struct BasisMetaLoadResult
 {
     public readonly bool Loaded;
     public readonly bool IsTransient;
+    /// <summary>The load positively identified unusable bytes. The only grounds for eviction.</summary>
+    public readonly bool IsCorrupt;
     public readonly string Error;
 
-    private BasisMetaLoadResult(bool loaded, bool isTransient, string error)
+    private BasisMetaLoadResult(bool loaded, bool isTransient, bool isCorrupt, string error)
     {
         Loaded = loaded;
         IsTransient = isTransient;
+        IsCorrupt = isCorrupt;
         Error = error;
     }
 
-    public static BasisMetaLoadResult Success => new BasisMetaLoadResult(true, false, null);
-    public static BasisMetaLoadResult Transient(string error) => new BasisMetaLoadResult(false, true, error);
-    public static BasisMetaLoadResult Corrupt(string error) => new BasisMetaLoadResult(false, false, error);
+    public static BasisMetaLoadResult Success => new BasisMetaLoadResult(true, false, false, null);
+    /// <summary>Equivalent to <c>Failed(error, retryable: true)</c>; retained for callers outside
+    /// this repo. Prefer <see cref="FromFailure"/>, which picks the verdict for you.</summary>
+    public static BasisMetaLoadResult Transient(string error) => new BasisMetaLoadResult(false, true, false, error);
+    public static BasisMetaLoadResult Corrupt(string error) => new BasisMetaLoadResult(false, false, true, error);
+    /// <summary>
+    /// A failure that was NOT positively attributed to bad bytes. Keeps the item.
+    /// <paramref name="retryable"/> only chooses whether a caller with a retry budget should spend
+    /// it; it has no bearing on whether anything is deleted.
+    /// </summary>
+    public static BasisMetaLoadResult Failed(string error, bool retryable) => new BasisMetaLoadResult(false, retryable, false, error);
+
+    /// <summary>
+    /// The single place a reader's verdict becomes a caller's licence to delete. Corrupt is granted
+    /// only when <paramref name="kind"/> already says so — never re-derived from the message text —
+    /// and every other failure keeps the item, using the text heuristic solely to size a retry.
+    ///
+    /// <para>Both load paths route through here so the rule cannot drift apart between them, and so
+    /// it can be tested without a disk or a network.</para>
+    /// </summary>
+    public static BasisMetaLoadResult FromFailure(BasisLoadFailureKind kind, string error)
+    {
+        if (kind == BasisLoadFailureKind.Corrupt)
+        {
+            return Corrupt(error);
+        }
+        return Failed(error, LooksLikeTransientError(error));
+    }
 
     // Implicit bool conversion preserves legacy `bool x = await HandleMetaOnlyLoad(...)` call sites.
     public static implicit operator bool(BasisMetaLoadResult r) => r.Loaded;
 
+    /// <summary>
+    /// Guesses, from message text, whether retrying might help. This is a HEURISTIC over strings
+    /// that embed URLs, file paths and connector contents, so it is wrong in both directions — a
+    /// bee served from a host containing "ssl" makes every error for that item look transient.
+    /// That is tolerable here because the answer only sizes a retry.
+    ///
+    /// <para>It must never gate a destructive action. Deciding what to delete from this was the
+    /// bug: policy refusals and DNS failures contain none of these tokens, so "we could not fetch
+    /// it" read as "the bytes are bad" and the user's saved worlds and avatars were deleted. Use
+    /// <see cref="IsCorrupt"/> for that.</para>
+    /// </summary>
     public static bool LooksLikeTransientError(string error)
     {
         if (string.IsNullOrEmpty(error)) return false;
@@ -130,7 +176,7 @@ public static class BasisBeeManagement
             {
                 try
                 {
-                    var (connector, connectorError) = await BasisBundleManagement.DownloadConnectorFile(wrapper, new BasisProgressReport(), cancellationToken, MaxDownloadSizeInBytes);
+                    var (connector, connectorError, _) = await BasisBundleManagement.DownloadConnectorFile(wrapper, new BasisProgressReport(), cancellationToken, MaxDownloadSizeInBytes);
                     if (connector == null)
                     {
                         BasisDebug.Log($"Connector prefetch unavailable ({connectorError}) — continuing with the full download.", BasisDebug.LogTag.Event);
@@ -366,10 +412,23 @@ public static class BasisBeeManagement
         string beeLocation = wrapper.LoadableBundle.BasisRemoteBundleEncrypted.RemoteBeeFileLocation;
         if (BasisIOManagement.TryResolveLocalBeePath(beeLocation, out string localBeePath))
         {
-            var (localConnector, localErr) = await BasisBundleManagement.LocalDirectConnectorFile(wrapper, localBeePath, report, cancellationToken);
+            var (localConnector, localErr, localKind) = await BasisBundleManagement.LocalDirectConnectorFile(wrapper, localBeePath, report, cancellationToken);
             if (localConnector == null || !string.IsNullOrEmpty(localErr))
             {
-                return BasisMetaLoadResult.Corrupt(localErr ?? "Local connector read failed.");
+                string localMessage = localErr ?? "Local connector read failed.";
+                // This branch used to hard-code Corrupt, so a cancelled read or a locked file
+                // deleted a local bee the user cannot re-download. Only an actually unreadable
+                // file — one that parsed as neither on-disk layout — evicts now.
+                BasisMetaLoadResult localResult = BasisMetaLoadResult.FromFailure(localKind, localMessage);
+                if (localResult.IsCorrupt)
+                {
+                    BasisDebug.LogError($"Local bee is unreadable: {localMessage}");
+                }
+                else
+                {
+                    BasisDebug.LogWarning($"Local meta-only load deferred: {localMessage}");
+                }
+                return localResult;
             }
             return BasisMetaLoadResult.Success;
         }
@@ -379,7 +438,7 @@ public static class BasisBeeManagement
         // here, so without it a card would keep showing the previous name/thumbnail/date after the
         // bee behind its url was replaced.
         bool useCachedConnector = IsMetaOnDisc && CacheIsCurrentForRequestedVersion(wrapper, MetaInfo, beeLocation, evictStaleCache: false);
-        (BasisBundleConnector Connector, string ErrorMessage) output;
+        (BasisBundleConnector Connector, string ErrorMessage, BasisLoadFailureKind FailureKind) output;
         if (useCachedConnector)
         {
             output = await BasisBundleManagement.ReadConnectorFile(wrapper, MetaInfo.StoredLocal, report, cancellationToken).ConfigureAwait(false);
@@ -391,16 +450,23 @@ public static class BasisBeeManagement
         }
         if (!string.IsNullOrEmpty(output.ErrorMessage))
         {
-            // A transient failure (SSL/DNS/timeout/cancel) must not be treated as corruption by the caller.
-            // The on-disc cache (if any) is still intact; only the download attempt failed.
-            if (BasisMetaLoadResult.LooksLikeTransientError(output.ErrorMessage))
+            // Corrupt is the caller's licence to delete the user's cached bee and their saved
+            // library entry, so it is granted only where a reader positively identified unusable
+            // bytes. It is never re-derived here from the message text: the string carries URLs and
+            // file paths, and "we declined to fetch it" / "we could not reach it" read identically
+            // to "the bytes are wrong".
+            BasisMetaLoadResult failure = BasisMetaLoadResult.FromFailure(output.FailureKind, output.ErrorMessage);
+            if (failure.IsCorrupt)
             {
-                BasisDebug.LogWarning($"Meta-only load deferred (transient): {output.ErrorMessage}");
-                return BasisMetaLoadResult.Transient(output.ErrorMessage);
+                BasisDebug.LogError($"Meta-only load found unusable content: {output.ErrorMessage}");
             }
-
-            BasisDebug.LogError($"Missing BundleArray {output.ErrorMessage}");
-            return BasisMetaLoadResult.Corrupt(output.ErrorMessage);
+            else
+            {
+                // The connector was not obtained. Keep whatever is cached and let the next preload
+                // try again; IsTransient only sizes a retry budget.
+                BasisDebug.LogWarning($"Meta-only load deferred (retryable={failure.IsTransient}): {output.ErrorMessage}");
+            }
+            return failure;
         }
         if (useCachedConnector == false)
         {

--- a/Basis/Packages/com.basis.bundlemanagement/BasisBundleManagement.cs
+++ b/Basis/Packages/com.basis.bundlemanagement/BasisBundleManagement.cs
@@ -118,13 +118,15 @@ public static class BasisBundleManagement
     }
 
     /// <summary>
-    /// Reads only the connector from an already-downloaded .BEE file.
+    /// Reads only the connector from an already-downloaded .BEE file. The third tuple element
+    /// carries the reader's verdict; only <see cref="BasisLoadFailureKind.Corrupt"/> may be treated
+    /// by a caller as grounds for deleting the user's content.
     /// </summary>
-    public static async Task<(BasisBundleConnector Connector, string ErrorMessage)> ReadConnectorFile(BasisTrackedBundleWrapper bundleWrapper, BasisStoredEncryptedBundle storedBundle, BasisProgressReport progressCallback, CancellationToken cancellationToken)
+    public static async Task<(BasisBundleConnector Connector, string ErrorMessage, BasisLoadFailureKind FailureKind)> ReadConnectorFile(BasisTrackedBundleWrapper bundleWrapper, BasisStoredEncryptedBundle storedBundle, BasisProgressReport progressCallback, CancellationToken cancellationToken)
     {
         if (!BasisBeeValidator.IsValidBundleWrapper(bundleWrapper, out string wrapperErr) || storedBundle is null)
         {
-            return (null, wrapperErr ?? "Stored bundle is null.");
+            return (null, wrapperErr ?? "Stored bundle is null.", BasisLoadFailureKind.Unspecified);
         }
 
         string readPath = null;
@@ -139,23 +141,23 @@ public static class BasisBundleManagement
 
         if (string.IsNullOrWhiteSpace(readPath))
         {
-            return (null, "Stored bundle path is null or empty.");
+            return (null, "Stored bundle path is null or empty.", BasisLoadFailureKind.Unspecified);
         }
 
         if (string.IsNullOrWhiteSpace(bundleWrapper.LoadableBundle.UnlockPassword))
         {
-            return (null, "Unlock password is null or empty.");
+            return (null, "Unlock password is null or empty.", BasisLoadFailureKind.Unspecified);
         }
 
         if (cancellationToken.IsCancellationRequested)
         {
-            return (null, "Cancelled before starting.");
+            return (null, "Cancelled before starting.", BasisLoadFailureKind.Unspecified);
         }
         BeeResult<BeeReadResult> result = await BasisIOManagement.ReadBEEConnectorFileEx(readPath, bundleWrapper.LoadableBundle.UnlockPassword, progressCallback, cancellationToken).ConfigureAwait(false);
 
         if (!result.IsSuccess || result.Value is null)
         {
-            return (null, "ReadBEEFileEx failed. " + (result.Error ?? "No details."));
+            return (null, "ReadBEEFileEx failed. " + (result.Error ?? "No details."), result.FailureKind);
         }
 
         BasisIOManagement.BeeReadResult data = result.Value;
@@ -163,32 +165,38 @@ public static class BasisBundleManagement
 
         if (!BasisBeeValidator.IsValidConnector(data.Connector, out string connErr))
         {
-            return (null, connErr);
+            // Unspecified, not Corrupt: IsValidConnector only null-checks, and every caller above
+            // already returned on a null connector, so reaching this is an internal invariant
+            // violation rather than a statement about the user's bytes. If this check ever grows
+            // real field validation, classify each new rejection before letting it evict.
+            return (null, connErr, BasisLoadFailureKind.Unspecified);
         }
 
-        return (data.Connector, string.Empty);
+        return (data.Connector, string.Empty, BasisLoadFailureKind.Unspecified);
     }
 
     /// <summary>
     /// Downloads connector only and returns it.
     /// </summary>
-    public static async Task<(BasisBundleConnector Connector, string ErrorMessage)> DownloadConnectorFile(BasisTrackedBundleWrapper bundleWrapper, BasisProgressReport progressCallback, CancellationToken cancellationToken, long MaxDownloadSizeInMB = 4L * 1024 * 1024 * 1024)
+    public static async Task<(BasisBundleConnector Connector, string ErrorMessage, BasisLoadFailureKind FailureKind)> DownloadConnectorFile(BasisTrackedBundleWrapper bundleWrapper, BasisProgressReport progressCallback, CancellationToken cancellationToken, long MaxDownloadSizeInMB = 4L * 1024 * 1024 * 1024)
     {
+        // Refusing to start is not the same as the content being bad: an unsupported scheme, a
+        // blocked host or a missing password all land here and must never evict.
         if (!BasisBeeValidator.ValidateWrapperPasswordAndUrl(bundleWrapper, out string url, out string err))
         {
-            return (null, err);
+            return (null, err, BasisLoadFailureKind.Unspecified);
         }
 
         if (cancellationToken.IsCancellationRequested)
         {
-            return (null, "Cancelled before starting.");
+            return (null, "Cancelled before starting.", BasisLoadFailureKind.Unspecified);
         }
         BasisDebug.Log("Downloading BEE (connector-only) from " + url);
         BeeResult<(BasisBundleConnector, string, string)> result = await BasisIOManagement.DownloadConnectorOnlyEx(url, bundleWrapper.LoadableBundle.UnlockPassword!, progressCallback, cancellationToken, MaxDownloadSizeInMB);
 
         if (!result.IsSuccess || result.Value.Item1 is null)
         {
-            return (null, BasisBeeValidator.BuildResultError("DownloadConnectorOnlyEx failed", !string.IsNullOrEmpty(result.Error), result.ResponseCode != -1 && result.ResponseCode != 0, result.Error, result.ResponseCode));
+            return (null, BasisBeeValidator.BuildResultError("DownloadConnectorOnlyEx failed", !string.IsNullOrEmpty(result.Error), result.ResponseCode != -1 && result.ResponseCode != 0, result.Error, result.ResponseCode), result.FailureKind);
         }
 
         bundleWrapper.LoadableBundle.BasisBundleConnector = result.Value.Item1;
@@ -197,11 +205,15 @@ public static class BasisBundleManagement
 
         if (!BasisBeeValidator.IsValidConnector(result.Value.Item1, out string connErr))
         {
-            return (null, connErr);
+            // Unspecified, not Corrupt: IsValidConnector only null-checks, and every caller above
+            // already returned on a null connector, so reaching this is an internal invariant
+            // violation rather than a statement about the user's bytes. If this check ever grows
+            // real field validation, classify each new rejection before letting it evict.
+            return (null, connErr, BasisLoadFailureKind.Unspecified);
         }
 
         BasisDebug.Log("Successfully obtained connector (connector-only).");
-        return (result.Value.Item1, string.Empty);
+        return (result.Value.Item1, string.Empty, BasisLoadFailureKind.Unspecified);
     }
 
     /// <summary>
@@ -272,32 +284,33 @@ public static class BasisBundleManagement
     /// Reads only the connector from a local BEE file, trying the remote-format layout first and
     /// falling back to the full-file cache layout. Used by meta-only loads (library cards).
     /// </summary>
-    public static async Task<(BasisBundleConnector Connector, string ErrorMessage)> LocalDirectConnectorFile(BasisTrackedBundleWrapper bundleWrapper, string localPath, BasisProgressReport progressCallback, CancellationToken cancellationToken)
+    public static async Task<(BasisBundleConnector Connector, string ErrorMessage, BasisLoadFailureKind FailureKind)> LocalDirectConnectorFile(BasisTrackedBundleWrapper bundleWrapper, string localPath, BasisProgressReport progressCallback, CancellationToken cancellationToken)
     {
         if (!BasisBeeValidator.IsValidBundleWrapper(bundleWrapper, out string wrapperErr))
         {
-            return (null, wrapperErr);
+            return (null, wrapperErr, BasisLoadFailureKind.Unspecified);
         }
 
         if (string.IsNullOrWhiteSpace(localPath))
         {
-            return (null, "Local bee path is null or empty.");
+            return (null, "Local bee path is null or empty.", BasisLoadFailureKind.Unspecified);
         }
 
         if (string.IsNullOrWhiteSpace(bundleWrapper.LoadableBundle.UnlockPassword))
         {
-            return (null, "Unlock password is null or empty.");
+            return (null, "Unlock password is null or empty.", BasisLoadFailureKind.Unspecified);
         }
 
         if (cancellationToken.IsCancellationRequested)
         {
-            return (null, "Cancelled before starting.");
+            return (null, "Cancelled before starting.", BasisLoadFailureKind.Unspecified);
         }
 
         string password = bundleWrapper.LoadableBundle.UnlockPassword;
         BasisDebug.Log("Reading local bee connector from disk: " + localPath);
 
         BeeResult<BeeReadResult> result = await BasisIOManagement.ReadRemoteBeeFromDiskEx(localPath, password, progressCallback, cancellationToken, includeSection: false).ConfigureAwait(false);
+        BasisLoadFailureKind remoteFormatKind = result.IsSuccess ? BasisLoadFailureKind.Unspecified : result.FailureKind;
         if (!result.IsSuccess || result.Value is null)
         {
             result = await BasisIOManagement.ReadBEEConnectorFileEx(localPath, password, progressCallback, cancellationToken).ConfigureAwait(false);
@@ -305,7 +318,16 @@ public static class BasisBundleManagement
 
         if (!result.IsSuccess || result.Value is null)
         {
-            return (null, "Local bee connector read failed. " + (result.Error ?? "No details."));
+            // Reading this file with the wrong layout is EXPECTED — the two readers are a
+            // format probe, and whichever one runs second is parsing a header it was never
+            // meant to see, so its verdict alone means nothing. Only call the file unusable
+            // when both layouts positively rejected it; otherwise the fallback's confusion
+            // would delete a local bee that is merely in the other format, or one this
+            // reader declined for a reason the first reader deliberately left unclassified.
+            BasisLoadFailureKind kind = remoteFormatKind == BasisLoadFailureKind.Corrupt && result.FailureKind == BasisLoadFailureKind.Corrupt
+                ? BasisLoadFailureKind.Corrupt
+                : BasisLoadFailureKind.Unspecified;
+            return (null, "Local bee connector read failed. " + (result.Error ?? "No details."), kind);
         }
 
         bundleWrapper.LoadableBundle.BasisBundleConnector = result.Value.Connector;
@@ -313,10 +335,14 @@ public static class BasisBundleManagement
 
         if (!BasisBeeValidator.IsValidConnector(result.Value.Connector, out string connErr))
         {
-            return (null, connErr);
+            // Unspecified, not Corrupt: IsValidConnector only null-checks, and every caller above
+            // already returned on a null connector, so reaching this is an internal invariant
+            // violation rather than a statement about the user's bytes. If this check ever grows
+            // real field validation, classify each new rejection before letting it evict.
+            return (null, connErr, BasisLoadFailureKind.Unspecified);
         }
 
-        return (result.Value.Connector, string.Empty);
+        return (result.Value.Connector, string.Empty, BasisLoadFailureKind.Unspecified);
     }
 
     private static bool TryGetPlatform(BasisBundleConnector connector, out BasisBundleGenerated generated, out string error)

--- a/Basis/Packages/com.basis.bundlemanagement/BasisIOManagement.cs
+++ b/Basis/Packages/com.basis.bundlemanagement/BasisIOManagement.cs
@@ -404,17 +404,22 @@ public static class BasisIOManagement
         // Header
         var headerRes = await DownloadRangeInternal(url, 0, BasisBeeConstants.RemoteHeaderSize - 1, null, progressCallback, cancellationToken, MaxDownloadSizeInMB);
         if (!headerRes.IsSuccess || headerRes.Value?.Data == null)
-            return BeeResult<(BasisBundleConnector, string, string)>.Fail($"DownloadConnectorOnlyEx: Failed to read header. {headerRes.Error ?? "No data"}", headerRes.ResponseCode);
+            return BeeResult<(BasisBundleConnector, string, string)>.FailFrom(headerRes, $"DownloadConnectorOnlyEx: Failed to read header. {headerRes.Error ?? "No data"}");
 
+        // Transport, not content: a range request that came back the wrong size can be a proxy
+        // truncating us. Left unclassified so it never evicts.
         if (headerRes.Value.Data.Length != BasisBeeConstants.RemoteHeaderSize)
             return BeeResult<(BasisBundleConnector, string, string)>.Fail($"DownloadConnectorOnlyEx: Header size mismatch. Expected {BasisBeeConstants.RemoteHeaderSize}, got {headerRes.Value.Data.Length}.", headerRes.ResponseCode);
 
         string observedVersionTag = headerRes.Value.Validator.Tag;
 
         long connectorLength = ReadInt64LittleEndian(headerRes.Value.Data);
+        // The file's OWN header declares a length no BEE can have. That is the bytes being wrong.
         if (connectorLength <= 0)
-            return BeeResult<(BasisBundleConnector, string, string)>.Fail($"DownloadConnectorOnlyEx: Invalid connector length {connectorLength}.");
+            return BeeResult<(BasisBundleConnector, string, string)>.FailCorrupt($"DownloadConnectorOnlyEx: Invalid connector length {connectorLength}.");
 
+        // Our cap, not the format's — a future cap change must not retroactively make valid
+        // content "corrupt", so this stays unclassified.
         if (connectorLength > BasisBeeConstants.MaxConnectorBytes)
             return BeeResult<(BasisBundleConnector, string, string)>.Fail($"DownloadConnectorOnlyEx: Connector length {connectorLength} exceeds max allowed {BasisBeeConstants.MaxConnectorBytes}.");
 
@@ -426,18 +431,27 @@ public static class BasisIOManagement
 
         if (connectorRes.IsSuccess == false && connectorRes.Error != string.Empty)
         {
-            return BeeResult<(BasisBundleConnector, string, string)>.Fail(connectorRes.Error, connectorRes.ResponseCode);
+            return BeeResult<(BasisBundleConnector, string, string)>.FailFrom(connectorRes, connectorRes.Error);
         }
 
         if (!connectorRes.IsSuccess || connectorRes.Value?.Data == null)
-            return BeeResult<(BasisBundleConnector, string, string)>.Fail($"DownloadConnectorOnlyEx: Failed to read connector bytes. {connectorRes.Error ?? "No data"}", connectorRes.ResponseCode);
+            return BeeResult<(BasisBundleConnector, string, string)>.FailFrom(connectorRes, $"DownloadConnectorOnlyEx: Failed to read connector bytes. {connectorRes.Error ?? "No data"}");
 
+        // Also transport: we asked for an exact range and got a different count.
         if (connectorRes.Value.Data.LongLength != connectorLength)
             return BeeResult<(BasisBundleConnector, string, string)>.Fail($"DownloadConnectorOnlyEx: Expected {connectorLength} bytes, got {connectorRes.Value.Data.LongLength}.", connectorRes.ResponseCode);
 
         var connector = await BasisEncryptionToData.GenerateMetaFromBytes(vp, connectorRes.Value.Data, progressCallback);
         if (connector == null)
         {
+            // NOT classified Corrupt, despite looking like the obvious place for it.
+            // GenerateMetaFromBytes flattens BasisDecryptResult to null, and BasisDecryptError.Unknown
+            // is produced by a catch-all that swallows every exception in the decrypt path — including
+            // OutOfMemoryException from the defensive copy and the output buffer. A memory spike while
+            // four connectors parse concurrently must not read as "your saved world is corrupt".
+            // WrongPasswordOrCorruptedData is likewise ambiguous by name: a rotated password is not bad
+            // bytes. Recovering a real verdict here means surfacing BasisDecryptError from
+            // BasisEncryptionToData; until then this stays non-destructive.
             return BeeResult<(BasisBundleConnector, string, string)>.Fail("DownloadConnectorOnlyEx: Failed to parse connector metadata (null).");
         }
 
@@ -551,26 +565,34 @@ public static class BasisIOManagement
 
         using var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 96 * 1024, useAsync: true);
 
+        // These checks read the on-disk header the format defines: a file that cannot satisfy its
+        // own declared sizes is not a BEE in this layout, so they are the one place that reports
+        // Corrupt. Note the verdict alone is not permission to delete anything — when this runs as
+        // the second half of the local-bee format probe (LocalDirectConnectorFile) the path is an
+        // arbitrary user file that may simply be in the other layout, and that caller requires BOTH
+        // readers to agree before it treats the file as unusable.
         if (fs.Length < BasisBeeConstants.DiskHeaderSize)
-            return BeeResult<BeeReadResult>.Fail($"ReadBEEFileEx: File too small to contain header. Size={fs.Length} bytes.");
+            return BeeResult<BeeReadResult>.FailCorrupt($"ReadBEEFileEx: File too small to contain header. Size={fs.Length} bytes.");
 
         // Read Int32 connector size (little-endian)
         byte[] sizeBytes = await ReadExactAsync(fs, BasisBeeConstants.DiskHeaderSize, cancellationToken).ConfigureAwait(false);
         if (sizeBytes.Length != BasisBeeConstants.DiskHeaderSize)
-            return BeeResult<BeeReadResult>.Fail($"ReadBEEFileEx: Failed to read connector size (header). Got {sizeBytes.Length} bytes.");
+            return BeeResult<BeeReadResult>.FailCorrupt($"ReadBEEFileEx: Failed to read connector size (header). Got {sizeBytes.Length} bytes.");
 
         int connectorSize = ReadInt32LittleEndian(sizeBytes);
         long remainingPossible = fs.Length - fs.Position;
         if (connectorSize <= 0 || connectorSize > remainingPossible)
-            return BeeResult<BeeReadResult>.Fail($"ReadBEEFileEx: Invalid connector size {connectorSize}. Remaining file bytes: {remainingPossible}. File may be corrupt.");
+            return BeeResult<BeeReadResult>.FailCorrupt($"ReadBEEFileEx: Invalid connector size {connectorSize}. Remaining file bytes: {remainingPossible}. File may be corrupt.");
 
         // Read connector bytes
         byte[] connectorBytes = await ReadExactAsync(fs, connectorSize, cancellationToken).ConfigureAwait(false);
         if (connectorBytes.Length != connectorSize)
-            return BeeResult<BeeReadResult>.Fail($"ReadBEEFileEx: Failed to read full connector block. Expected {connectorSize}, got {connectorBytes.Length}.");
+            return BeeResult<BeeReadResult>.FailCorrupt($"ReadBEEFileEx: Failed to read full connector block. Expected {connectorSize}, got {connectorBytes.Length}.");
 
         BasisBundleConnector connector = await BasisEncryptionToData.GenerateMetaFromBytes(vp, connectorBytes, progressCallback).ConfigureAwait(false);
 
+        // Not Corrupt: a null here also covers a wrong password and any swallowed exception
+        // (including OOM) inside the decrypt path. See the note in DownloadConnectorOnlyEx.
         if (connector == null)
             return BeeResult<BeeReadResult>.Fail("ReadBEEFileEx: Failed to regenerate connector metadata (null).");
 
@@ -597,28 +619,30 @@ public static class BasisIOManagement
         using var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 96 * 1024, useAsync: true);
 
         if (fs.Length < BasisBeeConstants.RemoteHeaderSize)
-            return BeeResult<BeeReadResult>.Fail($"ReadRemoteBeeFromDiskEx: File too small to contain remote header. Size={fs.Length} bytes.");
+            return BeeResult<BeeReadResult>.FailCorrupt($"ReadRemoteBeeFromDiskEx: File too small to contain remote header. Size={fs.Length} bytes.");
 
         byte[] headerBytes = await ReadExactAsync(fs, BasisBeeConstants.RemoteHeaderSize, cancellationToken).ConfigureAwait(false);
         if (headerBytes.Length != BasisBeeConstants.RemoteHeaderSize)
-            return BeeResult<BeeReadResult>.Fail($"ReadRemoteBeeFromDiskEx: Failed to read remote header. Got {headerBytes.Length} bytes.");
+            return BeeResult<BeeReadResult>.FailCorrupt($"ReadRemoteBeeFromDiskEx: Failed to read remote header. Got {headerBytes.Length} bytes.");
 
         long connectorLength = ReadInt64LittleEndian(headerBytes);
         if (connectorLength <= 0)
-            return BeeResult<BeeReadResult>.Fail($"ReadRemoteBeeFromDiskEx: Invalid connector length {connectorLength}. File may not be a remote-format BEE.");
+            return BeeResult<BeeReadResult>.FailCorrupt($"ReadRemoteBeeFromDiskEx: Invalid connector length {connectorLength}. File may not be a remote-format BEE.");
 
+        // Our cap, not the format's — left unclassified, same as the download path.
         if (connectorLength > BasisBeeConstants.MaxConnectorBytes)
             return BeeResult<BeeReadResult>.Fail($"ReadRemoteBeeFromDiskEx: Connector length {connectorLength} exceeds max allowed {BasisBeeConstants.MaxConnectorBytes}.");
 
         long remainingAfterHeader = fs.Length - fs.Position;
         if (connectorLength > remainingAfterHeader)
-            return BeeResult<BeeReadResult>.Fail($"ReadRemoteBeeFromDiskEx: Connector length {connectorLength} exceeds file remainder {remainingAfterHeader}.");
+            return BeeResult<BeeReadResult>.FailCorrupt($"ReadRemoteBeeFromDiskEx: Connector length {connectorLength} exceeds file remainder {remainingAfterHeader}.");
 
         byte[] connectorBytes = await ReadExactAsync(fs, checked((int)connectorLength), cancellationToken).ConfigureAwait(false);
         if (connectorBytes.LongLength != connectorLength)
-            return BeeResult<BeeReadResult>.Fail($"ReadRemoteBeeFromDiskEx: Failed to read full connector block. Expected {connectorLength}, got {connectorBytes.Length}.");
+            return BeeResult<BeeReadResult>.FailCorrupt($"ReadRemoteBeeFromDiskEx: Failed to read full connector block. Expected {connectorLength}, got {connectorBytes.Length}.");
 
         BasisBundleConnector connector = await BasisEncryptionToData.GenerateMetaFromBytes(vp, connectorBytes, progressCallback).ConfigureAwait(false);
+        // Not Corrupt: same decrypt-result ambiguity as the other two readers.
         if (connector == null)
             return BeeResult<BeeReadResult>.Fail("ReadRemoteBeeFromDiskEx: Failed to parse connector metadata (null).");
 

--- a/Basis/Packages/com.basis.bundlemanagement/BeeResult.cs
+++ b/Basis/Packages/com.basis.bundlemanagement/BeeResult.cs
@@ -1,14 +1,51 @@
+/// <summary>
+/// Why a load failed, recorded where the failure was observed rather than re-derived downstream
+/// from the message text.
+///
+/// <para><see cref="Corrupt"/> is the only value that means THE BYTES ARE BAD, and it is the only
+/// value any caller may treat as grounds for destroying the user's cached content or their library
+/// entry. Everything else — a refusal to fetch, an unreachable host, a local disk fault, a
+/// cancellation — means we did not obtain the bytes, which is not the same as the bytes being
+/// wrong.</para>
+///
+/// <para><see cref="Unspecified"/> is deliberately the default so a newly added <c>Fail(...)</c>
+/// cannot silently acquire the power to delete user data. Marking a failure destructive has to be
+/// something someone typed. New members added here inherit the same protection: only
+/// <see cref="Corrupt"/> ever evicts.</para>
+/// </summary>
+public enum BasisLoadFailureKind
+{
+    Unspecified = 0,
+    Corrupt = 1,
+}
+
 public readonly struct BeeResult<T>
 {
     public bool IsSuccess { get; }
     public T Value { get; }
     public string Error { get; }
     public long ResponseCode { get; }
-    private BeeResult(bool ok, T value, string error, long code)
+    /// <summary>See <see cref="BasisLoadFailureKind"/>. Unspecified for every failure that did not
+    /// positively identify unusable bytes, which is most of them.</summary>
+    public BasisLoadFailureKind FailureKind { get; }
+    private BeeResult(bool ok, T value, string error, long code, BasisLoadFailureKind kind)
     {
-        IsSuccess = ok; Value = value; Error = error; ResponseCode = code;
+        IsSuccess = ok; Value = value; Error = error; ResponseCode = code; FailureKind = kind;
     }
-    public static BeeResult<T> Ok(T value) => new(true, value, null, -1);
-    public static BeeResult<T> Fail(string error, long responseCode = -1) => new(false, default, error, responseCode);
+    public static BeeResult<T> Ok(T value) => new(true, value, null, -1, BasisLoadFailureKind.Unspecified);
+    public static BeeResult<T> Fail(string error, long responseCode = -1) => new(false, default, error, responseCode, BasisLoadFailureKind.Unspecified);
+    /// <summary>
+    /// A failure backed by positive evidence the bytes are unusable: a header that cannot describe
+    /// this format, a length the file cannot satisfy, a short read of a region the file claims to
+    /// contain, or a connector block that will not decrypt/parse. Use this ONLY for those. It is
+    /// what authorizes the library to delete the user's cached bee and their saved item.
+    /// </summary>
+    public static BeeResult<T> FailCorrupt(string error, long responseCode = -1) => new(false, default, error, responseCode, BasisLoadFailureKind.Corrupt);
+    /// <summary>
+    /// Re-wraps another result's failure under a new message, carrying its verdict and response
+    /// code forward. Every wrap site must use this instead of <see cref="Fail"/>, or the inner
+    /// reader's verdict is silently downgraded to Unspecified.
+    /// </summary>
+    public static BeeResult<T> FailFrom<TInner>(BeeResult<TInner> inner, string error) => new(false, default, error, inner.ResponseCode, inner.FailureKind);
     public override string ToString() => IsSuccess ? $"OK: {Value}" : $"FAIL[{ResponseCode.ToString() ?? "-"}]: {Error}";
 }

--- a/Basis/Packages/com.basis.bundlemanagement/Tests/Editor/BasisMetaLoadClassificationTests.cs
+++ b/Basis/Packages/com.basis.bundlemanagement/Tests/Editor/BasisMetaLoadClassificationTests.cs
@@ -1,0 +1,165 @@
+using NUnit.Framework;
+
+/// <summary>
+/// Covers what is allowed to destroy a user's saved worlds and avatars.
+///
+/// <para>A failed meta-only load hands the library a <see cref="BasisMetaLoadResult"/>, and the
+/// library deletes the cached bee AND the ItemKeyStore entry — the url and the password, the only
+/// copy the client holds — whenever that result reads as corruption. The verdict used to be a
+/// substring match for "Network error:", "Cancelled", "Timeout" or "SSL" against the error text.
+/// Only one of those is ever produced by a machine (UnityWebRequest failures are prefixed
+/// "Network error: "), so every failure the client generates ITSELF carried none of them and was
+/// read as corruption: a URL-security refusal, a fail-closed DNS lookup, a size cap, a redirect
+/// budget, a full disk. One DNS blip permanently deleted the item.</para>
+///
+/// <para>These tests drive <see cref="BasisMetaLoadResult.FromFailure"/>, the single function both
+/// load paths in HandleMetaOnlyLoad now route through. Asserting the factories directly would be a
+/// tautology — <c>Fail</c> and <c>FailCorrupt</c> hard-code their verdicts and never read the
+/// message — so the mapping is what gets pinned here: given the verdict a reader reported, does the
+/// library get permission to delete? Re-deriving corruption from message text is exactly the bug,
+/// and doing so again would fail these tests.</para>
+/// </summary>
+public class BasisMetaLoadClassificationTests
+{
+    // Composed the way the pipeline builds them, hop by hop:
+    //   BasisUrlSecurity.ValidateResolvedHostAsync -> DownloadRangeInternal ("Blocked URL: ")
+    //   -> DownloadConnectorOnlyEx ("Failed to read header. ") -> BuildResultError.
+    // No HTTP code is set on the gate path, so there is no " (HTTP n)" suffix.
+    private const string PolicyRefusal =
+        "DownloadConnectorOnlyEx failed: DownloadConnectorOnlyEx: Failed to read header. Blocked URL: host 'cdn.example.com' resolves to a blocked address (benchmarking 198.18/15).";
+    private const string DnsLookupFailed =
+        "DownloadConnectorOnlyEx failed: DownloadConnectorOnlyEx: Failed to read header. Blocked URL: host 'cdn.example.com' could not be validated (DNS lookup failed: No such host is known.).";
+    private const string DnsReturnedNothing =
+        "DownloadConnectorOnlyEx failed: DownloadConnectorOnlyEx: Failed to read header. Blocked URL: host 'cdn.example.com' could not be validated (DNS returned no addresses).";
+    private const string LiteralAddressRefusal =
+        "DownloadConnectorOnlyEx failed: DownloadConnectorOnlyEx: Blocked URL host '10.0.0.5': RFC1918 10/8";
+    private const string RangeStrippingProxy =
+        "DownloadConnectorOnlyEx failed (HTTP 200): DownloadConnectorOnlyEx: Failed to read header. Server returned 200 (full file). Host must support HTTP range requests (206).";
+    private const string TruncatedTransfer =
+        "DownloadConnectorOnlyEx failed (HTTP 206): DownloadConnectorOnlyEx: Failed to read header. Content-Length mismatch. Header=8, Received=4.";
+    private const string DiskFull =
+        "DownloadConnectorOnlyEx failed: DownloadBEEEx: WriteBeeFileAsync: IOException: There is not enough space on the disk.";
+    // BasisBeeValidator.IsValidUrl rejects the scheme in DownloadConnectorFile BEFORE
+    // DownloadConnectorOnlyEx runs, so this one reaches the classifier unwrapped.
+    private const string UnmountedLocalBee =
+        "Unsupported URL scheme 'file'. Only HTTP/HTTPS are supported.";
+    private const string CacheIndexDisagreesWithDisk =
+        "ReadBEEFileEx failed. ReadBEEFileEx: File not found: /cache/AssetBundles/abc123.bec";
+    private const string DecryptReturnedNull =
+        "DownloadConnectorOnlyEx failed: DownloadConnectorOnlyEx: Failed to parse connector metadata (null).";
+
+    // ---- failures we could not attribute to bad bytes: never grounds for deletion ----
+
+    [TestCase(PolicyRefusal)]
+    [TestCase(DnsLookupFailed)]
+    [TestCase(DnsReturnedNothing)]
+    [TestCase(LiteralAddressRefusal)]
+    [TestCase(RangeStrippingProxy)]
+    [TestCase(TruncatedTransfer)]
+    [TestCase(DiskFull)]
+    [TestCase(UnmountedLocalBee)]
+    [TestCase(CacheIndexDisagreesWithDisk)]
+    [TestCase(DecryptReturnedNull)]
+    public void AnUnattributedFailureNeverAuthorizesDeletion(string error)
+    {
+        // The premise of the whole bug: none of these carry a token the old text classifier looked
+        // for, which is why "we could not fetch it" was read as "the bytes are bad".
+        Assert.That(BasisMetaLoadResult.LooksLikeTransientError(error), Is.False,
+            "premise: this is exactly the text that made the old classifier call a failure to fetch corruption");
+
+        BasisMetaLoadResult result = BasisMetaLoadResult.FromFailure(BasisLoadFailureKind.Unspecified, error);
+        Assert.That(result.IsCorrupt, Is.False,
+            "the library reads IsCorrupt as permission to DeleteStoredFile and RemoveKey");
+        Assert.That(result.Loaded, Is.False, "a failure must not report itself as loaded");
+    }
+
+    // ---- and a reader that positively identified unusable bytes: still evicts ----
+
+    [TestCase("ReadBEEFileEx failed. ReadBEEFileEx: File too small to contain header. Size=3 bytes.")]
+    [TestCase("ReadBEEFileEx failed. ReadBEEFileEx: Invalid connector size -1. Remaining file bytes: 4096. File may be corrupt.")]
+    [TestCase("ReadBEEFileEx failed. ReadBEEFileEx: Failed to read full connector block. Expected 512, got 128.")]
+    [TestCase("DownloadConnectorOnlyEx failed: DownloadConnectorOnlyEx: Invalid connector length -4.")]
+    public void BytesAReaderRejectedStillAuthorizeDeletion(string error)
+    {
+        Assert.That(BasisMetaLoadResult.FromFailure(BasisLoadFailureKind.Corrupt, error).IsCorrupt, Is.True,
+            "a file that cannot satisfy its own declared sizes must stay evictable, or a bad cache entry is permanent");
+    }
+
+    [Test]
+    public void TheVerdictComesFromTheReaderNotFromWordsInTheMessage()
+    {
+        // Both directions of the text heuristic, against the real mapping. The error strings
+        // interpolate urls and file paths, so a bee served from a host containing "ssl" makes every
+        // failure for that item look transient — and a refusal contains none of the tokens at all.
+        const string corruptFromAnSslLookingHost =
+            "ReadBEEFileEx failed. ReadBEEFileEx: File too small to contain header. Size=3 bytes. url=https://assets-ssl.example.com/x.bee";
+
+        Assert.That(BasisMetaLoadResult.LooksLikeTransientError(corruptFromAnSslLookingHost), Is.True,
+            "premise: the text classifier really does misread this one as transient");
+        Assert.That(BasisMetaLoadResult.FromFailure(BasisLoadFailureKind.Corrupt, corruptFromAnSslLookingHost).IsCorrupt,
+            Is.True, "text that looks transient must not downgrade a reader's Corrupt verdict");
+
+        Assert.That(BasisMetaLoadResult.FromFailure(BasisLoadFailureKind.Unspecified, corruptFromAnSslLookingHost).IsCorrupt,
+            Is.False, "and text that looks corrupt must not manufacture a verdict no reader gave");
+    }
+
+    // ---- the fail-safe default ----
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("something nobody has written a case for yet")]
+    [TestCase("Server returned 418. Accept-Ranges=, Content-Range=, Content-Length=")]
+    public void AnUnclassifiedFailureIsNonDestructiveByDefault(string error)
+    {
+        Assert.That(BeeResult<bool>.Fail(error).FailureKind, Is.EqualTo(BasisLoadFailureKind.Unspecified),
+            "Unspecified must be the zero value so a newly added Fail() cannot quietly gain the power to delete user data");
+        Assert.That(BasisMetaLoadResult.FromFailure(BasisLoadFailureKind.Unspecified, error).IsCorrupt, Is.False,
+            "absence of evidence of transience is not evidence of corruption");
+    }
+
+    [Test]
+    public void DefaultConstructedBeeResultCannotAuthorizeDeletion()
+    {
+        Assert.That(default(BeeResult<bool>).FailureKind, Is.EqualTo(BasisLoadFailureKind.Unspecified),
+            "the enum's zero value is what protects every failure site nobody has classified");
+    }
+
+    [Test]
+    public void WrappingAFailureCarriesItsVerdictAndCode()
+    {
+        BeeResult<bool> corrupt = BeeResult<bool>.FailCorrupt("inner: bad header", 206);
+        BeeResult<int> wrappedCorrupt = BeeResult<int>.FailFrom(corrupt, "outer: read failed. inner: bad header");
+        Assert.That(wrappedCorrupt.FailureKind, Is.EqualTo(BasisLoadFailureKind.Corrupt),
+            "a wrap site that drops the verdict silently makes a bad cache entry permanent");
+        Assert.That(wrappedCorrupt.ResponseCode, Is.EqualTo(206), "the response code must survive the wrap too");
+
+        BeeResult<bool> refused = BeeResult<bool>.Fail(PolicyRefusal);
+        Assert.That(BeeResult<int>.FailFrom(refused, "outer: " + PolicyRefusal).FailureKind,
+            Is.EqualTo(BasisLoadFailureKind.Unspecified),
+            "wrapping must not invent corruption that the inner reader never claimed");
+    }
+
+    [Test]
+    public void LegacyBoolConversionStillReportsOnlyWhetherTheLoadSucceeded()
+    {
+        // LibraryProvider.TryDetectModeFromUrl still does `bool isValid = await HandleMetaOnlyLoad(...)`.
+        Assert.That((bool)BasisMetaLoadResult.Success, Is.True);
+        Assert.That((bool)BasisMetaLoadResult.FromFailure(BasisLoadFailureKind.Unspecified, PolicyRefusal), Is.False);
+        Assert.That((bool)BasisMetaLoadResult.FromFailure(BasisLoadFailureKind.Corrupt, "bad header"), Is.False);
+    }
+
+    [Test]
+    public void RetryabilityIsCarriedSeparatelyFromTheEvictionDecision()
+    {
+        // BasisAvatarFarLOD spends its second of two attempts on IsTransient. That budget decision
+        // is allowed to use a heuristic; the deletion decision is not.
+        BasisMetaLoadResult networkBlip = BasisMetaLoadResult.FromFailure(
+            BasisLoadFailureKind.Unspecified, "Network error: Cannot resolve destination host. ");
+        Assert.That(networkBlip.IsTransient, Is.True, "a network blip should still buy a retry");
+        Assert.That(networkBlip.IsCorrupt, Is.False, "and must never delete");
+
+        BasisMetaLoadResult refusal = BasisMetaLoadResult.FromFailure(BasisLoadFailureKind.Unspecified, PolicyRefusal);
+        Assert.That(refusal.IsTransient, Is.False, "retrying a refused host in the same tick cannot help");
+        Assert.That(refusal.IsCorrupt, Is.False, "but not retrying is still not a reason to delete");
+    }
+}

--- a/Basis/Packages/com.basis.bundlemanagement/Tests/Editor/BasisMetaLoadClassificationTests.cs.meta
+++ b/Basis/Packages/com.basis.bundlemanagement/Tests/Editor/BasisMetaLoadClassificationTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7f5ac9e3d6eb4fbca0022ce57060bd39

--- a/Basis/Packages/com.basis.framework/BasisUI/Menus/Library/CachedMetaData.cs
+++ b/Basis/Packages/com.basis.framework/BasisUI/Menus/Library/CachedMetaData.cs
@@ -119,12 +119,17 @@ namespace Basis.BasisUI
         public readonly struct MetaOnlyLoadOutcome
         {
             public readonly BasisLoadableBundleWrapper Wrapper;
-            public readonly bool IsTransient;
+            /// <summary>
+            /// The load failed without positive evidence the content is bad, so the item was kept
+            /// and nothing downstream may delete it. Named for what it authorizes, not for a guess
+            /// at the cause — reading "is this transient?" as "may I delete this?" was the bug.
+            /// </summary>
+            public readonly bool Deferred;
 
-            public MetaOnlyLoadOutcome(BasisLoadableBundleWrapper wrapper, bool isTransient)
+            public MetaOnlyLoadOutcome(BasisLoadableBundleWrapper wrapper, bool deferred)
             {
                 Wrapper = wrapper;
-                IsTransient = isTransient;
+                Deferred = deferred;
             }
         }
 
@@ -133,17 +138,21 @@ namespace Basis.BasisUI
             // make a new wrapper to load the metadata into
             BasisLoadableBundleWrapper newWrapper = CreateNewWrapperFromItem(item);
 
-            // new report and CancellationSource source
+            // new report and CancellationSource source. Bounded and disposed: a deferred item is no
+            // longer deleted after one attempt, so an unreachable host is now retried on every
+            // library refresh and would otherwise hold a _preloadGate slot for the OS connect
+            // timeout each time. Same budget BasisAvatarFarLOD already uses per attempt.
             BasisProgressReport Report = new BasisProgressReport();
-            CancellationTokenSource CancellationSource = new CancellationTokenSource();
+            using CancellationTokenSource CancellationSource = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
             // perform the action to download the file or grab it from disc?
             BasisMetaLoadResult metaResult = await BasisBeeManagement.HandleMetaOnlyLoad(newWrapper.basisTrackedBundleWrapper, Report, CancellationSource.Token);
 
-            // On transient (network/SSL/cancel) failure, do NOT fall through to LoadWrapperFromDisc —
-            // that path auto-removes the key when IsMetaDataOnDisc returns false, which would delete
-            // the user's cached item just because the remote is unreachable right now.
-            if (!metaResult.Loaded && metaResult.IsTransient)
+            // Unless the load positively identified unusable bytes, do NOT fall through to
+            // LoadWrapperFromDisc — that path auto-removes the key when IsMetaDataOnDisc returns
+            // false, which would delete the user's saved item just because we could not fetch its
+            // metadata right now.
+            if (!metaResult.Loaded && !metaResult.IsCorrupt)
             {
                 return new MetaOnlyLoadOutcome(null, true);
             }
@@ -164,12 +173,13 @@ namespace Basis.BasisUI
         public readonly struct CacheNewItemResult
         {
             public readonly CachedContent Cached;
-            public readonly bool IsTransient;
+            /// <summary>See <see cref="MetaOnlyLoadOutcome.Deferred"/>. Keep the item.</summary>
+            public readonly bool Deferred;
 
-            public CacheNewItemResult(CachedContent cached, bool isTransient)
+            public CacheNewItemResult(CachedContent cached, bool deferred)
             {
                 Cached = cached;
-                IsTransient = isTransient;
+                Deferred = deferred;
             }
         }
 
@@ -177,7 +187,7 @@ namespace Basis.BasisUI
         {
             MetaOnlyLoadOutcome outcome = await CreateWrapperAndPerformMetaOnlyLoad(item);
 
-            if (outcome.IsTransient)
+            if (outcome.Deferred)
             {
                 return new CacheNewItemResult(null, true);
             }
@@ -222,7 +232,7 @@ namespace Basis.BasisUI
             try
             {
                 CachedContent cached = null;
-                bool isTransient = false;
+                bool deferred = false;
 
                 if (item.EmbeddedSettings.IsEmbedded && item.EmbeddedSettings.SourceType == BasisDataStoreItemKeys.EmbeddedSource.Addressable)
                 {
@@ -248,11 +258,16 @@ namespace Basis.BasisUI
                                 BasisLoadableBundle = null,
                             };
                             break;
+                        // These two produce no CachedContent, and no reader ever looked at any bytes,
+                        // so they must not fall through to the eviction branch below. Not knowing how
+                        // to present an embedded item is our gap, not evidence the item is bad.
                         case BundledContentHolder.Mode.World:
                             BasisDebug.LogWarning($"CachedMetaData cannot determine {item.Url} with item.Mode = {item.Mode}");
+                            deferred = true;
                             break;
                         default:
                             BasisDebug.LogWarning($"CachedMetaData cannot determine what to do with embedded item = {item.Url} with item.Mode = {item.Mode}");
+                            deferred = true;
                             break;
                     }
                 }
@@ -260,16 +275,25 @@ namespace Basis.BasisUI
                 {
                     CacheNewItemResult result = await CacheNewItem(item);
                     cached = result.Cached;
-                    isTransient = result.IsTransient;
+                    deferred = result.Deferred;
                 }
 
-                if (isTransient)
+                if (deferred)
                 {
-                    // Remote unreachable (SSL / DNS / cancel). Leave the item in the library and try again later.
-                    BasisDebug.LogWarning($"Deferred meta preload for '{urlKey}' — remote unreachable. Keeping cached item intact.");
+                    // We could not get the metadata, but nothing told us the content is bad —
+                    // unreachable host, refused URL, disk fault, cancellation. Leave the item in the
+                    // library and try again on the next preload.
+                    BasisDebug.LogWarning($"Deferred meta preload for '{urlKey}' — metadata unavailable. Keeping the library entry.");
                     return;
                 }
 
+                // Reached only when a load ran and did not defer. Note this branch is narrower than
+                // its message suggests and always has been: a corrupt CACHED bee does not arrive
+                // here, because LoadWrapperFromDisc finds the file still present and hands back the
+                // placeholder wrapper CreateNewWrapperFromItem built, whose connector is non-null.
+                // What actually lands here is a load that reported success without producing a
+                // connector, or LoadWrapperFromDisc returning null because the meta cache has no
+                // record. Evicting a genuinely unreadable cached bee is a separate gap.
                 if (cached == null || cached.BasisBundleConnector == null)
                 {
                     BasisDebug.LogError($"Item '{urlKey}' has corrupt or invalid data. Removing from library.");
@@ -282,23 +306,14 @@ namespace Basis.BasisUI
             }
             catch (Exception ex)
             {
-                string exMessage = ex.Message + " " + (ex.InnerException?.Message ?? string.Empty);
-                if (BasisMetaLoadResult.LooksLikeTransientError(exMessage))
-                {
-                    BasisDebug.LogWarning($"Deferred meta preload for '{item?.Url}' — transient error: {ex.Message}");
-                    return;
-                }
-
-                BasisDebug.LogError($"Failed to load metadata for '{item?.Url}'. Removing from library. Error: {ex.Message}");
-                try
-                {
-                    BasisStorageManagement.DeleteStoredFile(item?.Url);
-                    await BasisDataStoreItemKeys.RemoveKey(item);
-                }
-                catch (Exception cleanupEx)
-                {
-                    BasisDebug.LogError(cleanupEx);
-                }
+                // An exception is never positive evidence that the user's content is bad. Every
+                // throw reachable from here is ours — a locked or unreadable cache file, a cache
+                // path not yet initialised, a cancellation, a null dereference. Deciding to delete
+                // the item because the exception text did not happen to contain one of four words
+                // is what destroyed people's libraries; the structural checks that CAN prove bad
+                // bytes all return a classified failure instead of throwing, so nothing that
+                // should be evicted stops being evicted by keeping the item here.
+                BasisDebug.LogWarning($"Deferred meta preload for '{item?.Url}' — {ex.GetType().Name}: {ex.Message}. Keeping the library entry.");
             }
         }
         [HideInCallstack]


### PR DESCRIPTION
## Summary

A failed meta-only load could permanently delete the user's saved worlds and avatars — `BasisStorageManagement.DeleteStoredFile` plus `BasisDataStoreItemKeys.RemoveKey`, which destroys the cached bee, the library entry, and the only copy of that item's password the client holds. Whether that happened was decided by substring-matching the error text for `"Network error:"`, `"Cancelled"`, `"Timeout"` or `"SSL"` (`BasisBeeManagement.cs`).

Only one of those four is ever machine-generated — UnityWebRequest failures get the `"Network error: "` prefix. So the classifier collapsed to *"did UnityWebRequest itself fail? → keep the data. Everything else → delete it."* Every gate we wrote ourselves is on the delete side by construction: the SSRF/URL guard, the fail-closed DNS check, the size cap, the range-support requirement, the redirect hop budget, and every local disk fault. **A plain DNS blip deletes the item, on any network, with no proxy involved.**

### What changed

- `BeeResult<T>` carries a `BasisLoadFailureKind`. `Unspecified` is the zero value **and** the default for the existing `Fail(...)`, so the ~96 failure sites I did not touch are non-destructive automatically, and a newly added `Fail(...)` cannot silently gain the power to delete user data.
- Only checks that positively identify unusable bytes use `FailCorrupt(...)`: a header that cannot describe this format, a declared length the file cannot satisfy, a short read of a region the file claims to contain. Three wrap sites use `FailFrom(...)` so an inner reader's verdict is not silently downgraded.
- The three connector tuples in `BasisBundleManagement` widen to carry the verdict; `BasisMetaLoadResult` gains `IsCorrupt`, the only thing that authorizes eviction. Both load paths route through one `FromFailure()` so the rule cannot drift between them.
- `CachedMetaData`'s gate flips from *"defer only if the text looked transient"* to *"defer unless the bytes were positively bad"*, and its `catch` stops deleting entirely.

### Deliberately not classified Corrupt

`GenerateMetaFromBytes` returning `null` — the obvious-looking candidate. It flattens `BasisDecryptResult`, and `BasisDecryptError.Unknown` is produced by a catch-all that swallows every exception in the decrypt path, **including `OutOfMemoryException`** from the defensive copy and the output buffer. Four connectors parse concurrently behind `_preloadGate`; a memory spike must not read as "your saved world is corrupt". `WrongPasswordOrCorruptedData` is ambiguous by name too — a rotated password is not bad bytes. Recovering a real verdict here means surfacing `BasisDecryptError` out of `BasisEncryptionToData`, which is its own change.

### Also fixed along the way

- The local `file://` branch hard-coded `Corrupt` without consulting the classifier at all, so even the literal string `"Cancelled before starting."` deleted a local bee that cannot be re-downloaded. The two readers there are a **format probe** — whichever runs second is parsing a header it was never meant to see — so a file is only called unusable when both layouts reject it.
- Embedded Addressable items whose `Mode` we cannot present reached the delete branch with no load having run at all.
- The preload `CancellationTokenSource` is now disposed and bounded to 30s. Deferred items are retried rather than deleted, so an unreachable host would otherwise hold a preload-gate slot for the OS connect timeout on every library refresh.

### Scope: this narrows the trigger, not the remedy

Worth stating plainly because it contradicts what I first assumed. **Evicting a genuinely unreadable cached bee does not work, and did not before this PR either.** When the cached bytes are corrupt, `CreateWrapperAndPerformMetaOnlyLoad` falls through to `LoadWrapperFromDisc`, which finds the file still present and returns the placeholder wrapper `CreateNewWrapperFromItem` built — whose `BasisBundleConnector` is non-null — so the item is cached with blank metadata instead of being evicted. The delete branch only ever fired when the **meta cache had no record**, which is bookkeeping, not corruption.

So this PR does not trade a data-loss bug for a cache-poisoning bug: the poisoning path predates it and is unchanged. But it does mean the `Corrupt` verdict is currently near-inert on that route, and closing that gap properly is a separate change.

## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [ ] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — N/A, see Notes.
- [x] **Addressables used for asset/memory loading** — N/A, see Notes.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — N/A, see Notes.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — N/A, see Notes.
- [x] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — N/A, see Notes.
- [x] **Considered jobification** — see Notes.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — see Notes.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — N/A, see Notes.
- [x] **Logging uses `BasisDebug`** — all new logging is `BasisDebug.LogWarning` / `BasisDebug.LogError`.
- [x] **No scene-wide discovery for dependencies** — N/A, see Notes.
- [x] **No allocations in hot paths** — see Notes.
- [x] **No debugging in hot paths** — see Notes.
- [x] **Hot-path collection access is optimized** — N/A, see Notes.
<!-- required-checks-end -->

## Testing details

- [ ] Windows
- [ ] Linux
- [ ] Android

Input / control mode coverage:

- [x] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [x] N/A — change does not touch any of the above

## Notes

**The Tested box is deliberately unticked, and the platform boxes with it.** This has not been opened in Unity. What *was* verified: a Roslyn parse of every changed file (zero syntax errors; the remaining diagnostics are missing-type errors from the unreferenced Unity assemblies), all 19 return sites in the three widened tuples confirmed by hand to carry three elements, and the new fixture extracted into a standalone NUnit project and run — 23/23 pass. Someone needs to open `Basis/` in Unity, let it compile, and run the EditMode fixture before this merges. Flagging rather than ticking, per CONTRIBUTING.md.

**The test is mutation-checked.** An earlier version of this fixture asserted the `BeeResult` factories directly, which is a tautology — `Fail` and `FailCorrupt` hard-code their verdicts and never read the message, so every case passed for any input, including with the original bug reintroduced. It now drives `BasisMetaLoadResult.FromFailure`, the real decision both load paths use. Reintroducing the bug verbatim (classify from message text) turns **16 of 23 red**; the current tree is green. It also pins the premise the whole change rests on — that none of these self-generated errors contains any of the four heuristic tokens — and the mirror direction, where a url containing "ssl" made real corruption look transient.

**Where the compliance lives.** This is error-classification plumbing in `com.basis.bundlemanagement` plus two guards in the library preload. No transforms, no asset loading, no `GetComponent`, no camera access, no scene discovery, and nothing added to `BasisEventDriver`. No jobification opportunity: it is an enum comparison inside an already-async IO path. No new allocations — `BasisLoadFailureKind` is an enum field on an existing `readonly struct`, and `BeeResult<T>` stays a struct. Nothing here is per-frame; the meta preload runs behind a 4-wide `SemaphoreSlim` on library refresh and at boot, which is also why the new logging is safe.

**Public shape preserved.** `BasisMetaLoadResult` keeps `Loaded`, `IsTransient`, `Error`, the `Success` / `Transient` / `Corrupt` factories and the implicit `bool` operator — that operator exists specifically so `LibraryProvider`'s `bool isValid = await HandleMetaOnlyLoad(...)` keeps working, and it still does. New: `IsCorrupt`, `Failed(error, retryable)` and `FromFailure(kind, error)`. `Transient` is now unused in production (it is exactly `Failed(e, retryable: true)`) and is kept only for callers outside this repo — say the word and I will drop it.

**One rename.** `MetaOnlyLoadOutcome.IsTransient` and `CacheNewItemResult.IsTransient` become `Deferred`. Both structs are public but have no consumers outside `CachedMetaData.cs`. Reading "is this transient?" as "may I delete this?" is the bug in miniature, so the flag is now named for what it gates.

**Known follow-up, worth its own issue.** A deferred item currently renders as a permanent `library.loading` card, and the only interaction it has — tapping it — reaches `LibraryProvider.HandleBadItem`, which deletes the bee and the key **with no confirmation prompt**, unlike the normal delete button. That path predates this PR, but this PR makes it much more reachable, because items that used to be deleted on the first failure now persist as stuck cards. It needs an "unavailable / tap to retry" state and the deletion routed through `LibraryProviderDialogRemove.PromptUserForRemoval`. I did not fold it in because it is UI work with a localization key, but it should land soon after.

**Also deliberately not in this PR:** the 198.18.0.0/15 blocklist decision (#994); `LoadWrapperFromDisc` removing the key on a cache miss, which `TryDetectModeFromUrl` can reach with a synthetic key that matches a real entry on (Url, Pass); `BasisAvatarPedestal` wiping the disc cache on any exception; and narrowing the remedy so a corrupt cached entry drops its bytes but keeps the key and self-heals.
