### PR TITLE
feat(mediaplayer): count RTP loss and discarded access units

### DIFF
--- a/Basis/Packages/com.basis.mediaplayer/Native~/basis_media_core.c
+++ b/Basis/Packages/com.basis.mediaplayer/Native~/basis_media_core.c
@@ -196,6 +196,23 @@ struct basis_media_engine {
     volatile long video_au_count;
     volatile long audio_frame_count;
 
+    /* RTP loss accounting (UDP transports only). A sequence gap taints the access
+     * unit under assembly, which is then discarded rather than handed to the
+     * decoder with missing slices — so the stream degrades silently, with no
+     * effect on delivery timing and nothing visible in the queue depths. Counted
+     * here so the cost is measurable. Same unlocked-read treatment as the AU
+     * counters above: these are diagnostics, and a stale read costs nothing. */
+    volatile long rtp_video_gaps;
+    volatile long rtp_video_drops;
+    volatile long rtp_audio_gaps;
+
+    /* Access units discarded by a local reassembly failure — allocation, or the
+     * depacketiser's per-AU ceiling refusing an unbounded reassembly. Kept apart
+     * from the loss counters above because the cause is different in kind: these
+     * can fire on a transport with no packet loss at all, and a run of them says
+     * the source is malformed or hostile rather than that the path is dropping. */
+    volatile long reasm_video_drops;
+
     /* Total media duration reported by the demuxer (VOD); 0 = unknown/live.
      * Demux thread writes once, main thread reads — a torn read on 32-bit is
      * the worst case and Windows/Android are 64-bit. */
@@ -243,6 +260,15 @@ basis_decoder_t* basis_engine_get_decoder(basis_media_engine_t* e) { return e ? 
 int basis_engine_is_paused(basis_media_engine_t* e) { return e ? e->paused : 0; }
 int basis_engine_is_running(basis_media_engine_t* e) { return e ? e->running : 0; }
 int basis_engine_is_paced(basis_media_engine_t* e) { return e ? e->paced : 0; }
+
+void basis_engine_note_rtp_gap(basis_media_engine_t* e, int is_video) {
+    if (!e) return;
+    if (is_video) e->rtp_video_gaps++; else e->rtp_audio_gaps++;
+}
+void basis_engine_note_video_au_dropped(basis_media_engine_t* e, int from_gap) {
+    if (!e) return;
+    if (from_gap) e->rtp_video_drops++; else e->reasm_video_drops++;
+}
 
 /* ---- render-event liveness registry ------------------------------------
  * OnRenderEvent (Unity render thread) is handed the engine pointer and can fire
@@ -1722,8 +1748,11 @@ BASIS_API int BASIS_CALL basis_media_get_transport(basis_media_engine_t* e, char
 
 BASIS_API int BASIS_CALL basis_media_get_debug(basis_media_engine_t* e, char* buf, int buf_size) {
     if (!e || !buf || buf_size <= 0) return 0;
-    int n = snprintf(buf, (size_t)buf_size, "vau=%ld aau=%ld | ",
-                     e->video_au_count, e->audio_frame_count);
+    int n = snprintf(buf, (size_t)buf_size,
+                     "vau=%ld aau=%ld vgap=%ld vdrop=%ld agap=%ld vrsm=%ld | ",
+                     e->video_au_count, e->audio_frame_count,
+                     e->rtp_video_gaps, e->rtp_video_drops, e->rtp_audio_gaps,
+                     e->reasm_video_drops);
     if (n < 0) n = 0;
     if (e->decoder && n < buf_size) n += basis_decoder_get_debug(e->decoder, buf + n, buf_size - n);
     return n;

--- a/Basis/Packages/com.basis.mediaplayer/Native~/basis_media_internal.h
+++ b/Basis/Packages/com.basis.mediaplayer/Native~/basis_media_internal.h
@@ -258,6 +258,19 @@ int basis_engine_is_running(basis_media_engine_t* engine);
  * presents on a fixed 1x-from-first-PTS clock instead of the live-edge clock. */
 int basis_engine_is_paced(basis_media_engine_t* engine);
 
+/* RTP loss accounting, reported by the depacketiser. A gap is a sequence
+ * discontinuity, which only UDP transports can see. Both are invisible in
+ * delivery timing and queue depths, so without these the cost of packet loss
+ * cannot be measured.
+ *
+ * from_gap separates the two reasons an access unit gets discarded: a sequence
+ * gap left it incomplete, or reassembly failed locally (allocation, or the
+ * per-AU ceiling refusing an unbounded reassembly). The second can happen with
+ * no packet loss on any transport, so counting them together would report a
+ * malformed source as network loss. */
+void basis_engine_note_rtp_gap(basis_media_engine_t* engine, int is_video);
+void basis_engine_note_video_au_dropped(basis_media_engine_t* engine, int from_gap);
+
 /* Leading frames of a decoded audio block that sit ahead of the media-time
  * origin, and so must not reach the PCM ring.
  *

--- a/Basis/Packages/com.basis.mediaplayer/Native~/protocol/basis_rtsp.c
+++ b/Basis/Packages/com.basis.mediaplayer/Native~/protocol/basis_rtsp.c
@@ -447,8 +447,13 @@ typedef struct {
 
     /* UDP loss handling: a sequence gap taints the access unit under
      * assembly — it's discarded at its boundary instead of delivered with
-     * missing slices. */
+     * missing slices. v_drop is also raised by reassembly failures (allocation,
+     * or the RTP_MAX_BUF ceiling), which are local and can happen on either
+     * transport, so v_gap_taint records that this particular discard came from
+     * a sequence gap. Without it the counters would report a cap refusal on
+     * TCP-interleaved — a transport with no loss at all — as network loss. */
     int v_drop;
+    int v_gap_taint;
 } depkt_t;
 
 static const uint8_t SC4[4] = {0,0,0,1};
@@ -522,7 +527,10 @@ static int64_t rtp_ts_extend(uint32_t ts, int64_t* ext, int* have_ext,
 }
 
 static void deliver_au(depkt_t* d) {
-    if (d->v_drop) { d->au_len = 0; d->v_drop = 0; return; }
+    if (d->v_drop) {
+        basis_engine_note_video_au_dropped(d->sink->user, d->v_gap_taint);
+        d->au_len = 0; d->v_drop = 0; d->v_gap_taint = 0; return;
+    }
     if (d->au_len <= 0) return;
     if (!d->video_announced) {
         int w = 0, h = 0;
@@ -936,11 +944,14 @@ static void udp_deliver_video(void* ctx, const uint8_t* pkt, int len) { depkt_vi
 static void udp_deliver_audio(void* ctx, const uint8_t* pkt, int len) { depkt_audio((depkt_t*)ctx, pkt, len); }
 static void udp_gap_video(void* ctx) {
     depkt_t* d = (depkt_t*)ctx;
+    basis_engine_note_rtp_gap(d->sink->user, 1);
     d->fu_active = 0;
     d->v_drop = 1;
+    d->v_gap_taint = 1;
 }
 static void udp_gap_audio(void* ctx) {
     depkt_t* d = (depkt_t*)ctx;
+    basis_engine_note_rtp_gap(d->sink->user, 0);
     d->afrag_active = 0;
     d->afrag_len = 0;
 }

--- a/Basis/Packages/com.basis.mediaplayer/Runtime/BasisMediaPlayerDiagnostics.cs
+++ b/Basis/Packages/com.basis.mediaplayer/Runtime/BasisMediaPlayerDiagnostics.cs
@@ -61,6 +61,13 @@ public sealed class BasisMediaPlayerDiagnostics : MonoBehaviour
         {
             Directory.CreateDirectory(Path.GetDirectoryName(ResolvedLogPath) ?? ".");
             bool fileExists = File.Exists(ResolvedLogPath);
+            string header = BuildHeader();
+            // A file written by an older build carries fewer columns, so appending to it
+            // would slide every value under the wrong heading. An appended file already
+            // contains session markers, so it is read a section at a time — emit the
+            // current header alongside the marker whenever the schema has moved, and the
+            // new section is self-describing without discarding the old one.
+            bool schemaChanged = fileExists && AppendBetweenSessions && !HeaderMatches(header);
             var fs = new FileStream(ResolvedLogPath,
                 AppendBetweenSessions ? FileMode.Append : FileMode.Create,
                 FileAccess.Write,
@@ -68,11 +75,12 @@ public sealed class BasisMediaPlayerDiagnostics : MonoBehaviour
             writer = new StreamWriter(fs, new UTF8Encoding(false));
             if (!fileExists || !AppendBetweenSessions)
             {
-                writer.WriteLine(BuildHeader());
+                writer.WriteLine(header);
             }
             else
             {
                 writer.WriteLine("# --- session " + DateTime.UtcNow.ToString("o") + " ---");
+                if (schemaChanged) writer.WriteLine(header);
             }
             writer.Flush();
             IsLogging = true;
@@ -137,6 +145,34 @@ public sealed class BasisMediaPlayerDiagnostics : MonoBehaviour
         return sandboxed;
     }
 
+    // Compares against the last header in the file, not the first line: an appended file
+    // may already carry several, and the rows being appended sit under the most recent.
+    // Unreadable or headerless counts as a mismatch, which costs one redundant header
+    // line and keeps the section parseable either way.
+    private bool HeaderMatches(string header)
+    {
+        try
+        {
+            // A header line is the only one starting with the first column's name; data
+            // rows start with a timestamp. Keep the last one seen — that is the schema
+            // the rows about to be appended would otherwise be read under.
+            string firstColumn = header.Substring(0, header.IndexOf(','));
+            string lastHeader = null;
+            using (var reader = new StreamReader(new FileStream(ResolvedLogPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)))
+            {
+                string line;
+                while ((line = reader.ReadLine()) != null)
+                    if (line.StartsWith(firstColumn, StringComparison.Ordinal)) lastHeader = line;
+            }
+            return lastHeader == header;
+        }
+        catch (Exception ex)
+        {
+            BasisDebug.LogWarning($"BasisMediaPlayerDiagnostics: could not read existing header ({ex.Message}); writing a fresh one.", BasisDebug.LogTag.Video);
+            return false;
+        }
+    }
+
     private string BuildHeader()
     {
         return string.Join(",",
@@ -182,6 +218,10 @@ public sealed class BasisMediaPlayerDiagnostics : MonoBehaviour
             "eng_audio_queue_ms",
             "eng_audio_trims",
             "eng_video_queue",
+            "eng_rtp_video_gaps",
+            "eng_rtp_video_drops",
+            "eng_rtp_audio_gaps",
+            "eng_reasm_video_drops",
             "eng_audio_latency_ms",
             "eng_ttff_ms",
             "eng_audio_cfg",
@@ -260,6 +300,10 @@ public sealed class BasisMediaPlayerDiagnostics : MonoBehaviour
         AppendL(engineDebug.AudioQMs);
         AppendL(engineDebug.Trims);
         AppendL(engineDebug.VideoQ);
+        AppendL(engineDebug.VideoGaps);
+        AppendL(engineDebug.VideoDrops);
+        AppendL(engineDebug.AudioGaps);
+        AppendL(engineDebug.ReasmDrops);
         AppendL(engineDebug.AudioLatencyMs);
         AppendL(engineDebug.TtffMs);
         AppendI(engineDebug.AudioCfg);
@@ -334,6 +378,12 @@ public sealed class BasisMediaPlayerDiagnostics : MonoBehaviour
         // the present clock): audio currently queued in ms, clock-gated trims
         // fired, and video frames held in the present ring.
         public long AudioQMs, Trims, VideoQ, AudioLatencyMs;
+        // RTP loss on UDP transports: sequence gaps seen, and video access units
+        // discarded because a gap left them incomplete. Neither shows up in the
+        // queue depths or the present clock, so packet loss is otherwise silent.
+        // ReasmDrops is the other reason an AU is discarded — reassembly failed
+        // locally — which can happen with no loss and on any transport.
+        public long VideoGaps, VideoDrops, AudioGaps, ReasmDrops;
 
         public void Reset()
         {
@@ -341,6 +391,7 @@ public sealed class BasisMediaPlayerDiagnostics : MonoBehaviour
             LagMs = BufMs = TtffMs = AOutCount = 0;
             BufMode = AudioCfg = AudioSr = 0;
             AudioQMs = Trims = VideoQ = AudioLatencyMs = 0;
+            VideoGaps = VideoDrops = AudioGaps = ReasmDrops = 0;
         }
 
         public void ParseFrom(string s)
@@ -403,10 +454,14 @@ public sealed class BasisMediaPlayerDiagnostics : MonoBehaviour
                     if (s[kStart] == 'a' && s[kStart + 1] == 'o' && s[kStart + 2] == 'u' && s[kStart + 3] == 't') { AOutCount = v; return; }
                     if (s[kStart] == 'a' && s[kStart + 1] == 'l' && s[kStart + 3] == 't') { AudioLatencyMs = v; return; } // alat
                     if (s[kStart] == 't' && s[kStart + 1] == 't' && s[kStart + 2] == 'f' && s[kStart + 3] == 'f') { TtffMs = v; return; }
+                    if (s[kStart] == 'v' && s[kStart + 1] == 'g' && s[kStart + 2] == 'a' && s[kStart + 3] == 'p') { VideoGaps = v; return; }
+                    if (s[kStart] == 'a' && s[kStart + 1] == 'g' && s[kStart + 2] == 'a' && s[kStart + 3] == 'p') { AudioGaps = v; return; }
+                    if (s[kStart] == 'v' && s[kStart + 1] == 'r' && s[kStart + 2] == 's' && s[kStart + 3] == 'm') { ReasmDrops = v; return; }
                     return;
                 case 5:
                     if (s[kStart] == 'n' && s[kStart + 4] == 'e') { NoDue = v; return; }
                     if (s[kStart] == 'a' && s[kStart + 4] == 'm') { Trims = v; return; } // atrim
+                    if (s[kStart] == 'v' && s[kStart + 1] == 'd') { VideoDrops = v; return; } // vdrop
                     return;
                 case 6:
                     if (s[kStart] == 'r' && s[kStart + 5] == 'r') { Render = v; return; }

--- a/Basis/Packages/com.basis.mediaplayer/TESTING.md
+++ b/Basis/Packages/com.basis.mediaplayer/TESTING.md
@@ -505,8 +505,28 @@ with on-screen text or a logo, every time video-path code changes.
   `eng_ttff_ms` (time to first frame), `engine_pos_us` step distribution (late presents show
   as double-steps coinciding with wall-clock gaps), `eng_lag_ms`/`eng_buf_ms` (clock vs
   buffer health), `audio_queue_depth`/`eng_audio_trims` (audio starvation/overrun),
-  `cpu_*_drops/skips` (CPU-path frame accounting). Filter rows to `engine_state == Playing`
-  before drawing conclusions.
+  `cpu_*_drops/skips` (CPU-path frame accounting),
+  `eng_rtp_video_gaps`/`eng_rtp_video_drops`/`eng_rtp_audio_gaps` (RTP loss on UDP
+  transports). Filter rows to `engine_state == Playing` before drawing conclusions.
+- **RTP loss counters**: on `rtsp://` where UDP wins the negotiation, packet loss costs whole
+  access units rather than delivery time — a sequence gap taints the AU under assembly and it
+  is discarded rather than handed to the decoder incomplete. Queue depths, the present clock
+  and `eng_lag_ms` can therefore all look healthy while frames are being dropped. A climbing
+  `eng_rtp_video_drops` against a steady `eng_lag_ms` is loss, not starvation, and buffering
+  does not address it. These stay at zero on TCP transports, which have no sequence gaps to
+  detect.
+
+  They also stay at zero on a native plugin built before the counters existed, because the
+  values come from the native side — so a stale binary reports absence of loss rather than
+  absence of instrumentation, which is the more dangerous of the two. If a UDP stream is
+  visibly dropping frames and all four columns read zero, check the plugin for that platform
+  is current before concluding the path is clean.
+- **`eng_reasm_video_drops`** counts the other reason an access unit is discarded: reassembly
+  failed locally, either an allocation failure or the depacketiser refusing a reassembly past
+  its per-AU ceiling. It is deliberately separate from the loss counters because the cause is
+  different in kind — it needs no packet loss and fires on any transport, so a run of it points
+  at a malformed or hostile source rather than at network conditions. Non-zero here on
+  `rtspt://`, which cannot lose packets, always means the source, never the path.
 - **Debug window**: `Basis → Debug → Media Player Debug` shows live engine state per player.
 - **Feedless harness**: `BasisSyntheticTestSource` (`Runtime/Sources/`) drives the player
   without any network feed — isolates render-path changes from transport noise.

--- a/tools/media-fuzz/native/fuzz_rtsp.c
+++ b/tools/media-fuzz/native/fuzz_rtsp.c
@@ -12,7 +12,9 @@
  *     link-time basis_io stub that serves the fuzz bytes in place of a socket.
  *
  * The other basis_io entry points are stubbed no-ops purely to satisfy the link
- * (basis_rtsp_run references them but is never called here).
+ * (basis_rtsp_run references them but is never called here), as are the engine
+ * loss counters the depacketiser reports gaps and dropped access units to —
+ * there is no engine in this TU, and the counts are not what is under test.
  *
  * Build: see ../build.sh (clang -fsanitize=fuzzer,address,undefined).
  */
@@ -48,6 +50,10 @@ int basis_io_udp_connect(basis_io_t* io, const char* h, int p) { (void)io; (void
 int basis_io_udp_open_pair(const char* h, basis_io_t** a, basis_io_t** b, int* p) {
     (void)h; if (a) *a = NULL; if (b) *b = NULL; if (p) *p = 0; return -1;
 }
+
+/* ---- engine stub: loss accounting has no engine to report to here --------- */
+void basis_engine_note_rtp_gap(basis_media_engine_t* e, int is_video) { (void)e; (void)is_video; }
+void basis_engine_note_video_au_dropped(basis_media_engine_t* e, int from_gap) { (void)e; (void)from_gap; }
 
 /* Pull in the real parser (statics become visible in this TU). */
 #include "protocol/basis_rtsp.c"


### PR DESCRIPTION
## Summary
Packet loss on UDP RTSP costs whole access units rather than delivery time: a sequence gap taints the access unit under assembly and it's discarded rather than handed to the decoder with missing slices. The queue depths, the present clock and `eng_lag_ms` all stay healthy through it, so a lossy stream and a clean one look identical in the diagnostics.

This counts sequence gaps and discarded access units on the engine and adds them to the diagnostics CSV as `eng_rtp_video_gaps`, `eng_rtp_video_drops` and `eng_rtp_audio_gaps`.

An access unit is also discarded when reassembly fails locally — an allocation failure, or the per-AU ceiling refusing an unbounded reassembly. That needs no packet loss and can happen on either transport, so it's tracked separately as `eng_reasm_video_drops` rather than folded into the loss figure.

No behaviour change: the ceiling and the refuse-and-discard semantics are untouched.

## Required checks
All boxes below must be ticked before this PR can merge. If a check is genuinely N/A, tick it anyway and explain under **Notes**.

<!-- required-checks-start -->
<!-- Tick the boxes in place — do not edit the line text. The pr-checklist workflow parses this block; per-PR context goes under Notes. -->
- [x] **Tested** — I built and ran this locally. The change works in the editor and (where relevant) in a built player.
- [x] **Transform access is combined and limited** — In hot paths, transform reads/writes go through `TransformAccessArray` or are otherwise batched. I have not added per-frame `transform.position` / `transform.rotation` / `transform.localPosition` calls inside loops. Whenever I need both position and rotation, I use the combined APIs — `SetPositionAndRotation` / `SetLocalPositionAndRotation` for writes, `GetPositionAndRotation` / `GetLocalPositionAndRotation` for reads — instead of two separate property accesses; the combined call does one local-to-world matrix traversal instead of two.
- [x] **Addressables used for asset/memory loading** — Any new asset loads go through Addressables. No new `Resources.Load`, no direct asset references that pull large content into memory on scene load.
- [x] **No new `GetComponent` / `AddComponent` where avoidable** — Where unavoidable, the result is cached on a field, and any `GetComponent<T>` is replaced with `TryGetComponent<T>(out var x)` — bare `GetComponent` will be denied. `TryGetComponent` is the modern API (Unity 2019.2+) and skips the Editor-only GC allocation `GetComponent` causes when a component is missing: Unity wraps the `null` return in a managed "fake null" object so its overloaded `==` operator can still detect destroyed C++ objects, and constructing that wrapper allocates; `TryGetComponent` returns a `bool` plus `out` parameter and never builds the wrapper. None of these calls run inside `Update`, `LateUpdate`, `FixedUpdate`, jobs, or other per-frame code paths.
- [x] **Per-frame work is scheduled through `BasisEventDriver`** — Any new per-frame work hooks into `BasisEventDriver` rather than adding standalone `Update` / `LateUpdate` / `FixedUpdate` callbacks on a MonoBehaviour.
- [x] **Anything added to `BasisEventDriver` is bulletproof, or guarded by `try`/`catch`** — `BasisEventDriver` runs the single per-frame tick that drives the whole framework (network apply, local player sim, blendshapes, JigglePhysics, nameplates, and more) as one sequential chain. An unhandled exception anywhere in that chain aborts the rest of the tick, so every step after the throwing one is silently skipped for that frame. New work added to the driver must either be guaranteed not to throw, or be wrapped in a `try`/`catch` that contains the failure and surfaces it through `BasisDebug` — logged once / rate-limited, never every frame (see the existing `HVRBasisBuiltInAddresses.Simulate()` guard for the pattern). Expect this to be scrutinized closely in review.
- [x] **Considered jobification** — I asked whether this work can be moved to a Unity Job (Burst-compiled where possible). If it can, it is. If it cannot, the reason is in **Notes**.
- [x] **No needless `{ get; set; }` properties or access lockdowns** — Public fields are fine; Basis is meant to be read and modified freely, so don't wall things off `private`/`internal` without a real reason. Don't wrap a field in `{ get; set; }` when the accessors do nothing — property accessors have a real performance cost vs direct field access, and the lead maintainer prefers plain fields (or a method / setter-only property when only the setter needs logic) over a noop-getter pair. For `.Instance` singletons, callers reassigning `Type.Instance` is allowed; if that would break your code, log a warning or throw — don't block the assignment. Locking down access is not your call.
- [x] **Camera access goes through `BasisLocalCameraDriver`** — Code that needs the local camera (transform, projection, rig data, etc.) pulls it from `BasisLocalCameraDriver` rather than looking one up itself. Don't roll a separate camera discovery path.
- [x] **Logging uses `BasisDebug`** — All new logging calls go through `BasisDebug.Log` / `BasisDebug.LogWarning` / `BasisDebug.LogError` (with an appropriate `LogTag`) instead of `UnityEngine.Debug.Log` / `Debug.LogWarning` / `Debug.LogError`. `BasisDebug` routes through Basis's tagged, color-coded logger and respects the project-wide `LoggingDisabled` toggle so logging can be killed at runtime; bare `Debug.Log` calls bypass that and will be denied.
- [x] **No scene-wide discovery for dependencies** — New code is architected so it does not need `FindObjectOfType` / `FindObjectsOfType` / `GameObject.Find` / `FindGameObjectsWithTag` to locate what it depends on. References are wired in — registered through an existing manager/driver, injected at init, or passed in by the caller — rather than discovered by scanning the scene at runtime. If a scene scan is genuinely unavoidable, justify it under **Notes**.
- [x] **No allocations in hot paths** — Per-frame code (Update / LateUpdate / FixedUpdate, simulation loops, jobs, anything called once per frame or more) does not allocate. No `new` on reference types, no LINQ, no `string` concatenation/interpolation, no boxing, no `foreach` over interface-typed collections. Allocate once at init and reuse the buffer.
- [x] **No debugging in hot paths** — No log calls of any kind on per-frame paths, including `BasisDebug`. Hot-path logging floods the console and incurs cost on every frame regardless of whether the message is filtered out downstream. If a hot-path log is needed while iterating, gate it behind `#if UNITY_EDITOR` and remove (or leave gated) before merge.
- [x] **Hot-path collection access is optimized** — Cache `.Count` (lists) / `.Length` (arrays) into a local `int` before the loop instead of re-reading the property each iteration. Prefer `T[]` (with a separate length int when the array is over-sized) over `List<T>` where the data is hot — Unity's mono BCL doesn't expose `CollectionsMarshal.AsSpan(List<T>)`, so a list can't be fed into `Span<T>` / unsafe paths cleanly. Where the perf justifies it, drop into `Span<T>` / `ref` locals / `Unsafe.As` / `unsafe` pointer code to skip bounds checks and copies, and call out the invariants you're relying on under **Notes** so reviewers can sanity-check them.
<!-- required-checks-end -->

## Testing details
Tick the platforms you actually tested on. Leave the rest unticked — these are informational and do not block merge.

- [x] Windows
- [ ] Linux
- [ ] Android
- [ ] iOS
- [ ] macOS

Input / control mode coverage:

- [ ] Tested in VR (note headset under **Notes**)
- [ ] Tested in desktop / non-VR mode
- [ ] Tested with phone controls (mobile touch input)
- [x] N/A — change does not touch player/XR/input code

Where applicable, confirm these flows still work after your changes:

- [ ] Hot-switching (desktop ↔ VR mode swap at runtime)
- [ ] Avatar swapping
- [ ] Server swapping (joining / leaving / changing servers)
- [x] N/A — change does not touch any of the above

## Notes
Required boxes are ticked including the N/A ones. This adds two internal native functions, four engine counters and four CSV columns; no transforms, assets, components, camera access, `BasisEventDriver` work, scene lookups or logging are involved. The three added `AppendL` calls sit alongside ~55 existing ones in the opt-in diagnostics component's row writer.

Tested on Windows in the editor against `rtsp://stream.vrcdn.live/live/vrcdn` with 300 ms added RTT and 0.05% induced packet loss: 30 gaps and 30 discarded access units over 174 s, `eng_reasm_video_drops` at 0, and every delivery metric clean (no starves, video ring never below 10 of 32). Cross-checked against ffmpeg on the same endpoint, which independently reported 28 RTP losses over 120 s.

Native binaries are deliberately not included — they're queued with other media player work. Until they're rebuilt the columns read 0, so `TESTING.md` notes that a stale plugin reports absence of loss rather than absence of instrumentation. Android is unticked above because the binary wasn't device-tested.
